### PR TITLE
fix(auth): advance to the pending flow on allauth 401 (login MFA + login-by-code)

### DIFF
--- a/app/components/Account/Login/Code/Form.vue
+++ b/app/components/Account/Login/Code/Form.vue
@@ -48,6 +48,23 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
     emit('requestLoginCode')
   }
   catch (err) {
+    // allauth accepts the request and emails the code, then signals the
+    // next step as a 401 with `login_by_code` pending — which `$fetch`
+    // throws. That is success, not failure: advance to the confirm step
+    // instead of surfacing a false "could not send the code".
+    const flowRoute = pendingFlowRouteNameFromError(err)
+    if (flowRoute) {
+      log.info('auth', 'Login code sent, advancing to confirm', { route: flowRoute })
+      toast.add({
+        title: t('success.title'),
+        description: t('success.description'),
+        color: 'success',
+        icon: 'i-heroicons-check-circle',
+      })
+      emit('requestLoginCode')
+      await navigateTo(localePath(flowRoute))
+      return
+    }
     hasError.value = true
     handleAllAuthClientError(err)
   }

--- a/app/components/Account/Login/Form.vue
+++ b/app/components/Account/Login/Form.vue
@@ -53,6 +53,19 @@ const onSubmit = async (event: FormSubmitEvent<Schema>) => {
     session.value = response?.data
   }
   catch (error) {
+    // A correct password on a 2FA-enabled account does not sign the user
+    // in outright — allauth replies 401 with `mfa_authenticate` pending,
+    // which `$fetch` throws. That is not a login failure: route to the
+    // second-factor challenge (carrying `next`) instead of leaving the
+    // form silent.
+    const flowRoute = pendingFlowRouteNameFromError(error)
+    if (flowRoute) {
+      const rawNext = router.currentRoute.value.query.next?.toString()
+      const safeNext = isSafeRelativePath(rawNext) ? rawNext : undefined
+      log.info('auth', 'Password accepted, advancing to pending flow', { route: flowRoute })
+      await navigateTo({ path: localePath(flowRoute), query: safeNext ? { next: safeNext } : undefined })
+      return
+    }
     handleAllAuthClientError(error)
   }
   finally {

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -216,6 +216,49 @@ export const pathForPendingFlow = (
   return pendingFlow ? pathForFlow(pendingFlow) : null
 }
 
+// The Nuxt allauth proxy re-throws Django's response via
+// `createError({ data })`, so a thrown `$fetch` error carries the allauth
+// payload (`{ status, data: { flows }, meta }`) at `error.data.data`. Pull
+// it back out so a caller can inspect the flow it represents.
+export function extractAllAuthError(
+  error: unknown,
+): AllAuthResponseError | null {
+  if (typeof error !== 'object' || error === null || !('data' in error)) {
+    return null
+  }
+  const outer = (error as { data?: unknown }).data
+  if (
+    typeof outer !== 'object' || outer === null
+    || !('data' in outer) || !('status' in outer)
+  ) {
+    return null
+  }
+  return outer as AllAuthResponseError
+}
+
+// A 401 carrying a *pending* flow is allauth's "advance to the next step"
+// signal — login-by-code: code sent → confirm; password OK but 2FA on →
+// mfa_authenticate — NOT a failure. But `$fetch` surfaces every 401 as a
+// throw, so form submit handlers must inspect the error themselves and
+// route to the pending flow. (The global `auth:change` hook attempts this
+// too, but navigating from deep inside the fetch-error interceptor is
+// unreliable; doing it from the form's own context is not.) Returns the
+// target route name for `useLocalePath`, or null when there is no
+// actionable pending flow (i.e. a genuine error the caller should surface).
+export function pendingFlowRouteNameFromError(error: unknown) {
+  const authData = extractAllAuthError(error)
+  if (!authData) return null
+  const pendingFlow = getPendingFlow(authData)
+  if (!pendingFlow) return null
+  try {
+    return pathForFlow(pendingFlow)
+  }
+  catch {
+    log.warn('auth', 'Pending flow has no known route', { flow: pendingFlow.id })
+    return null
+  }
+}
+
 const UNSAFE_PATH_PREFIXES = ['http://', 'https://', '//', 'data:', 'javascript:', 'vbscript:']
 
 export function isSafeRelativePath(value: string | undefined): boolean {

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -72,7 +72,17 @@ export async function handleAllAuthError(
   const event = useEvent()
 
   if (isAllAuthError(error)) {
-    log.info('auth', `handleAllAuthError: status ${error.data.status}`)
+    // Surface the pending flow (if any) so a 401 that is really allauth's
+    // "advance to next step" signal (login_by_code code sent, mfa pending)
+    // is distinguishable in logs from a genuine auth failure — both come
+    // through here as a 401.
+    const flows = (error.data as { data?: { flows?: Array<{ id: string, is_pending?: boolean }> } }).data?.flows
+    const pendingFlow = flows?.find(flow => flow.is_pending)
+    log.info(
+      'auth',
+      `handleAllAuthError: status ${error.data.status}`,
+      pendingFlow ? { pendingFlow: pendingFlow.id } : {},
+    )
 
     if (error.data.status === 410) {
       log.info('auth', 'Session expired (410), clearing user session')

--- a/test/unit/utils/auth.spec.ts
+++ b/test/unit/utils/auth.spec.ts
@@ -5,6 +5,8 @@ import {
   isAllAuthResponseError,
   getPendingFlows,
   getPendingFlow,
+  extractAllAuthError,
+  pendingFlowRouteNameFromError,
 } from '../../../app/utils/auth'
 
 const mockLog = {
@@ -17,6 +19,21 @@ describe('Utils - Auth', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal('log', mockLog)
+    // pathForFlow() relies on these auto-imported constants, which are not
+    // present in the bare unit env — stub them with their real values so
+    // the flow-routing helpers can be exercised (mirrors app/shared).
+    vi.stubGlobal('Flows', {
+      PROVIDER_REDIRECT: 'provider_redirect',
+      LOGIN_BY_CODE: 'login_by_code',
+      MFA_AUTHENTICATE: 'mfa_authenticate',
+    })
+    vi.stubGlobal('AUTHENTICATOR_TYPE_PRIORITY', ['webauthn', 'totp', 'recovery_codes'])
+    vi.stubGlobal('Flow2path', {
+      login_by_code: 'account-login-code-confirm',
+      'mfa_authenticate:webauthn': 'account-2fa-authenticate-webauthn',
+      'mfa_authenticate:totp': 'account-2fa-authenticate-totp',
+      'mfa_authenticate:recovery_codes': 'account-2fa-authenticate-recovery-codes',
+    })
   })
 
   describe('authInfo', () => {
@@ -243,6 +260,76 @@ describe('Utils - Auth', () => {
       const result = getPendingFlow(response)
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('extractAllAuthError', () => {
+    it('unwraps the allauth payload nested at error.data.data', () => {
+      const payload = {
+        status: 401,
+        data: { flows: [{ id: 'login_by_code', is_pending: true }] },
+        meta: { is_authenticated: false },
+      }
+      // Shape produced by the Nuxt proxy: createError({ data: payload })
+      // surfaces on the thrown $fetch error as error.data === payload.
+      const error = { data: payload }
+
+      expect(extractAllAuthError(error)).toEqual(payload)
+    })
+
+    it('returns null for a non-allauth error shape', () => {
+      expect(extractAllAuthError({ data: { message: 'boom' } })).toBeNull()
+      expect(extractAllAuthError(new Error('nope'))).toBeNull()
+      expect(extractAllAuthError(null)).toBeNull()
+    })
+  })
+
+  describe('pendingFlowRouteNameFromError', () => {
+    it('routes a login_by_code pending flow to the confirm page', () => {
+      const error = {
+        data: {
+          status: 401,
+          data: { flows: [{ id: 'login_by_code', is_pending: true }] },
+          meta: { is_authenticated: false },
+        },
+      }
+
+      expect(pendingFlowRouteNameFromError(error)).toBe('account-login-code-confirm')
+    })
+
+    it('routes a pending mfa_authenticate flow to the preferred second factor', () => {
+      const error = {
+        data: {
+          status: 401,
+          data: {
+            flows: [{
+              id: 'mfa_authenticate',
+              is_pending: true,
+              types: ['recovery_codes', 'webauthn'],
+            }],
+          },
+          meta: { is_authenticated: false },
+        },
+      }
+
+      // webauthn outranks recovery_codes in AUTHENTICATOR_TYPE_PRIORITY.
+      expect(pendingFlowRouteNameFromError(error)).toBe('account-2fa-authenticate-webauthn')
+    })
+
+    it('returns null when the 401 carries no pending flow (a genuine error)', () => {
+      const error = {
+        data: {
+          status: 401,
+          data: { flows: [{ id: 'login', is_pending: false }] },
+          meta: { is_authenticated: false },
+        },
+      }
+
+      expect(pendingFlowRouteNameFromError(error)).toBeNull()
+    })
+
+    it('returns null for a non-allauth error', () => {
+      expect(pendingFlowRouteNameFromError(new Error('network'))).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Symptoms (reported)
1. Logging in with a **2FA-enabled account** — clicking *Login* does nothing (no error, not logged in).
2. On **/account/login/code** — requesting a code shows *"Σφάλμα αποστολής / Δεν ήταν δυνατή η αποστολή του κωδικού"* (could not send the code).

## Root cause (validated against logs + allauth docs)
Both are **401-with-a-pending-flow**, which is allauth headless's normal *"advance to the next step"* signal — **not** a failure:
- Login with a correct password on a 2FA account → `401` + `mfa_authenticate` **is_pending** (password OK, now do the second factor).
- `POST /auth/code/request` → `401` + `login_by_code` **is_pending** — the code email **was sent** (the request took ~2.8s doing SMTP; `handleAllAuthError` even persists the flow's `session_token`).

Verified from production backend + Nuxt-proxy logs (the 401 bodies carry `is_pending` flows) and reproduced in-browser (the code page never advances). `$fetch` surfaces every 401 as a throw, and the two forms treated it as a hard error. The global `auth:change` hook is supposed to navigate on these but doesn't fire the navigation reliably from inside the fetch-error interceptor — the existing `ConfirmForm` already works around this by navigating **explicitly**.

## Fix
Advance to the pending flow from the form's own context (same pattern as `ConfirmForm`):
- `extractAllAuthError()` + `pendingFlowRouteNameFromError()` (app/utils/auth.ts) pull the pending flow out of the thrown error and map it to its route via the existing `pathForFlow`/`Flow2path`.
- **Login form** → routes to the second-factor page (carrying `next`).
- **Login-by-code form** → treats `login_by_code` pending as success: toast + advance to the confirm step.
- **server `handleAllAuthError`** logs the pending flow id, so a 401 that is really "code sent / 2FA required" is distinguishable from a genuine failure in kubectl logs.

The 2FA page's guard reads `useAuthInfo()`, which the hook still populates (it sets auth-state *before* the navigation that fails), so it passes once we land there. The confirm step already navigates explicitly.

## Tests / checks
- New unit tests for `extractAllAuthError` / `pendingFlowRouteNameFromError` (22 passing).
- `vue-tsc --noEmit` clean, eslint clean.

Post-deploy I'll verify both flows end-to-end in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login now correctly advances to verification when two-factor authentication is required.
  * Login code requests display a success message and navigate directly to the confirmation step.
  * Safe continuation links are preserved during multi-step authentication.

* **Bug Fixes**
  * Expected authentication-flow responses are no longer shown as generic login errors.

* **Tests**
  * Added coverage for pending authentication flows, MFA method selection, and invalid error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->