### PR TITLE
fix(openapi): drop internal-only fields from Acs/BoxNow shipment detail schema

### DIFF
--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -48160,29 +48160,11 @@
                         "description": "Relative URL to download the voucher PDF via the Django proxy.",
                         "readOnly": true
                     },
-                    "deliveryFlag": {
-                        "type": "string",
-                        "readOnly": true,
-                        "description": "Raw delivery_flag value from ACS_Trackingsummary."
-                    },
-                    "returnedFlag": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "rawShipmentStatus": {
-                        "type": "string",
-                        "readOnly": true
-                    },
                     "cancelRequestedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
                         "nullable": true
-                    },
-                    "metadata": {
-                        "readOnly": true,
-                        "title": "Μεταδεδομένα",
-                        "description": "Multipart child voucher numbers, last create-voucher response, last error envelope, cached POD URL."
                     }
                 },
                 "required": [
@@ -48190,7 +48172,6 @@
                     "chargeType",
                     "createdAt",
                     "deliveryDate",
-                    "deliveryFlag",
                     "deliveryKind",
                     "deliveryProducts",
                     "events",
@@ -48199,9 +48180,6 @@
                     "labelUrl",
                     "lastEventAt",
                     "lastPolledAt",
-                    "metadata",
-                    "rawShipmentStatus",
-                    "returnedFlag",
                     "shipmentState",
                     "shipmentStateDisplay",
                     "station",
@@ -51216,11 +51194,6 @@
                         "format": "date-time",
                         "readOnly": true,
                         "nullable": true
-                    },
-                    "metadata": {
-                        "readOnly": true,
-                        "title": "Μεταδεδομένα",
-                        "description": "Full delivery-request response and diagnostics from BoxNow"
                     }
                 },
                 "required": [
@@ -51236,7 +51209,6 @@
                     "lastEventAt",
                     "locker",
                     "lockerExternalId",
-                    "metadata",
                     "parcelId",
                     "parcelState",
                     "parcelStateDisplay",

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -28486,31 +28486,16 @@ components:
           nullable: true
           description: Relative URL to download the voucher PDF via the Django proxy.
           readOnly: true
-        deliveryFlag:
-          type: string
-          readOnly: true
-          description: Raw delivery_flag value from ACS_Trackingsummary.
-        returnedFlag:
-          type: string
-          readOnly: true
-        rawShipmentStatus:
-          type: string
-          readOnly: true
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-        metadata:
-          readOnly: true
-          title: Μεταδεδομένα
-          description: Multipart child voucher numbers, last create-voucher response, last error envelope, cached POD URL.
       required:
         - cancelRequestedAt
         - chargeType
         - createdAt
         - deliveryDate
-        - deliveryFlag
         - deliveryKind
         - deliveryProducts
         - events
@@ -28519,9 +28504,6 @@ components:
         - labelUrl
         - lastEventAt
         - lastPolledAt
-        - metadata
-        - rawShipmentStatus
-        - returnedFlag
         - shipmentState
         - shipmentStateDisplay
         - station
@@ -30885,10 +30867,6 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-        metadata:
-          readOnly: true
-          title: Μεταδεδομένα
-          description: Full delivery-request response and diagnostics from BoxNow
       required:
         - allowReturn
         - amountToBeCollected
@@ -30902,7 +30880,6 @@ components:
         - lastEventAt
         - locker
         - lockerExternalId
-        - metadata
         - parcelId
         - parcelState
         - parcelStateDisplay

--- a/schema.yml
+++ b/schema.yml
@@ -28486,31 +28486,16 @@ components:
           nullable: true
           description: Relative URL to download the voucher PDF via the Django proxy.
           readOnly: true
-        deliveryFlag:
-          type: string
-          readOnly: true
-          description: Raw delivery_flag value from ACS_Trackingsummary.
-        returnedFlag:
-          type: string
-          readOnly: true
-        rawShipmentStatus:
-          type: string
-          readOnly: true
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-        metadata:
-          readOnly: true
-          title: Μεταδεδομένα
-          description: Multipart child voucher numbers, last create-voucher response, last error envelope, cached POD URL.
       required:
         - cancelRequestedAt
         - chargeType
         - createdAt
         - deliveryDate
-        - deliveryFlag
         - deliveryKind
         - deliveryProducts
         - events
@@ -28519,9 +28504,6 @@ components:
         - labelUrl
         - lastEventAt
         - lastPolledAt
-        - metadata
-        - rawShipmentStatus
-        - returnedFlag
         - shipmentState
         - shipmentStateDisplay
         - station
@@ -30885,10 +30867,6 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-        metadata:
-          readOnly: true
-          title: Μεταδεδομένα
-          description: Full delivery-request response and diagnostics from BoxNow
       required:
         - allowReturn
         - amountToBeCollected
@@ -30902,7 +30880,6 @@ components:
         - lastEventAt
         - locker
         - lockerExternalId
-        - metadata
         - parcelId
         - parcelState
         - parcelStateDisplay

--- a/shared/openapi/types.gen.ts
+++ b/shared/openapi/types.gen.ts
@@ -150,19 +150,7 @@ export type AcsShipmentDetail = {
      * Relative URL to download the voucher PDF via the Django proxy.
      */
   readonly labelUrl: string | null
-  /**
-     * Raw delivery_flag value from ACS_Trackingsummary.
-     */
-  readonly deliveryFlag: string
-  readonly returnedFlag: string
-  readonly rawShipmentStatus: string
   readonly cancelRequestedAt: string | null
-  /**
-     * Μεταδεδομένα
-     *
-     * Multipart child voucher numbers, last create-voucher response, last error envelope, cached POD URL.
-     */
-  readonly metadata: unknown
 }
 
 /**
@@ -1626,12 +1614,6 @@ export type BoxNowShipmentDetail = {
   readonly amountToBeCollected: number
   readonly allowReturn: boolean
   readonly cancelRequestedAt: string | null
-  /**
-     * Μεταδεδομένα
-     *
-     * Full delivery-request response and diagnostics from BoxNow
-     */
-  readonly metadata: unknown
 }
 
 /**

--- a/shared/openapi/zod.gen.ts
+++ b/shared/openapi/zod.gen.ts
@@ -4035,15 +4035,7 @@ export const zAcsShipmentDetail = z.object({
     description: 'Last 50 tracking events ordered by event_time desc.',
   }).readonly(),
   labelUrl: z.string().readonly().nullable(),
-  deliveryFlag: z.string().register(z.globalRegistry, {
-    description: 'Raw delivery_flag value from ACS_Trackingsummary.',
-  }).readonly(),
-  returnedFlag: z.string().readonly(),
-  rawShipmentStatus: z.string().readonly(),
   cancelRequestedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
-  metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Multipart child voucher numbers, last create-voucher response, last error envelope, cached POD URL.',
-  }),
 }).register(z.globalRegistry, {
   description: 'Detail serializer used on the order-detail endpoint.',
 })
@@ -4673,9 +4665,6 @@ export const zBoxNowShipmentDetail = z.object({
   }).readonly(),
   allowReturn: z.boolean().readonly(),
   cancelRequestedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
-  metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Full delivery-request response and diagnostics from BoxNow',
-  }),
 }).register(z.globalRegistry, {
   description: 'Detail serializer for a single BoxNow shipment.\n\nExtends the list serializer with:\n- nested ``locker`` object (``BoxNowLockerSerializer``)\n- ``events`` — last 20 ``BoxNowParcelEvent`` records ordered by\n  ``event_time`` descending\n- ``label_url`` — relative URL for downloading the parcel label PDF\n  via the Django proxy route; ``None`` when ``parcel_id`` is blank\n\nImports of ``BoxNowLockerSerializer`` and\n``BoxNowParcelEventSerializer`` are deferred to method bodies to\nprevent circular import chains between the serializer modules.',
 })


### PR DESCRIPTION
## Problem

A production test order with **pay-on-delivery + ACS home-delivery** failed at checkout with a 422 `Data parsing failed`. The Django order was created fine, but the Nuxt server's `parseDataAs` rejected the response.

## Root cause — pre-existing schema drift (not from the recent audit)

The customer-facing Django serializers deliberately omit internal/PII fields:
- `AcsShipmentDetailSerializer` omits `deliveryFlag`, `returnedFlag`, `rawShipmentStatus`, `metadata` (removed in GDPR commit `20a03bad`)
- `BoxNowShipmentDetail` omits `metadata`

The Nuxt OpenAPI schema was **never regenerated** after those Django changes, so the generated zod (`AcsShipmentDetail`, `BoxNowShipmentDetail`) still marked those fields as **required**. Every COD order-create response nests the shipment detail, so validation failed on the (correctly) absent fields — breaking **COD + ACS home-delivery** and **COD + BoxNow** checkout.

Verified via a structural drift scan (`required` in Nuxt but absent from the current Django component) — these two were the only checkout-affecting drifts.

## Fix

Realign the generated schema/types/zod with the current Django contract by removing the omitted fields. Pure regen — no app code references these fields.

## Changes
- `openapi/schema.json`, `openapi/schema.yml`, `schema.yml` — remove the omitted fields from `AcsShipmentDetail` / `BoxNowShipmentDetail`
- `shared/openapi/types.gen.ts`, `shared/openapi/zod.gen.ts` — regenerated

## Follow-up (not in this PR)
- `NotificationUserWriteRequest` still lists `notification` as required while Django's write serializer omits it — unrelated to checkout (write body), flagged for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Updates**
  - Shipment and parcel responses no longer expose internal delivery diagnostics, metadata, or raw status fields.
  - `cancelRequestedAt` remains available as a nullable timestamp.
  - Updated response validation and schema definitions to reflect the streamlined payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->