### PR TITLE
fix(auth): advance every allauth flow on a pending-flow 401 (login-by-code → 2FA, etc.)

### DIFF
--- a/app/components/Account/2Fa/AuthenticateCode.vue
+++ b/app/components/Account/2Fa/AuthenticateCode.vue
@@ -66,6 +66,10 @@ async function onSubmit(event: FormSubmitEvent<Schema>): Promise<void> {
     emit('twoFaAuthenticate')
   }
   catch (error) {
+    // Advance if 2FA leads to a further pending step; a wrong code keeps the
+    // same mfa_authenticate flow pending (same route), so the guard in
+    // tryAdvanceToPendingFlow returns false and the error is shown.
+    if (await tryAdvanceToPendingFlow(error)) return
     showError.value = true
     handleAllAuthClientError(error)
   }

--- a/app/components/Account/Login/Code/ConfirmForm.vue
+++ b/app/components/Account/Login/Code/ConfirmForm.vue
@@ -41,6 +41,10 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
     await router.push(localePath('index'))
   }
   catch (err) {
+    // A valid code on a 2FA-enabled account doesn't finish login — allauth
+    // consumes login_by_code and replies 401 with mfa_authenticate pending.
+    // That is not an invalid code: advance to the second-factor challenge.
+    if (await tryAdvanceToPendingFlow(err)) return
     hasError.value = true
     handleAllAuthClientError(err)
   }

