### PR TITLE
fix(openapi): realign full schema with Django to eliminate contract drift

### DIFF
--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -48953,10 +48953,18 @@
                         "type": "integer"
                     },
                     "website": {
-                        "type": "string",
-                        "format": "uri",
                         "title": "Ιστότοπος",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     }
                 },
                 "required": [
@@ -51683,7 +51691,6 @@
                     },
                     "cartId": {
                         "type": "string",
-                        "format": "uuid",
                         "readOnly": true
                     },
                     "product": {
@@ -51853,7 +51860,6 @@
                     },
                     "cartId": {
                         "type": "string",
-                        "format": "uuid",
                         "readOnly": true
                     },
                     "product": {
@@ -52050,15 +52056,6 @@
                     "currency",
                     "paymentIntentId"
                 ]
-            },
-            "CartWriteRequest": {
-                "type": "object",
-                "properties": {
-                    "user": {
-                        "type": "integer",
-                        "nullable": true
-                    }
-                }
             },
             "CompartmentSizeEnum": {
                 "enum": [
@@ -53499,17 +53496,11 @@
             "NotificationUserWriteRequest": {
                 "type": "object",
                 "properties": {
-                    "notification": {
-                        "type": "integer"
-                    },
                     "seen": {
                         "type": "boolean",
                         "title": "Ορατό"
                     }
-                },
-                "required": [
-                    "notification"
-                ]
+                }
             },
             "Order": {
                 "type": "object",
@@ -53906,10 +53897,18 @@
                         "description": "BoxNow compartment size: 1=Small, 2=Medium, 3=Large"
                     },
                     "shippingProviderCode": {
-                        "type": "string",
                         "description": "Carrier code from /api/v1/shipping/options (e.g. 'acs').",
-                        "maxLength": 32,
-                        "pattern": "^[-a-zA-Z0-9_]+$"
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 32,
+                                "pattern": "^[-a-zA-Z0-9_]+$"
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "shippingKind": {
                         "allOf": [
@@ -56676,10 +56675,18 @@
                         "type": "integer"
                     },
                     "website": {
-                        "type": "string",
-                        "format": "uri",
                         "title": "Ιστότοπος",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     }
                 }
             },
@@ -56929,15 +56936,6 @@
                     }
                 }
             },
