### PR TITLE
feat(cache): admin cache purge endpoint

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -134,6 +134,7 @@ export default defineNuxtConfig({
     turnstile: {
       secretKey: process.env.NUXT_TURNSTILE_SECRET_KEY,
     },
+    cachePurgeToken: process.env.NUXT_CACHE_PURGE_TOKEN,
     redis: {
       host: process.env.NUXT_REDIS_HOST,
       port: Number(process.env.NUXT_REDIS_PORT || 6379),

--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
       "node-forge": "^1.4.0",
       "picomatch@2": "^2.3.2",
       "picomatch@4": "^4.0.4",
-      "lodash": "^4.18.1"
+      "lodash": "^4.18.1",
+      "simple-git": ">=3.36.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   lodash: ^4.18.1
+  simple-git: '>=3.36.0'
 
 importers:
 
@@ -3716,6 +3717,12 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       ajv: ^7.0.0 || ^8.0.0
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
@@ -8305,8 +8312,8 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
-  simple-git@3.33.0:
-    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
@@ -10781,7 +10788,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       semver: 7.7.4
-      simple-git: 3.33.0
+      simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.15
@@ -12812,6 +12819,12 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       kleur: 4.1.5
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@simple-libs/stream-utils@1.2.0': {}
 
@@ -18298,10 +18311,12 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-git@3.33.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color

--- a/server/api/admin/cache/purge.post.ts
+++ b/server/api/admin/cache/purge.post.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod'
+
+/**
+ * Admin cache purge endpoint, called by the Django admin's
+ * CacheService to invalidate Nitro SSR cache entries that mirror
+ * Django data.
+ *
+ * Auth: shared-secret header `X-Cache-Purge-Token` (timing-safe compare).
+ *
+ * Body:
+ *   {
+ *     patterns: string[]  // glob patterns; trailing `*` is implicit when stripped
+ *     dryRun?: boolean    // default false
+ *   }
+ *
+ * Response:
+ *   {
+ *     matched: number     // total keys matched across patterns
+ *     deleted: number     // keys actually removed (== matched unless dryRun)
+ *     blocked: number     // matched keys filtered out by the deny list
+ *     dryRun: boolean
+ *   }
+ *
+ * Notes:
+ *   - Patterns may be supplied either with or without the unstorage
+ *     mount prefix (`cache:`). Both forms are accepted; the `cache:`
+ *     prefix is stripped before delegating to `useStorage('cache')`.
+ *   - Only the trailing `*` glob is honored. Mid-pattern globs are
+ *     translated to a regex post-filter so callers can do
+ *     `cache:nitro:handlers:Foo*` AND e.g. `cache:nitro:handlers:*Bar*`.
+ */
+
+const PROTECTED_FRAGMENTS = [
+  'session:',
+  'throttle:',
+  'rate-limit:',
+  'health:',
+  'circuit_breaker:',
+  'bull:',
+] as const
+
+const bodySchema = z.object({
+  patterns: z.array(z.string().min(1)).min(1).max(64),
+  dryRun: z.boolean().optional().default(false),
+})
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return mismatch === 0
+}
+
+function isProtected(key: string): boolean {
+  return PROTECTED_FRAGMENTS.some(f => key.includes(f))
+}
+
+function patternToMatcher(pattern: string): { prefix: string, regex: RegExp | null } {
+  const stripped = pattern.startsWith('cache:') ? pattern.slice('cache:'.length) : pattern
+  const star = stripped.indexOf('*')
+  if (star === -1) {
+    return { prefix: stripped, regex: null }
+  }
+  if (star === stripped.length - 1) {
+    return { prefix: stripped.slice(0, -1), regex: null }
+  }
+  // Mid-pattern glob — fall back to regex post-filter against the
+  // shortest deterministic prefix.
+  const prefix = stripped.slice(0, star)
+  const escaped = stripped
+    .split('*')
+    .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*')
+  return { prefix, regex: new RegExp(`^${escaped}$`) }
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const expected = (config.cachePurgeToken as string | undefined) || ''
+  const supplied = getRequestHeader(event, 'x-cache-purge-token') || ''
+
+  if (!expected || !supplied || !timingSafeEqual(expected, supplied)) {
+    log.warn('cache-purge', 'Rejected: invalid token', {
+      ip: getRequestIP(event, { xForwardedFor: true }),
+    })
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const body = await readValidatedBody(event, bodySchema.parse)
+  const storage = useStorage('cache')
+
+  let matched = 0
+  let deleted = 0
+  let blocked = 0
+  const visited = new Set<string>()
+
+  for (const pattern of body.patterns) {
+    const { prefix, regex } = patternToMatcher(pattern)
+    let keys: string[]
+    try {
+      keys = await storage.getKeys(prefix)
+    }
+    catch (error) {
+      log.warn('cache-purge', 'getKeys failed', {
+        prefix,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    for (const key of keys) {
+      if (visited.has(key)) continue
+      visited.add(key)
+      if (regex && !regex.test(key)) continue
+      if (isProtected(key)) {
+        blocked += 1
+        continue
+      }
+      matched += 1
+      if (!body.dryRun) {
+        try {
+          await storage.removeItem(key)
+          deleted += 1
+        }
+        catch (error) {
+          log.warn('cache-purge', 'removeItem failed', {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    }
+  }
+
+  log.info('cache-purge', 'Completed', {
+    patterns: body.patterns,
+    matched,
+    deleted,
+    blocked,
+    dryRun: body.dryRun,
+  })
+
+  return { matched, deleted, blocked, dryRun: body.dryRun }
+})


### PR DESCRIPTION
## Summary

Companion to the Django **CacheService** rewrite (see [grooveshop-django-api#5](https://github.com/vasilistotskas/grooveshop-django-api/pull/5)). Adds the cross-service Nitro endpoint Django calls into to invalidate cached SSR responses (`cache:nitro:handlers:*`, `cache:nitro:routes:*`).

## What's in

- `server/api/admin/cache/purge.post.ts` — POST endpoint, shared-secret auth (`X-Cache-Purge-Token`, timing-safe compare), Zod-validated body. Accepts a list of glob patterns + optional `dryRun`. Strips the optional `cache:` prefix, walks `useStorage('cache')` via prefix or regex matching, mirrors the Django deny list (`session:`, `throttle:`, `bull:`, `health:`, `circuit_breaker:`, `rate-limit:`) so a misregistered pattern can never wipe SSR session/queue state. Per-pattern error isolation. Logs every call via evlog.
- `nuxt.config.ts` — adds `runtimeConfig.cachePurgeToken` from `NUXT_CACHE_PURGE_TOKEN`.

## How it gets called

The token must match between this service and Django. The Django `CacheService` does:

```http
POST http://frontend-nuxt-service/api/admin/cache/purge
X-Cache-Purge-Token: <shared-secret>
Content-Type: application/json

{ "patterns": ["cache:nitro:handlers:PayWayViewSet*"], "dryRun": false }
```

Returns:

```json
{ "matched": 3, "deleted": 3, "blocked": 0, "dryRun": false }
```

## Test plan

- [x] `pnpm lint server/api/admin/cache/purge.post.ts` — clean
- [x] `vue-tsc --noEmit` — no type errors in this file
- [x] Manual: Django side returned `{ "error": "Nuxt purge endpoint is not configured" }` until env vars set, then proxies through cleanly. Verified end-to-end via Chrome MCP against the dockerized Django backend.

## Deploy

The `NUXT_CACHE_PURGE_TOKEN` env var must be set in `frontend-secrets` (the infra PR has the unsealed value gitignored locally; run `untracked/secrets/seal.sh` to push it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin cache purge endpoint with token-based authentication. Admins can now selectively purge cached content using patterns, with support for a dry-run mode to preview changes before applying them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->