--- a/app/components/Account/Login/Code/Form.vue
+++ b/app/components/Account/Login/Code/Form.vue
@@ -48,13 +48,11 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
     emit('requestLoginCode')
   }
   catch (err) {
-    // allauth accepts the request and emails the code, then signals the
-    // next step as a 401 with `login_by_code` pending — which `$fetch`
-    // throws. That is success, not failure: advance to the confirm step
-    // instead of surfacing a false "could not send the code".
-    const flowRoute = pendingFlowRouteNameFromError(err)
-    if (flowRoute) {
-      log.info('auth', 'Login code sent, advancing to confirm', { route: flowRoute })
+    // allauth accepts the request and emails the code, then signals the next
+    // step as a 401 with `login_by_code` pending — which `$fetch` throws. That
+    // is success, not failure: advance to the confirm step instead of
+    // surfacing a false "could not send the code".
+    if (await tryAdvanceToPendingFlow(err)) {
       toast.add({
         title: t('success.title'),
         description: t('success.description'),
@@ -62,7 +60,6 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
         icon: 'i-heroicons-check-circle',
       })
       emit('requestLoginCode')
-      await navigateTo(localePath(flowRoute))
       return
     }
     hasError.value = true

--- a/app/components/Account/Login/Form.vue
+++ b/app/components/Account/Login/Form.vue
@@ -53,19 +53,11 @@ const onSubmit = async (event: FormSubmitEvent<Schema>) => {
     session.value = response?.data
   }
   catch (error) {
-    // A correct password on a 2FA-enabled account does not sign the user
-    // in outright — allauth replies 401 with `mfa_authenticate` pending,
-    // which `$fetch` throws. That is not a login failure: route to the
-    // second-factor challenge (carrying `next`) instead of leaving the
-    // form silent.
-    const flowRoute = pendingFlowRouteNameFromError(error)
-    if (flowRoute) {
-      const rawNext = router.currentRoute.value.query.next?.toString()
-      const safeNext = isSafeRelativePath(rawNext) ? rawNext : undefined
-      log.info('auth', 'Password accepted, advancing to pending flow', { route: flowRoute })
-      await navigateTo({ path: localePath(flowRoute), query: safeNext ? { next: safeNext } : undefined })
-      return
-    }
+    // A correct password on a 2FA-enabled account does not sign the user in
+    // outright — allauth replies 401 with `mfa_authenticate` pending. That is
+    // not a login failure: route to the second-factor challenge instead of
+    // leaving the form silent.
+    if (await tryAdvanceToPendingFlow(error)) return
     handleAllAuthClientError(error)
   }
   finally {

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -267,6 +267,27 @@ export function pendingFlowRouteNameFromError(error: unknown) {
   }
 }
 
+// A pending-flow 4xx from allauth means "advance to the next step" (2FA after a
+// correct password or code, confirm after a code request) — not a failure.
+// Route there from the caller's own context and report whether we did, so a
+// form can suppress its error message and let the flow continue. Does NOT
+// navigate when the pending flow maps to the page we are already on — that's a
+// retry/error on the *same* step (e.g. a wrong 2FA code), which the caller must
+// still surface as an error.
+export async function tryAdvanceToPendingFlow(error: unknown): Promise<boolean> {
+  const routeName = pendingFlowRouteNameFromError(error)
+  if (!routeName) return false
+  const localePath = useLocalePath()
+  const router = useRouter()
+  const target = localePath(routeName)
+  if (router.currentRoute.value.path === target) return false
+  const rawNext = router.currentRoute.value.query.next?.toString()
+  const safeNext = isSafeRelativePath(rawNext) ? rawNext : undefined
+  log.info('auth', 'Advancing to pending flow', { route: routeName })
+  await navigateTo({ path: target, query: safeNext ? { next: safeNext } : undefined })
+  return true
+}
+
 const UNSAFE_PATH_PREFIXES = ['http://', 'https://', '//', 'data:', 'javascript:', 'vbscript:']
 
 export function isSafeRelativePath(value: string | undefined): boolean {

--- a/server/api/_allauth/app/v1/auth/2fa/authenticate.post.ts
+++ b/server/api/_allauth/app/v1/auth/2fa/authenticate.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return authenticateResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/2fa/reauthenticate.post.ts
+++ b/server/api/_allauth/app/v1/auth/2fa/reauthenticate.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return reauthenticateResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/code/confirm.post.ts
+++ b/server/api/_allauth/app/v1/auth/code/confirm.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return confirmResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/email/verify.post.ts
+++ b/server/api/_allauth/app/v1/auth/email/verify.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return verifyEmailResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/password/request.post.ts
+++ b/server/api/_allauth/app/v1/auth/password/request.post.ts
@@ -11,6 +11,6 @@ export default defineEventHandler(async (event) => {
     return await parseDataAs(response, ZodPasswordRequestResponse)
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/password/reset.post.ts
+++ b/server/api/_allauth/app/v1/auth/password/reset.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return passwordResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/provider/signup.post.ts
+++ b/server/api/_allauth/app/v1/auth/provider/signup.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/provider/token.post.ts
+++ b/server/api/_allauth/app/v1/auth/provider/token.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return tokenResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/reauthenticate.post.ts
+++ b/server/api/_allauth/app/v1/auth/reauthenticate.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return reauthenticateResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/signup.post.ts
+++ b/server/api/_allauth/app/v1/auth/signup.post.ts
@@ -15,6 +15,6 @@ export default defineEventHandler(async (event) => {
     return signupResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/webauthn/authenticate.post.ts
+++ b/server/api/_allauth/app/v1/auth/webauthn/authenticate.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/webauthn/login.post.ts
+++ b/server/api/_allauth/app/v1/auth/webauthn/login.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/webauthn/reauthenticate.post.ts
+++ b/server/api/_allauth/app/v1/auth/webauthn/reauthenticate.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/webauthn/signup.post.ts
+++ b/server/api/_allauth/app/v1/auth/webauthn/signup.post.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/server/api/_allauth/app/v1/auth/webauthn/signup.put.ts
+++ b/server/api/_allauth/app/v1/auth/webauthn/signup.put.ts
@@ -13,6 +13,6 @@ export default defineEventHandler(async (event) => {
     return providerResponse
   }
   catch (error) {
-    await handleAllAuthError(error)
+    return await forwardAllAuthFlow(error)
   }
 })

--- a/test/unit/utils/auth.spec.ts
+++ b/test/unit/utils/auth.spec.ts
@@ -7,6 +7,7 @@ import {
   getPendingFlow,
   extractAllAuthError,
   pendingFlowRouteNameFromError,
+  tryAdvanceToPendingFlow,
 } from '../../../app/utils/auth'
 
 const mockLog = {
@@ -338,6 +339,56 @@ describe('Utils - Auth', () => {
 
     it('returns null for a non-allauth error', () => {
       expect(pendingFlowRouteNameFromError(new Error('network'))).toBeNull()
+    })
+  })
+
+  describe('tryAdvanceToPendingFlow', () => {
+    let navigateToMock: ReturnType<typeof vi.fn>
+
+    const stubRoute = (path: string) => {
+      vi.stubGlobal('useRouter', () => ({
+        currentRoute: { value: { path, query: {} } },
+      }))
+    }
+
+    beforeEach(() => {
+      navigateToMock = vi.fn()
+      vi.stubGlobal('navigateTo', navigateToMock)
+      // Identity-ish localePath: route name -> "/<name>".
+      vi.stubGlobal('useLocalePath', () => (name: string) => `/${name}`)
+    })
+
+    it('advances to a pending flow on a different route', async () => {
+      stubRoute('/account-login-code')
+      const error = wrapAllAuthError({
+        status: 401,
+        data: { flows: [{ id: 'login_by_code', is_pending: true }] },
+        meta: { is_authenticated: false },
+      })
+
+      expect(await tryAdvanceToPendingFlow(error)).toBe(true)
+      expect(navigateToMock).toHaveBeenCalledWith({
+        path: '/account-login-code-confirm',
+        query: undefined,
+      })
+    })
+
+    it('does NOT advance when the pending flow is the current route (wrong-code retry)', async () => {
+      stubRoute('/account-2fa-authenticate-webauthn')
+      const error = wrapAllAuthError({
+        status: 401,
+        data: { flows: [{ id: 'mfa_authenticate', is_pending: true, types: ['webauthn'] }] },
+        meta: { is_authenticated: false },
+      })
+
+      expect(await tryAdvanceToPendingFlow(error)).toBe(false)
+      expect(navigateToMock).not.toHaveBeenCalled()
+    })
+
+    it('does not advance for a non-flow error', async () => {
+      stubRoute('/whatever')
+      expect(await tryAdvanceToPendingFlow(new Error('boom'))).toBe(false)
+      expect(navigateToMock).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Follow-up to #15. Covers (a) the remaining allauth flows and (b) the reported login-by-code confirm failure.

## Reported bug
Login-by-code with a valid code showed **"Μη έγκυρος κωδικός"** (invalid/expired code). The logs show the code was actually **valid**: on a 2FA-enabled account, allauth consumes `login_by_code` and replies **401 with `mfa_authenticate` pending** (then **409 Conflict** on the auto-retry, the flow already spent). The `ConfirmForm` treated that pending-flow 401 as an invalid code instead of advancing to the second factor — the same root cause as #13/#15.

## Fix
**Server** — apply `forwardAllAuthFlow` (from #15) to every flow-submission auth route (2FA authenticate/reauthenticate, `code/confirm`, `email/verify`, `password` request/reset, `provider` signup/token, `reauthenticate`, `signup`, all `webauthn` submits). It's a safe superset of `handleAllAuthError`: forwards a pending-flow 4xx to the client, throws everything else identically. GET/session/account-management routes are left as-is to avoid unexpected navigation on state reads.

**Client** — `tryAdvanceToPendingFlow()` routes to the pending flow from the form's own context, **guarded** so it does not navigate when the flow maps to the page you're already on (a wrong 2FA code keeps `mfa_authenticate` pending on the same route — that must stay an error, not a nav loop). Applied to the login, login-by-code, **code-confirm**, and 2FA-code forms; the login/code forms are refactored onto the shared helper.

## Tests / checks
- 3 new unit tests for `tryAdvanceToPendingFlow` (advance / same-route-guard / non-flow) — 26 auth unit tests pass.
- `vue-tsc` + eslint clean. The `Promise<undefined>` typing keeps the forward body out of each route's success type (no SerializeObject cascade).

Please retry login-by-code on your 2FA account — the valid code should now take you to the 2FA challenge instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)