-            "PatchedCartWriteRequest": {
-                "type": "object",
-                "properties": {
-                    "user": {
-                        "type": "integer",
-                        "nullable": true
-                    }
-                }
-            },
             "PatchedCountryWriteRequest": {
                 "type": "object",
                 "description": "Serializer that saves :class:`TranslatedFieldsField` automatically.",
@@ -57004,9 +57002,6 @@
             "PatchedNotificationUserWriteRequest": {
                 "type": "object",
                 "properties": {
-                    "notification": {
-                        "type": "integer"
-                    },
                     "seen": {
                         "type": "boolean",
                         "title": "Ορατό"
@@ -57914,12 +57909,20 @@
                         "maxLength": 255
                     },
                     "username": {
-                        "type": "string",
                         "nullable": true,
                         "title": "Όνομα χρήστη",
                         "description": "Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.",
-                        "pattern": "^[\\w.@+#-]+$",
-                        "maxLength": 30
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^[\\w.@+#-]+$",
+                                "maxLength": 30
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "image": {
                         "type": "string",
@@ -57970,53 +57973,109 @@
                         "title": "Ημ/νία γέννησης"
                     },
                     "twitter": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Twitter",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "linkedin": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ LinkedIn",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "facebook": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Facebook",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "instagram": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Instagram",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "website": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Ιστότοπος",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "youtube": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Youtube",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "github": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Github",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "bio": {
                         "type": "string",
@@ -61668,8 +61727,7 @@
                 "type": "object",
                 "properties": {
                     "cartId": {
-                        "type": "string",
-                        "format": "uuid",
+                        "type": "integer",
                         "nullable": true
                     },
                     "addedItems": {
@@ -61967,12 +62025,14 @@
                     "logo": {
                         "type": "string",
                         "format": "uri",
+                        "nullable": true,
                         "readOnly": true,
                         "description": "Absolute URL for the operator-uploaded primary brand logo (home-delivery rows + fallback for pickup_point when no pickup-specific variant is set). ``null`` when no upload — the storefront falls back to its bundled default."
                     },
                     "logoPickupPoint": {
                         "type": "string",
                         "format": "uri",
+                        "nullable": true,
                         "readOnly": true,
                         "description": "Absolute URL for the optional pickup-point-specific logo (e.g. a locker illustration distinct from the carrier's home-delivery brand mark). Surfaced on the pickup_point row's ``logoUrl`` when uploaded; otherwise the row falls back to ``logo``."
                     },
@@ -63317,12 +63377,20 @@
                         "readOnly": true
                     },
                     "username": {
-                        "type": "string",
                         "nullable": true,
                         "title": "Όνομα χρήστη",
                         "description": "Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.",
-                        "pattern": "^[\\w.@+#-]+$",
-                        "maxLength": 30
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^[\\w.@+#-]+$",
+                                "maxLength": 30
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "phone": {
                         "type": "string",
@@ -63661,12 +63729,20 @@
                         "maxLength": 255
                     },
                     "username": {
-                        "type": "string",
                         "nullable": true,
                         "title": "Όνομα χρήστη",
                         "description": "Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.",
-                        "pattern": "^[\\w.@+#-]+$",
-                        "maxLength": 30
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^[\\w.@+#-]+$",
+                                "maxLength": 30
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "image": {
                         "type": "string",
@@ -63717,53 +63793,109 @@
                         "title": "Ημ/νία γέννησης"
                     },
                     "twitter": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Twitter",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "linkedin": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ LinkedIn",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "facebook": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Facebook",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "instagram": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Instagram",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "website": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Ιστότοπος",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "youtube": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Youtube",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "github": {
-                        "type": "string",
-                        "format": "uri",
                         "nullable": true,
                         "title": "Προφίλ Github",
-                        "maxLength": 200
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 200
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        ]
                     },
                     "bio": {
                         "type": "string",

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -29114,10 +29114,13 @@ components:
         user:
           type: integer
         website:
-          type: string
-          format: uri
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
       required:
         - translations
         - user
@@ -31291,7 +31294,6 @@ components:
           readOnly: true
         cartId:
           type: string
-          format: uuid
           readOnly: true
         product:
           allOf:
@@ -31428,7 +31430,6 @@ components:
           readOnly: true
         cartId:
           type: string
-          format: uuid
           readOnly: true
         product:
           allOf:
@@ -31587,12 +31588,6 @@ components:
         - clientSecret
         - currency
         - paymentIntentId
-    CartWriteRequest:
-      type: object
-      properties:
-        user:
-          type: integer
-          nullable: true
     CompartmentSizeEnum:
       enum:
         - 1
@@ -32767,13 +32762,9 @@ components:
     NotificationUserWriteRequest:
       type: object
       properties:
-        notification:
-          type: integer
         seen:
           type: boolean
           title: Ορατό
-      required:
-        - notification
     Order:
       type: object
       properties:
@@ -33094,10 +33085,13 @@ components:
           default: 1
           description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large'
         shippingProviderCode:
-          type: string
           description: Carrier code from /api/v1/shipping/options (e.g. 'acs').
-          maxLength: 32
-          pattern: ^[-a-zA-Z0-9_]+$
+          oneOf:
+            - type: string
+              maxLength: 32
+              pattern: ^[-a-zA-Z0-9_]+$
+            - type: string
+              maxLength: 0
         shippingKind:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
@@ -35170,10 +35164,13 @@ components:
         user:
           type: integer
         website:
-          type: string
-          format: uri
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
     PatchedBlogCategoryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35340,12 +35337,6 @@ components:
           maximum: 2147483647
           minimum: 0
           title: Ποσότητα
-    PatchedCartWriteRequest:
-      type: object
-      properties:
-        user:
-          type: integer
-          nullable: true
     PatchedCountryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35395,8 +35386,6 @@ components:
     PatchedNotificationUserWriteRequest:
       type: object
       properties:
-        notification:
-          type: integer
         seen:
           type: boolean
           title: Ορατό
@@ -36038,12 +36027,15 @@ components:
           title: Επώνυμο
           maxLength: 255
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         image:
           type: string
           format: binary
@@ -36084,47 +36076,68 @@ components:
           nullable: true
           title: Ημ/νία γέννησης
         twitter:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Twitter
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         linkedin:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ LinkedIn
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         facebook:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Facebook
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         instagram:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Instagram
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         website:
-          type: string
-          format: uri
           nullable: true
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         youtube:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Youtube
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         github:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Github
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         bio:
           type: string
           title: Βιογραφικό
@@ -38874,8 +38887,7 @@ components:
       type: object
       properties:
         cartId:
-          type: string
-          format: uuid
+          type: integer
           nullable: true
         addedItems:
           type: array
@@ -39115,11 +39127,13 @@ components:
         logo:
           type: string
           format: uri
+          nullable: true
           readOnly: true
           description: Absolute URL for the operator-uploaded primary brand logo (home-delivery rows + fallback for pickup_point when no pickup-specific variant is set). ``null`` when no upload — the storefront falls back to its bundled default.
         logoPickupPoint:
           type: string
           format: uri
+          nullable: true
           readOnly: true
           description: Absolute URL for the optional pickup-point-specific logo (e.g. a locker illustration distinct from the carrier's home-delivery brand mark). Surfaced on the pickup_point row's ``logoUrl`` when uploaded; otherwise the row falls back to ``logo``.
         mainImagePath:
@@ -40175,12 +40189,15 @@ components:
           type: integer
           readOnly: true
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         phone:
           type: string
           nullable: true
@@ -40445,12 +40462,15 @@ components:
           title: Επώνυμο
           maxLength: 255
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         image:
           type: string
           format: binary
@@ -40491,47 +40511,68 @@ components:
           nullable: true
           title: Ημ/νία γέννησης
         twitter:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Twitter
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         linkedin:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ LinkedIn
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         facebook:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Facebook
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         instagram:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Instagram
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         website:
-          type: string
-          format: uri
           nullable: true
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         youtube:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Youtube
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         github:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Github
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         bio:
           type: string
           title: Βιογραφικό

--- a/schema.yml
+++ b/schema.yml
@@ -29114,10 +29114,13 @@ components:
         user:
           type: integer
         website:
-          type: string
-          format: uri
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
       required:
         - translations
         - user
@@ -31291,7 +31294,6 @@ components:
           readOnly: true
         cartId:
           type: string
-          format: uuid
           readOnly: true
         product:
           allOf:
@@ -31428,7 +31430,6 @@ components:
           readOnly: true
         cartId:
           type: string
-          format: uuid
           readOnly: true
         product:
           allOf:
@@ -31587,12 +31588,6 @@ components:
         - clientSecret
         - currency
         - paymentIntentId
-    CartWriteRequest:
-      type: object
-      properties:
-        user:
-          type: integer
-          nullable: true
     CompartmentSizeEnum:
       enum:
         - 1
@@ -32767,13 +32762,9 @@ components:
     NotificationUserWriteRequest:
       type: object
       properties:
-        notification:
-          type: integer
         seen:
           type: boolean
           title: Ορατό
-      required:
-        - notification
     Order:
       type: object
       properties:
@@ -33094,10 +33085,13 @@ components:
           default: 1
           description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large'
         shippingProviderCode:
-          type: string
           description: Carrier code from /api/v1/shipping/options (e.g. 'acs').
-          maxLength: 32
-          pattern: ^[-a-zA-Z0-9_]+$
+          oneOf:
+            - type: string
+              maxLength: 32
+              pattern: ^[-a-zA-Z0-9_]+$
+            - type: string
+              maxLength: 0
         shippingKind:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
@@ -35170,10 +35164,13 @@ components:
         user:
           type: integer
         website:
-          type: string
-          format: uri
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
     PatchedBlogCategoryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35340,12 +35337,6 @@ components:
           maximum: 2147483647
           minimum: 0
           title: Ποσότητα
-    PatchedCartWriteRequest:
-      type: object
-      properties:
-        user:
-          type: integer
-          nullable: true
     PatchedCountryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35395,8 +35386,6 @@ components:
     PatchedNotificationUserWriteRequest:
       type: object
       properties:
-        notification:
-          type: integer
         seen:
           type: boolean
           title: Ορατό
@@ -36038,12 +36027,15 @@ components:
           title: Επώνυμο
           maxLength: 255
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         image:
           type: string
           format: binary
@@ -36084,47 +36076,68 @@ components:
           nullable: true
           title: Ημ/νία γέννησης
         twitter:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Twitter
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         linkedin:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ LinkedIn
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         facebook:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Facebook
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         instagram:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Instagram
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         website:
-          type: string
-          format: uri
           nullable: true
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         youtube:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Youtube
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         github:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Github
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         bio:
           type: string
           title: Βιογραφικό
@@ -38874,8 +38887,7 @@ components:
       type: object
       properties:
         cartId:
-          type: string
-          format: uuid
+          type: integer
           nullable: true
         addedItems:
           type: array
@@ -39115,11 +39127,13 @@ components:
         logo:
           type: string
           format: uri
+          nullable: true
           readOnly: true
           description: Absolute URL for the operator-uploaded primary brand logo (home-delivery rows + fallback for pickup_point when no pickup-specific variant is set). ``null`` when no upload — the storefront falls back to its bundled default.
         logoPickupPoint:
           type: string
           format: uri
+          nullable: true
           readOnly: true
           description: Absolute URL for the optional pickup-point-specific logo (e.g. a locker illustration distinct from the carrier's home-delivery brand mark). Surfaced on the pickup_point row's ``logoUrl`` when uploaded; otherwise the row falls back to ``logo``.
         mainImagePath:
@@ -40175,12 +40189,15 @@ components:
           type: integer
           readOnly: true
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         phone:
           type: string
           nullable: true
@@ -40445,12 +40462,15 @@ components:
           title: Επώνυμο
           maxLength: 255
         username:
-          type: string
           nullable: true
           title: Όνομα χρήστη
           description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
-          pattern: ^[\w.@+#-]+$
-          maxLength: 30
+          oneOf:
+            - type: string
+              pattern: ^[\w.@+#-]+$
+              maxLength: 30
+            - type: string
+              maxLength: 0
         image:
           type: string
           format: binary
@@ -40491,47 +40511,68 @@ components:
           nullable: true
           title: Ημ/νία γέννησης
         twitter:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Twitter
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         linkedin:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ LinkedIn
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         facebook:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Facebook
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         instagram:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Instagram
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         website:
-          type: string
-          format: uri
           nullable: true
           title: Ιστότοπος
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         youtube:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Youtube
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         github:
-          type: string
-          format: uri
           nullable: true
           title: Προφίλ Github
-          maxLength: 200
+          oneOf:
+            - type: string
+              format: uri
+              maxLength: 200
+            - type: string
+              maxLength: 0
         bio:
           type: string
           title: Βιογραφικό

--- a/shared/openapi/types.gen.ts
+++ b/shared/openapi/types.gen.ts
@@ -514,7 +514,7 @@ export type BlogAuthorWriteRequest = {
   /**
      * Ιστότοπος
      */
-  website?: string
+  website?: string | string
 }
 
 /**
@@ -1990,10 +1990,6 @@ export type CartPaymentIntentResponse = {
   currency: string
 }
 
-export type CartWriteRequest = {
-  user?: number | null
-}
-
 /**
  * * `1` - Μικρό
  * * `2` - Μεσαίο
@@ -2746,7 +2742,6 @@ export type NotificationUserDetail = {
 }
 
 export type NotificationUserWriteRequest = {
-  notification: number
   /**
      * Ορατό
      */
@@ -2967,7 +2962,7 @@ export type OrderCreateFromCartRequest = {
   /**
      * Carrier code from /api/v1/shipping/options (e.g. 'acs').
      */
-  shippingProviderCode?: string
+  shippingProviderCode?: string | string
   /**
      * Generic fulfilment kind, independent of provider.
      *
@@ -3844,7 +3839,7 @@ export type PatchedBlogAuthorWriteRequest = {
   /**
      * Ιστότοπος
      */
-  website?: string
+  website?: string | string
 }
 
 /**
@@ -3967,10 +3962,6 @@ export type PatchedCartItemUpdateRequest = {
   quantity?: number
 }
 
-export type PatchedCartWriteRequest = {
-  user?: number | null
-}
-
 /**
  * Serializer that saves :class:`TranslatedFieldsField` automatically.
  */
@@ -4005,7 +3996,6 @@ export type PatchedCountryWriteRequest = {
 }
 
 export type PatchedNotificationUserWriteRequest = {
-  notification?: number
   /**
      * Ορατό
      */
@@ -4509,7 +4499,7 @@ export type PatchedUserWriteRequest = {
      *
      * Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
      */
-  username?: string | null
+  username?: string | string | null
   /**
      * Εικόνα
      */
@@ -4546,31 +4536,31 @@ export type PatchedUserWriteRequest = {
   /**
      * Προφίλ Twitter
      */
-  twitter?: string | null
+  twitter?: string | string | null
   /**
      * Προφίλ LinkedIn
      */
-  linkedin?: string | null
+  linkedin?: string | string | null
   /**
      * Προφίλ Facebook
      */
-  facebook?: string | null
+  facebook?: string | string | null
   /**
      * Προφίλ Instagram
      */
-  instagram?: string | null
+  instagram?: string | string | null
   /**
      * Ιστότοπος
      */
-  website?: string | null
+  website?: string | string | null
   /**
      * Προφίλ Youtube
      */
-  youtube?: string | null
+  youtube?: string | string | null
   /**
      * Προφίλ Github
      */
-  github?: string | null
+  github?: string | string | null
   /**
      * Βιογραφικό
      */
@@ -6136,7 +6126,7 @@ export type ReorderItem = {
 }
 
 export type ReorderResponse = {
-  cartId: string | null
+  cartId: number | null
   addedItems: Array<ReorderItem>
   skippedItems: Array<ReorderItem>
 }
@@ -6306,11 +6296,11 @@ export type ShippingProvider = {
   /**
      * Absolute URL for the operator-uploaded primary brand logo (home-delivery rows + fallback for pickup_point when no pickup-specific variant is set). ``null`` when no upload — the storefront falls back to its bundled default.
      */
-  readonly logo: string
+  readonly logo: string | null
   /**
      * Absolute URL for the optional pickup-point-specific logo (e.g. a locker illustration distinct from the carrier's home-delivery brand mark). Surfaced on the pickup_point row's ``logoUrl`` when uploaded; otherwise the row falls back to ``logo``.
      */
-  readonly logoPickupPoint: string
+  readonly logoPickupPoint: string | null
   /**
      * Relative ``media/uploads/shipping/<filename>`` path for the primary logo; empty string when no logo is uploaded. Mirrors the PayWay.icon contract.
      */
@@ -7036,7 +7026,7 @@ export type UserDetails = {
      *
      * Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
      */
-  username?: string | null
+  username?: string | string | null
   phone?: string | null
   /**
      * Πόλη
@@ -7230,7 +7220,7 @@ export type UserWriteRequest = {
      *
      * Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
      */
-  username?: string | null
+  username?: string | string | null
   /**
      * Εικόνα
      */
@@ -7267,31 +7257,31 @@ export type UserWriteRequest = {
   /**
      * Προφίλ Twitter
      */
-  twitter?: string | null
+  twitter?: string | string | null
   /**
      * Προφίλ LinkedIn
      */
-  linkedin?: string | null
+  linkedin?: string | string | null
   /**
      * Προφίλ Facebook
      */
-  facebook?: string | null
+  facebook?: string | string | null
   /**
      * Προφίλ Instagram
      */
-  instagram?: string | null
+  instagram?: string | string | null
   /**
      * Ιστότοπος
      */
-  website?: string | null
+  website?: string | string | null
   /**
      * Προφίλ Youtube
      */
-  youtube?: string | null
+  youtube?: string | string | null
   /**
      * Προφίλ Github
      */
-  github?: string | null
+  github?: string | string | null
   /**
      * Βιογραφικό
      */
@@ -8038,7 +8028,7 @@ export type OrderCreateFromCartRequestWritable = {
   /**
      * Carrier code from /api/v1/shipping/options (e.g. 'acs').
      */
-  shippingProviderCode?: string
+  shippingProviderCode?: string | string
   /**
      * Generic fulfilment kind, independent of provider.
      *
@@ -9550,7 +9540,7 @@ export type UserDetailsWritable = {
      *
      * Required. 30 characters or fewer.Letters, digits and @/./+/-/_ only.
      */
-  username?: string | null
+  username?: string | string | null
   phone?: string | null
   /**
      * Πόλη
@@ -12819,7 +12809,7 @@ export type RetrieveCartResponses = {
 export type RetrieveCartResponse = RetrieveCartResponses[keyof RetrieveCartResponses]
 
 export type PartialUpdateCartData = {
-  body?: PatchedCartWriteRequest
+  body?: unknown
   headers?: {
     /**
          * Guest cart UUID. Used to identify and maintain guest cart sessions.
@@ -12848,7 +12838,7 @@ export type PartialUpdateCartResponses = {
 export type PartialUpdateCartResponse = PartialUpdateCartResponses[keyof PartialUpdateCartResponses]
 
 export type UpdateCartData = {
-  body?: CartWriteRequest
+  body?: unknown
   headers?: {
     /**
          * Guest cart UUID. Used to identify and maintain guest cart sessions.

--- a/shared/openapi/zod.gen.ts
+++ b/shared/openapi/zod.gen.ts
@@ -197,7 +197,10 @@ export const zBlogAuthorWriteRequest = z.object({
     }).optional(),
   }),
   user: z.int(),
-  website: z.url().max(200).optional(),
+  website: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
 })
@@ -899,10 +902,6 @@ export const zCartPaymentIntentResponse = z.object({
   description: 'Response body returned by the create-payment-intent cart action.',
 })
 
-export const zCartWriteRequest = z.object({
-  user: z.int().nullish(),
-})
-
 /**
  * * `1` - Μικρό
  * * `2` - Μεσαίο
@@ -1485,7 +1484,6 @@ export const zNotificationUserActionRequest = z.object({
 })
 
 export const zNotificationUserWriteRequest = z.object({
-  notification: z.int(),
   seen: z.boolean().optional(),
 })
 
@@ -1752,7 +1750,10 @@ export const zPatchedBlogAuthorWriteRequest = z.object({
     }).optional(),
   }).optional(),
   user: z.int().optional(),
-  website: z.url().max(200).optional(),
+  website: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
 })
@@ -1861,10 +1862,6 @@ export const zPatchedCartItemUpdateRequest = z.object({
   quantity: z.int().gte(0).lte(2147483647).optional(),
 })
 
-export const zPatchedCartWriteRequest = z.object({
-  user: z.int().nullish(),
-})
-
 /**
  * Serializer that saves :class:`TranslatedFieldsField` automatically.
  */
@@ -1889,7 +1886,6 @@ export const zPatchedCountryWriteRequest = z.object({
 })
 
 export const zPatchedNotificationUserWriteRequest = z.object({
-  notification: z.int().optional(),
   seen: z.boolean().optional(),
 })
 
@@ -2168,7 +2164,10 @@ export const zPatchedUserWriteRequest = z.object({
   email: z.email().min(1).max(254).optional(),
   firstName: z.string().max(255).optional(),
   lastName: z.string().max(255).optional(),
-  username: z.string().max(30).regex(/^[\w.@+#-]+$/).nullish(),
+  username: z.union([
+    z.string().max(30).regex(/^[\w.@+#-]+$/),
+    z.string().max(0),
+  ]).nullish(),
   image: z.string().nullish(),
   phone: z.string().nullish(),
   city: z.string().max(255).optional(),
@@ -2178,13 +2177,34 @@ export const zPatchedUserWriteRequest = z.object({
   country: z.string().min(1).nullish(),
   region: z.string().min(1).nullish(),
   birthDate: z.iso.date().nullish(),
-  twitter: z.url().max(200).nullish(),
-  linkedin: z.url().max(200).nullish(),
-  facebook: z.url().max(200).nullish(),
-  instagram: z.url().max(200).nullish(),
-  website: z.url().max(200).nullish(),
-  youtube: z.url().max(200).nullish(),
-  github: z.url().max(200).nullish(),
+  twitter: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  linkedin: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  facebook: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  instagram: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  website: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  youtube: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  github: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
   bio: z.string().optional(),
   languageCode: z.string().min(1).max(10).register(z.globalRegistry, {
     description: 'Preferred language for emails and UI messages.',
@@ -2568,7 +2588,7 @@ export const zProduct = z.object({
 
 export const zCartItem = z.object({
   id: z.int().readonly(),
-  cartId: z.uuid().readonly(),
+  cartId: z.string().readonly(),
   product: zProduct,
   quantity: z.int().gte(0).lte(2147483647).optional(),
   weightInfo: z.object({
@@ -2649,7 +2669,7 @@ export const zCartDetail = z.object({
 
 export const zCartItemDetail = z.object({
   id: z.int().readonly(),
-  cartId: z.uuid().readonly(),
+  cartId: z.string().readonly(),
   product: zProduct,
   quantity: z.int().gte(0).lte(2147483647).optional(),
   weightInfo: z.object({
@@ -3674,7 +3694,7 @@ export const zReorderItem = z.object({
 })
 
 export const zReorderResponse = z.object({
-  cartId: z.uuid().nullable(),
+  cartId: z.int().nullable(),
   addedItems: z.array(zReorderItem),
   skippedItems: z.array(zReorderItem),
 })
@@ -3862,9 +3882,10 @@ export const zOrderCreateFromCartRequest = z.object({
   boxnowCompartmentSize: z.int().gte(1).lte(3).register(z.globalRegistry, {
     description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large',
   }).optional().default(1),
-  shippingProviderCode: z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Carrier code from /api/v1/shipping/options (e.g. \'acs\').',
-  }).optional(),
+  shippingProviderCode: z.union([
+    z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/),
+    z.string().max(0),
+  ]).optional(),
   shippingKind: zShippingKind.optional(),
   acsStationExternalId: z.string().max(32).register(z.globalRegistry, {
     description: 'ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).',
@@ -3921,12 +3942,8 @@ export const zShippingProvider = z.object({
   priority: z.int().register(z.globalRegistry, {
     description: 'Sort order in checkout — lower numbers appear first.',
   }).readonly(),
-  logo: z.url().register(z.globalRegistry, {
-    description: 'Absolute URL for the operator-uploaded primary brand logo (home-delivery rows + fallback for pickup_point when no pickup-specific variant is set). ``null`` when no upload — the storefront falls back to its bundled default.',
-  }).readonly(),
-  logoPickupPoint: z.url().register(z.globalRegistry, {
-    description: 'Absolute URL for the optional pickup-point-specific logo (e.g. a locker illustration distinct from the carrier\'s home-delivery brand mark). Surfaced on the pickup_point row\'s ``logoUrl`` when uploaded; otherwise the row falls back to ``logo``.',
-  }).readonly(),
+  logo: z.url().readonly().nullable(),
+  logoPickupPoint: z.url().readonly().nullable(),
   mainImagePath: z.string().register(z.globalRegistry, {
     description: 'Relative ``media/uploads/shipping/<filename>`` path for the primary logo; empty string when no logo is uploaded. Mirrors the PayWay.icon contract.',
   }).readonly(),
@@ -4930,7 +4947,10 @@ export const zUserDetails = z.object({
   firstName: z.string().max(255).optional(),
   lastName: z.string().max(255).optional(),
   id: z.int().readonly(),
-  username: z.string().max(30).regex(/^[\w.@+#-]+$/).nullish(),
+  username: z.union([
+    z.string().max(30).regex(/^[\w.@+#-]+$/),
+    z.string().max(0),
+  ]).nullish(),
   phone: z.string().nullish(),
   city: z.string().max(255).optional(),
   zipcode: z.string().max(255).optional(),
@@ -5329,7 +5349,10 @@ export const zUserWriteRequest = z.object({
   email: z.email().min(1).max(254),
   firstName: z.string().max(255).optional(),
   lastName: z.string().max(255).optional(),
-  username: z.string().max(30).regex(/^[\w.@+#-]+$/).nullish(),
+  username: z.union([
+    z.string().max(30).regex(/^[\w.@+#-]+$/),
+    z.string().max(0),
+  ]).nullish(),
   image: z.string().nullish(),
   phone: z.string().nullish(),
   city: z.string().max(255).optional(),
@@ -5339,13 +5362,34 @@ export const zUserWriteRequest = z.object({
   country: z.string().min(1).nullish(),
   region: z.string().min(1).nullish(),
   birthDate: z.iso.date().nullish(),
-  twitter: z.url().max(200).nullish(),
-  linkedin: z.url().max(200).nullish(),
-  facebook: z.url().max(200).nullish(),
-  instagram: z.url().max(200).nullish(),
-  website: z.url().max(200).nullish(),
-  youtube: z.url().max(200).nullish(),
-  github: z.url().max(200).nullish(),
+  twitter: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  linkedin: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  facebook: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  instagram: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  website: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  youtube: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
+  github: z.union([
+    z.url().max(200),
+    z.string().max(0),
+  ]).nullish(),
   bio: z.string().optional(),
   languageCode: z.string().min(1).max(10).register(z.globalRegistry, {
     description: 'Preferred language for emails and UI messages.',
@@ -5925,9 +5969,10 @@ export const zOrderCreateFromCartRequestWritable = z.object({
   boxnowCompartmentSize: z.int().gte(1).lte(3).register(z.globalRegistry, {
     description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large',
   }).optional().default(1),
-  shippingProviderCode: z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Carrier code from /api/v1/shipping/options (e.g. \'acs\').',
-  }).optional(),
+  shippingProviderCode: z.union([
+    z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/),
+    z.string().max(0),
+  ]).optional(),
   shippingKind: zShippingKind.optional(),
   acsStationExternalId: z.string().max(32).register(z.globalRegistry, {
     description: 'ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).',
@@ -7118,7 +7163,10 @@ export const zUserDetailsWritable = z.object({
   email: z.email().max(254),
   firstName: z.string().max(255).optional(),
   lastName: z.string().max(255).optional(),
-  username: z.string().max(30).regex(/^[\w.@+#-]+$/).nullish(),
+  username: z.union([
+    z.string().max(30).regex(/^[\w.@+#-]+$/),
+    z.string().max(0),
+  ]).nullish(),
   phone: z.string().nullish(),
   city: z.string().max(255).optional(),
   zipcode: z.string().max(255).optional(),
@@ -9877,7 +9925,7 @@ export const zRetrieveCartHeaders = z.object({
 
 export const zRetrieveCartResponse = zCartDetail
 
-export const zPartialUpdateCartBody = zPatchedCartWriteRequest
+export const zPartialUpdateCartBody = z.unknown()
 
 export const zPartialUpdateCartHeaders = z.object({
   'X-Cart-Id': z.uuid().register(z.globalRegistry, {
@@ -9887,7 +9935,7 @@ export const zPartialUpdateCartHeaders = z.object({
 
 export const zPartialUpdateCartResponse = zCartDetail
 
-export const zUpdateCartBody = zCartWriteRequest
+export const zUpdateCartBody = z.unknown()
 
 export const zUpdateCartHeaders = z.object({
   'X-Cart-Id': z.uuid().register(z.globalRegistry, {


### PR DESCRIPTION
## Context

Follow-up to #11 (the ACS/BoxNow shipment-detail 422 fix). You asked to fix `NotificationUserWriteRequest` and sweep for **other bugs of the same class** so we don't hit more broken flows.

## Method

Ran a structural diff of the committed OpenAPI snapshot against the **current deployed Django contract** (generated from the prod pod's code), across every failure pattern — missing-required, type mismatch, enum drift, nullability. Found **14 drifted components**; the Nuxt snapshot was stale. Each was validated against the authoritative Django serializer before fixing (not guessed).

## Bugs found & fixed

| Severity | Component.field | Problem |
|---|---|---|
| **Active** | `ReorderResponse.cartId` | Django returns an **integer** (cart PK); Nuxt zod required a UUID string → **every reorder 422'd** at `parseDataAs`. |
| Asked | `NotificationUserWriteRequest` / `Patched*` | `notification` is `read_only` on Django (only `seen` is client-writable) → drop from request body. |
| Latent | `ShippingProvider.logo` / `logoPickupPoint` | Nullable on Django ("null when no upload"); Nuxt required non-null URL → would 422 for a logo-less provider (both current providers have logos, so latent). |
| UX | `UserWriteRequest`/`Patched*`, `BlogAuthorWriteRequest`/`Patched*` | URL/social fields are `allow_blank` on Django; Nuxt rejected empty string → couldn't clear them. |
| Cosmetic | `CartItem`/`CartItemDetail.cartId` | Dropped spurious `uuid` format (value is a UUID but typed `str`). |
| Cosmetic | `OrderCreateFromCartRequest.shippingProviderCode`, `UserDetails.username` | Align `oneOf`/blank representation. |
| Cleanup | `CartWriteRequest`, `PatchedCartWriteRequest` | Removed — deleted from Django. |

## Approach

Applied only the **structural deltas** to the committed schema (preserving the existing English descriptions) so the diff is purely semantic — no locale churn. Then regenerated `types.gen.ts` / `zod.gen.ts`.

## Verification
- Structural drift scan: **0 findings** after the change.
- `vue-tsc --noEmit`: clean — no frontend consumer of any changed field breaks (reorder never reads `cartId`; shipping uses `logoUrl`, not `.logo`).
- eslint clean; no affected tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Profile usernames, social links, websites, and shipping provider codes can now be left blank when appropriate.
  * Shipping provider logos can now be unavailable or null.
  * Cart and reorder identifiers support updated formats for improved compatibility.
* **API Updates**
  * Cart update requests no longer require the previous structured request format.
  * Notification update requests no longer include the notification field.
  * Removed obsolete cart request definitions from the API schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->