### PR TITLE
fix(meta-pixel): use useScriptTriggerConsent as binary script-load gate

### DIFF
--- a/app/composables/setups.ts
+++ b/app/composables/setups.ts
@@ -133,54 +133,63 @@ export function setupGoogleAnalyticsConsent() {
 }
 
 /**
- * Initialise the Meta Pixel and bind its consent state to the cookie
- * banner. Mirrors ``setupGoogleAnalyticsConsent`` so the two scripts
- * share the same lifecycle:
+ * Initialise the Meta Pixel — single source of truth for the
+ * registration. Called from ``app.vue`` setup once per app instance.
  *
- * * Loaded with ``onNuxtReady`` so the pixel never blocks paint.
- * * ``defaultConsent: 'denied'`` keeps fbq calls queued silently
- *   until the visitor accepts marketing cookies.
- * * Watching ``cookiesEnabledIds`` flips ``consent.grant()`` /
- *   ``consent.revoke()`` whenever the banner state changes — the
- *   pixel's queued events drain on grant.
+ * Loading lifecycle:
  *
- * No-op when ``META_PIXEL_ID`` is not provisioned (the registry
- * resolves to undefined and ``useScriptMetaPixel`` would warn at
- * runtime). Composable returns early in that case.
+ * * Reactive ``adConsent`` is the boolean "user has given ad_storage
+ *   consent in the cookie banner" — recomputed when the banner state
+ *   changes.
+ * * ``useScriptTriggerConsent({ consent: adConsent })`` is the
+ *   documented binary script-load gate. The script tag is injected
+ *   into the DOM only after ``adConsent`` flips true; if it later
+ *   flips false, ``useScriptTriggerConsent`` revokes and the script
+ *   is unloaded. This is the gate documented in
+ *   ``https://nuxt.com/scripts/guides/consent`` — replacing the
+ *   previous pattern that combined ``defaultConsent: 'denied'`` with
+ *   a manual ``consent.grant()`` watcher. That older combination
+ *   left the @nuxt/scripts registry stuck in a "loaded-but-empty"
+ *   state (registered with no DOM tag, fbq queue never drained)
+ *   because ``defaultConsent`` is purely a vendor-side flag and
+ *   never gates script injection — the script would still attempt
+ *   to load on ``onNuxtReady`` but the SSR/client dedup of
+ *   ``useScriptMetaPixel`` options dropped ``defaultConsent`` between
+ *   the two call sites, creating subtle races. Single registration
+ *   here + single proxy lookup in ``useMetaPixel`` removes both.
+ *
+ * No-op when ``META_PIXEL_ID`` is not provisioned — the cookie banner
+ * stays untouched and ``useMetaPixel`` consumers receive a no-op
+ * proxy.
  */
 export function setupMetaPixelConsent() {
   const config = useRuntimeConfig()
   const pixelId = (config.public as { metaPixelId?: string })?.metaPixelId
   if (!pixelId) return
 
-  const { consent } = useScriptMetaPixel({
-    id: pixelId,
-    defaultConsent: 'denied',
-    scriptOptions: {
-      trigger: 'onNuxtReady',
-    },
-  } as Parameters<typeof useScriptMetaPixel>[0])
+  const { cookiesEnabledIds, isConsentGiven } = useCookieControl()
 
-  const {
-    cookiesEnabledIds,
-    isConsentGiven,
-  } = useCookieControl()
-
-  watch(
-    () => cookiesEnabledIds.value,
-    (current) => {
-      if (!consent || !isConsentGiven.value) return
-      // The Meta SDK only honours the ``ads`` slot; we mirror
-      // ``ad_storage`` from GA's consent vocabulary.
-      if (current?.includes('ad_storage')) {
-        consent.grant()
-      }
-      else {
-        consent.revoke()
-      }
-    },
-    { immediate: true },
+  // Reactive: the user has explicitly accepted the banner AND the
+  // ad_storage category is enabled. Either gate alone is insufficient:
+  //
+  // * isConsentGiven only flips true after the user clicks the banner
+  //   so we don't fire pixel events for visitors who never made a
+  //   choice.
+  // * Even when the banner is acknowledged, the user can deselect
+  //   ad_storage via "Manage preferences" — we honour that choice.
+  const adConsent = computed(() =>
+    !!(
+      isConsentGiven.value
+      && cookiesEnabledIds.value?.includes('ad_storage')
+    ),
   )
+
+  const trigger = useScriptTriggerConsent({ consent: adConsent })
+
+  useScriptMetaPixel({
+    id: pixelId,
+    scriptOptions: { trigger },
+  })
 }
 
 export function setupSocialLogin() {

--- a/app/composables/useMetaPixel.ts
+++ b/app/composables/useMetaPixel.ts
@@ -91,13 +91,16 @@ export function useMetaPixel() {
 
   const isProvisioned = !!pixelId
 
-  // ``useScriptMetaPixel`` is auto-imported by @nuxt/scripts. Cast
-  // through ``any`` because the typing for the registry is dynamic
-  // and we already validated the id presence above.
+  // ``useScriptMetaPixel`` is auto-imported by @nuxt/scripts. The
+  // actual registration (with the consent-gated script trigger)
+  // happens once in ``setupMetaPixelConsent`` from ``app.vue`` setup;
+  // calls here dedup against ``head._scripts['metaPixel']`` and
+  // return the same proxy. Passing options here would race with the
+  // setup site if the dedup picks the wrong call's options first
+  // (see comment in ``setups.ts:setupMetaPixelConsent`` for the
+  // historical incident this avoids).
   const proxy = isProvisioned
-
-    ? (useScriptMetaPixel({ id: pixelId, defaultConsent: 'denied' }) as any)
-        .proxy
+    ? useScriptMetaPixel({ id: pixelId }).proxy
     : { fbq: NOOP_PROXY }
 
   const fbq = (


### PR DESCRIPTION
## Problem

Meta Pixel was silently never firing in production despite the pixel ID being configured. Verified end-to-end via Chrome MCP on prod (https://webside.gr):

| Check | Observed |
|---|---|
| ``runtimeConfig.public.metaPixelId`` | ✅ ``2069195953640891`` |
| ``nuxtApp.\$scripts.metaPixel`` | ✅ registered |
| ``status.value`` | ``loaded`` (lying) |
| ``entry._nodes`` | ❌ undefined |
| ``<script src=connect.facebook.net…>`` in DOM | ❌ absent |
| ``fbq.queue`` | ``[[init, …], [track, PageView], [consent, grant]]`` — grows forever, never drains |
| ``_fbp`` cookie | ❌ never set |
| ``facebook.com/tr/`` beacons | ❌ none |

## Root cause

Confirmed via @nuxt/scripts 1.0.5 source (``meta-pixel.js``, ``utils.js``) + unhead 2.1.13 source (``useScript`` impl) + the official consent guide at https://scripts.nuxt.com/docs/guides/consent.

The previous code combined ``defaultConsent: 'denied'`` with a manual ``consent.grant()`` watcher AND called ``useScriptMetaPixel`` from two sites:

- ``setupMetaPixelConsent`` in ``app.vue`` setup with ``defaultConsent: 'denied'`` + ``scriptOptions.trigger: 'onNuxtReady'``
- ``useMetaPixel`` tracker composable with ``defaultConsent: 'denied'`` (no trigger)

Two compounding facts the docs make explicit but the old code didn't honour:

1. ``defaultConsent`` is **purely a vendor flag**. It does NOT gate script injection. ``consent.grant()`` only pushes ``fbq('consent', 'grant')`` into the queue — neither flips Unhead's load state.
2. The two ``useScriptMetaPixel`` calls dedup against ``head._scripts['metaPixel']`` but the SSR registration's ``clientInit`` captured options where ``options?.defaultConsent`` resolved as undefined when ``clientInit`` ran on the client. The registry then reported ``status: 'loaded'`` even though no DOM script tag was ever injected.

End result in prod: every fbq event Q'd forever, zero beacons sent, browser pixel functionally dead.

## Fix

Replace the dual-call ``defaultConsent``-based pattern with the canonical pattern documented at https://scripts.nuxt.com/docs/guides/consent — ``useScriptTriggerConsent`` as the binary script-load gate:

```ts
// app/composables/setups.ts (single source of truth)
const adConsent = computed(() =>
  !!(
    isConsentGiven.value
    && cookiesEnabledIds.value?.includes('ad_storage')
  ),
)
const trigger = useScriptTriggerConsent({ consent: adConsent })

useScriptMetaPixel({
  id: pixelId,
  scriptOptions: { trigger },
})
```

```ts
// app/composables/useMetaPixel.ts (consumer — relies on dedup)
const proxy = isProvisioned
  ? useScriptMetaPixel({ id: pixelId }).proxy
  : { fbq: NOOP_PROXY }
```

What changed:

- Single ``useScriptMetaPixel`` registration with the consent trigger as ``scriptOptions.trigger``. Tracker callsites just look up the same instance via dedup.
- ``defaultConsent`` removed — redundant once the script load itself is gated; the vendor never sees a "denied" state because the script doesn't load until consent flips.
- Manual ``cookiesEnabledIds`` ``{immediate: true}`` watcher gone — ``useScriptTriggerConsent`` reacts to the consent ref directly via its documented trigger contract.
- All ``as any`` and ``as Parameters<typeof useScriptMetaPixel>[0]`` casts removed — registry types now resolve cleanly without escape hatches.

## Expected behaviour

- **Pre-consent** (visitor hasn't accepted the cookie banner OR ``ad_storage`` is off): no ``<script src=connect.facebook.net…>`` in DOM, ``fbq`` undefined or queue empty, no ``_fbp`` cookie, no ``tr/`` beacons. Tracker call sites all no-op silently.
- **On accept** (banner click → ``isConsentGiven=true && ad_storage∈cookiesEnabledIds``): trigger flips, fbevents.js injected into DOM, ``init`` + ``PageView`` queue drains to Meta, ``_fbp`` cookie set, ``tr/`` PageView beacon fires.
- **On revoke**: ``useScriptTriggerConsent.revoke()`` flips the ``consented`` ref. Per the docs, this signals the script to unload (the docs don't guarantee DOM tag removal — but the tracker proxy is a no-op once the trigger gates events again on the next page load).

## Test plan

- [x] ``pnpm lint app/composables/{setups,useMetaPixel}.ts`` — clean
- [x] ``pnpm vue-tsc --noEmit`` — 0 errors, no ``as any``
- [ ] Local restart of ``pnpm dev`` and Chrome MCP verification (script tag injected on consent click, ``_fbp`` set, ``tr/`` beacon fires)
- [ ] After deploy: re-fire the manual ``CompleteRegistration`` CAPI dispatch verified earlier (PR #6) — both pixel + CAPI Purchase events should land in Events Manager with matching ``event_id`` for dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Meta Pixel consent registration and management logic for improved reliability and streamlined consent handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->