### PR TITLE
fix(auth): unwrap the allauth payload from the Nitro error wrapper

### DIFF
--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -216,24 +216,32 @@ export const pathForPendingFlow = (
   return pendingFlow ? pathForFlow(pendingFlow) : null
 }
 
-// The Nuxt allauth proxy re-throws Django's response via
-// `createError({ data })`, so a thrown `$fetch` error carries the allauth
-// payload (`{ status, data: { flows }, meta }`) at `error.data.data`. Pull
-// it back out so a caller can inspect the flow it represents.
+// The allauth payload is `{ status, data: { flows }, meta }`. The Nuxt proxy
+// re-throws Django's body via `createError({ data: payload })`, so the thrown
+// `$fetch` error exposes it at `error.data.data` — `error.data` is Nitro's
+// wrapper (`{ statusCode, statusMessage, data: payload }`), which carries
+// `statusCode`, NOT `status`. Pull the real payload out, tolerating a path
+// that exposes it directly at `error.data`.
+function isAllAuthPayload(value: unknown): value is AllAuthResponseError {
+  return typeof value === 'object' && value !== null
+    && 'status' in value && 'data' in value
+    && typeof (value as { data?: unknown }).data === 'object'
+}
+
 export function extractAllAuthError(
   error: unknown,
 ): AllAuthResponseError | null {
   if (typeof error !== 'object' || error === null || !('data' in error)) {
     return null
   }
-  const outer = (error as { data?: unknown }).data
-  if (
-    typeof outer !== 'object' || outer === null
-    || !('data' in outer) || !('status' in outer)
-  ) {
+  const wrapper = (error as { data?: unknown }).data
+  if (typeof wrapper !== 'object' || wrapper === null) {
     return null
   }
-  return outer as AllAuthResponseError
+  const nested = (wrapper as { data?: unknown }).data
+  if (isAllAuthPayload(nested)) return nested
+  if (isAllAuthPayload(wrapper)) return wrapper
+  return null
 }
 
 // A 401 carrying a *pending* flow is allauth's "advance to the next step"

--- a/test/unit/utils/auth.spec.ts
+++ b/test/unit/utils/auth.spec.ts
@@ -263,18 +263,32 @@ describe('Utils - Auth', () => {
     })
   })
 
+  // The thrown $fetch error's real shape: error.data is Nitro's error wrapper
+  // (`statusCode`, not `status`), and the allauth payload sits at
+  // error.data.data. Build it that way so the tests match production.
+  const wrapAllAuthError = (payload: unknown) => ({
+    data: { statusCode: 401, statusMessage: 'Unauthorized', data: payload },
+  })
+
   describe('extractAllAuthError', () => {
-    it('unwraps the allauth payload nested at error.data.data', () => {
+    it('unwraps the allauth payload from the Nitro error wrapper (error.data.data)', () => {
       const payload = {
         status: 401,
         data: { flows: [{ id: 'login_by_code', is_pending: true }] },
         meta: { is_authenticated: false },
       }
-      // Shape produced by the Nuxt proxy: createError({ data: payload })
-      // surfaces on the thrown $fetch error as error.data === payload.
-      const error = { data: payload }
 
-      expect(extractAllAuthError(error)).toEqual(payload)
+      expect(extractAllAuthError(wrapAllAuthError(payload))).toEqual(payload)
+    })
+
+    it('also accepts a payload exposed directly at error.data', () => {
+      const payload = {
+        status: 401,
+        data: { flows: [] },
+        meta: { is_authenticated: false },
+      }
+
+      expect(extractAllAuthError({ data: payload })).toEqual(payload)
     })
 
     it('returns null for a non-allauth error shape', () => {
@@ -286,44 +300,38 @@ describe('Utils - Auth', () => {
 
   describe('pendingFlowRouteNameFromError', () => {
     it('routes a login_by_code pending flow to the confirm page', () => {
-      const error = {
-        data: {
-          status: 401,
-          data: { flows: [{ id: 'login_by_code', is_pending: true }] },
-          meta: { is_authenticated: false },
-        },
-      }
+      const error = wrapAllAuthError({
+        status: 401,
+        data: { flows: [{ id: 'login_by_code', is_pending: true }] },
+        meta: { is_authenticated: false },
+      })
 
       expect(pendingFlowRouteNameFromError(error)).toBe('account-login-code-confirm')
     })
 
     it('routes a pending mfa_authenticate flow to the preferred second factor', () => {
-      const error = {
+      const error = wrapAllAuthError({
+        status: 401,
         data: {
-          status: 401,
-          data: {
-            flows: [{
-              id: 'mfa_authenticate',
-              is_pending: true,
-              types: ['recovery_codes', 'webauthn'],
-            }],
-          },
-          meta: { is_authenticated: false },
+          flows: [{
+            id: 'mfa_authenticate',
+            is_pending: true,
+            types: ['recovery_codes', 'webauthn'],
+          }],
         },
-      }
+        meta: { is_authenticated: false },
+      })
 
       // webauthn outranks recovery_codes in AUTHENTICATOR_TYPE_PRIORITY.
       expect(pendingFlowRouteNameFromError(error)).toBe('account-2fa-authenticate-webauthn')
     })
 
     it('returns null when the 401 carries no pending flow (a genuine error)', () => {
-      const error = {
-        data: {
-          status: 401,
-          data: { flows: [{ id: 'login', is_pending: false }] },
-          meta: { is_authenticated: false },
-        },
-      }
+      const error = wrapAllAuthError({
+        status: 401,
+        data: { flows: [{ id: 'login', is_pending: false }] },
+        meta: { is_authenticated: false },
+      })
 
       expect(pendingFlowRouteNameFromError(error)).toBeNull()
     })


### PR DESCRIPTION
Follow-up to #13. The pending-flow navigation shipped in v3.142.14 didn't fire because `extractAllAuthError` had the nesting wrong.

## Bug
The thrown `$fetch` error's `error.data` is **Nitro's error wrapper** — `{ statusCode, statusMessage, data: <allauth payload> }` — which has `statusCode`, not `status`. The allauth payload (`{ status, data: { flows }, meta }`) sits at **`error.data.data`** (exactly what the existing `handleAllAuthClientError` / `isRateLimitedClientError` read). My check `'status' in error.data` never matched → `pendingFlowRouteNameFromError` returned null → the forms still showed the error / did nothing.

Verified in-browser: after v3.142.14, the login-code page still didn't advance.

## Fix
Read `error.data.data` (with a fallback to `error.data` for a directly-exposed payload). Unit tests now construct the **real Nitro-wrapped shape** — the earlier tests passed only because they asserted against an unwrapped object.

`vue-tsc` + eslint clean, 23 auth unit tests pass. Will verify end-to-end in the browser after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)