### PR TITLE
fix(cache): don't serve stale results for sort/filter product listings

### DIFF
--- a/server/api/products/index.get.ts
+++ b/server/api/products/index.get.ts
@@ -14,9 +14,11 @@ export default defineCachedEventHandler(async (event) => {
   }
 }, {
   name: 'ProductViewSet',
+  // Sort/filter-sensitive listing: never serve stale results (a stale entry
+  // can show the wrong order after a backend change). Cache identical queries
+  // for load relief, but always fetch fresh on expiry rather than SWR.
   maxAge: 300, // Cache for 5 minutes
-  staleMaxAge: 600, // Serve stale for 10 minutes while revalidating
-  swr: true,
+  swr: false,
   getKey: (event) => {
     const query = getQuery(event)
     // Build a stable, canonicalized key from every param that affects the response.

--- a/server/api/products/search.get.ts
+++ b/server/api/products/search.get.ts
@@ -78,9 +78,12 @@ export default defineCachedEventHandler(async (event) => {
   }
 }, {
   name: 'SearchProductViewSet',
+  // Search results are sort/filter-sensitive: never serve them stale. A
+  // stale-while-revalidate entry can surface the wrong order after a backend
+  // change (e.g. a sort-mapping fix) until it revalidates. Cache identical
+  // queries briefly for load relief, but always fetch fresh on expiry.
   maxAge: 60, // Cache for 1 minute — Meilisearch is near-real-time
-  staleMaxAge: 300, // Serve stale for 5 minutes while revalidating
-  swr: true,
+  swr: false,
   getKey: (event) => {
     const query = getQuery(event)
     const keyParts = [


### PR DESCRIPTION
## Summary

Follow-up to the price-sort fix. The product **search** and **list** routes served results via stale-while-revalidate (`swr: true`). During the rollout of the backend sort-mapping fix (audit G0333, shipped to prod as `django-api v1.156.5`), those caches held pre-fix entries and SWR kept serving the **wrong sort order** for the stale window before revalidating — so price sorting still looked broken on the products page even after the API was corrected, and it flapped between correct and stale on rapid requests.

## Fix

Search and listing results are sort/filter-sensitive: serving a stale entry can surface the wrong order. This disables `swr` on both product routes (Nitro defaults `swr` to `true`) while keeping `maxAge`:
- `server/api/products/search.get.ts` — `swr: false`, drop `staleMaxAge` (keep `maxAge: 60`)
- `server/api/products/index.get.ts` — `swr: false`, drop `staleMaxAge` (keep `maxAge: 300`)

With `swr: false`, the cached entry's storage TTL becomes `maxAge`, so identical queries are still cached briefly for load relief, but on expiry the route always fetches fresh instead of serving stale data. No more stale-wrong flash on sort/filter changes.

## Audit of similar routes (checked, no change needed)
- **`blog/posts/index`** — same SWR pattern (24h stale) but DRF-ordered (robust) and static content, so it only ever serves stale-but-correctly-ordered data. SWR is appropriate here.
- **Blog Meilisearch (backend)** — correctly reuses the camelCase→snake_case sort map; no G0333-style flaw.
- **Static reference endpoints** (categories, tags, authors, settings, countries, pay-way, loyalty, shipping) — SWR is ideal; no sort/filter-correctness risk.

## Validation
Full suite green (1657 passed, 1 skipped); eslint clean; the product-search route test (40 tests) still passes.

## Note
The already-shipped backend fix (`v1.156.5`) is what actually corrected price sorting; I also purged the product cache surface in the Django admin, and verified in the browser that price asc/desc now order correctly. This PR prevents the stale-serve class of issue from recurring on the next backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product listings now refresh strictly after the cache expires, preventing outdated results from being displayed.
  * Product search results are refreshed after 60 seconds instead of serving stale data during revalidation.
  * Search results now better reflect current sorting and filtering criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->