### PR TITLE
fix(auth): forward allauth pending-flow payload to the client (Nitro strips createError data)

### DIFF
--- a/server/api/_allauth/app/v1/auth/code/request.post.ts
+++ b/server/api/_allauth/app/v1/auth/code/request.post.ts
@@ -13,6 +13,9 @@ export default defineEventHandler(async (event) => {
     return requestResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    // allauth signals "code emailed, now confirm it" as a 401 with a pending
+    // login_by_code flow. Forward that payload so the client can advance to
+    // the confirm step; genuine errors still throw.
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/login.post.ts
+++ b/server/api/_allauth/app/v1/auth/login.post.ts
@@ -15,6 +15,8 @@ export default defineEventHandler(async (event) => {
     return loginResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    // A pending-flow 401 (2FA required) is forwarded to the client so it can
+    // route to the second factor; genuine errors still throw.
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -1,6 +1,7 @@
 import { ZodError } from 'zod'
 import { FetchError } from 'ofetch'
 import { H3Error } from 'h3'
+import type { H3Event } from 'h3'
 
 export function isAllAuthError(error: unknown): error is AllAuthError {
   if (typeof error !== 'object' || error === null || !('data' in error)) {
@@ -66,53 +67,87 @@ export function handleError(
   })
 }
 
+function pendingFlowOf(error: AllAuthError) {
+  const flows = (error.data as { data?: { flows?: Array<{ id: string, is_pending?: boolean }> } }).data?.flows
+  return flows?.find(flow => flow.is_pending)
+}
+
+// Reconcile the encrypted user session from an allauth error response
+// (persist the flow's session/access token, or clear on expiry) and strip the
+// internal forwarding headers. Shared by the throw path (handleAllAuthError)
+// and the forward path (forwardAllAuthFlow).
+async function syncAllAuthSessionFromError(error: unknown, event: H3Event) {
+  if (!isAllAuthError(error)) {
+    log.error({ action: 'auth:unexpected', error })
+    return
+  }
+
+  const pendingFlow = pendingFlowOf(error)
+  // Distinguish a 401 that is really allauth's "advance to next step" signal
+  // (login_by_code code sent, mfa pending) from a genuine auth failure.
+  log.info(
+    'auth',
+    `allauth response: status ${error.data.status}`,
+    pendingFlow ? { pendingFlow: pendingFlow.id } : {},
+  )
+
+  if (error.data.status === 410) {
+    log.info('auth', 'Session expired (410), clearing user session')
+    await clearUserSession(event)
+  }
+  else if (isNotAuthenticatedResponseError(error) || isInvalidSessionResponseError(error)) {
+    const hasTokens = error.data.meta?.session_token || error.data.meta?.access_token
+    if (hasTokens) {
+      const existingSession = await getUserSession(event)
+      await replaceUserSession(event, {
+        ...existingSession,
+        secure: {
+          sessionToken: error.data.meta?.session_token ?? existingSession.secure?.sessionToken,
+          accessToken: error.data.meta?.access_token ?? existingSession.secure?.accessToken,
+        },
+      })
+    }
+    else if (!error.data.meta?.is_authenticated) {
+      log.info('auth', 'No tokens in error response, clearing user session')
+      await clearUserSession(event)
+    }
+  }
+
+  clearResponseHeaders(event, ['X-Session-Token', 'Authorization'])
+}
+
 export async function handleAllAuthError(
   error: unknown,
 ) {
   const event = useEvent()
-
-  if (isAllAuthError(error)) {
-    // Surface the pending flow (if any) so a 401 that is really allauth's
-    // "advance to next step" signal (login_by_code code sent, mfa pending)
-    // is distinguishable in logs from a genuine auth failure — both come
-    // through here as a 401.
-    const flows = (error.data as { data?: { flows?: Array<{ id: string, is_pending?: boolean }> } }).data?.flows
-    const pendingFlow = flows?.find(flow => flow.is_pending)
-    log.info(
-      'auth',
-      `handleAllAuthError: status ${error.data.status}`,
-      pendingFlow ? { pendingFlow: pendingFlow.id } : {},
-    )
-
-    if (error.data.status === 410) {
-      log.info('auth', 'Session expired (410), clearing user session')
-      await clearUserSession(event)
-    }
-    else if (isNotAuthenticatedResponseError(error) || isInvalidSessionResponseError(error)) {
-      log.info('auth', 'Not authenticated or invalid session, updating tokens')
-
-      const hasTokens = error.data.meta?.session_token || error.data.meta?.access_token
-      if (hasTokens) {
-        const existingSession = await getUserSession(event)
-        await replaceUserSession(event, {
-          ...existingSession,
-          secure: {
-            sessionToken: error.data.meta?.session_token ?? existingSession.secure?.sessionToken,
-            accessToken: error.data.meta?.access_token ?? existingSession.secure?.accessToken,
-          },
-        })
-      }
-      else if (!error.data.meta?.is_authenticated) {
-        log.info('auth', 'No tokens in error response, clearing user session')
-        await clearUserSession(event)
-      }
-    }
-
-    clearResponseHeaders(event, ['X-Session-Token', 'Authorization'])
-  }
-  else {
-    log.error({ action: 'auth:unexpected', error })
-  }
-
+  await syncAllAuthSessionFromError(error, event)
   handleError(error)
+}
+
+// allauth headless replies to a login on a 2FA account, or a login-by-code
+// request, with HTTP 401 carrying a *pending* flow — its normal "advance to
+// the next step" signal, not a failure. The flow payload lives in
+// `createError`'s `data`, but Nitro strips that from thrown-error responses,
+// so the client never sees the flow and cannot route to it. For a pending-flow
+// 4xx we therefore RETURN the payload (returned bodies are not stripped),
+// mirroring the wrapper shape the client reads (`error.data.data === payload`).
+// Genuine errors (no pending flow, or 5xx) still throw via handleAllAuthError.
+// Return type is `undefined` on purpose: the client only ever receives this
+// body via a thrown $fetch error (the response status is 4xx, so `$fetch`
+// rejects) — never as a resolved value — so keeping it out of the handler's
+// success type avoids polluting the typed `login()`/`requestLoginCode()`
+// return. The object is still emitted at runtime for Nitro to serialize.
+export async function forwardAllAuthFlow(error: unknown): Promise<undefined> {
+  const event = useEvent()
+  if (isAllAuthError(error)) {
+    const status = error.data.status
+    const pendingFlow = pendingFlowOf(error)
+    if (pendingFlow && typeof status === 'number' && status < 500) {
+      await syncAllAuthSessionFromError(error, event)
+      setResponseStatus(event, status)
+      return { statusCode: status, statusMessage: 'Unauthorized', data: error.data } as unknown as undefined
+    }
+  }
+  await handleAllAuthError(error)
+  return undefined
 }


### PR DESCRIPTION
Follow-up to #13/#14. Those shipped client-side navigation, but it never fired because **the client literally never receives the flow data**.

## Root cause (validated against the live endpoint)
allauth replies to a login on a 2FA account, or a login-by-code request, with **HTTP 401 carrying a pending flow** — its normal "advance to next step" signal (confirmed via allauth docs). That flow payload is passed through `createError({ data: payload })`, but **Nitro does not serialize a thrown error's `data` to the client in production**. A direct probe of `/api/_allauth/app/v1/auth/code/request` returns:
```json
{"url":"...","statusCode":401,"statusMessage":"Unauthorized","message":"Unauthorized","error":true}
```
— **no `data`**. So the client couldn't see the flow, the `auth:change` hook never fired (it reads the absent `response._data.data`), and the forms fell to their error paths. The existing `handleAllAuthClientError`/`isRateLimitedClientError` read the same missing `error.data.data` — these error-flows never worked.

## Fix
Server-side: for a **pending-flow 4xx**, *return* the payload (returned bodies are not stripped) instead of throwing — mirroring the wrapper shape the client already reads (`error.data.data === payload`). Genuine errors still throw.
- `forwardAllAuthFlow()` in `server/utils/error.ts`; session-token persistence refactored into a shared `syncAllAuthSessionFromError` so the confirm/2FA step still finds the flow's `session_token`.
- `login` + `code/request` routes opt in.
- Typed `Promise<undefined>` so the forward body stays out of the typed `login()`/`requestLoginCode()` success return (the client only sees it via a thrown 401) — avoids a SerializeObject type cascade — while still emitting the body at runtime.

The client-side pending-flow navigation from #13/#14 now has data to act on. `vue-tsc` + eslint clean, 23 auth unit tests pass. Verifying end-to-end in the browser after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login handling when two-factor authentication is required, allowing users to continue directly to the verification step.
  * Improved login-by-code handling so users can proceed to confirm codes after they are emailed.
  * Improved session recovery and expiration handling for authentication errors.
  * Preserved standard error behavior for invalid or unexpected authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->