### PR TITLE
fix(auth): keep stored session token when allauth omits it from an error response

### DIFF
--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -107,9 +107,17 @@ async function syncAllAuthSessionFromError(error: unknown, event: H3Event) {
         },
       })
     }
-    else if (!error.data.meta?.is_authenticated) {
-      log.info('auth', 'No tokens in error response, clearing user session')
-      await clearUserSession(event)
+    // No tokens in meta means KEEP the stored token, never clear: allauth's
+    // expose_session_token only emits meta.session_token when the Django
+    // session was modified AND the token CHANGED — an absent token on an
+    // app-client response means "keep using the one you sent". Clearing here
+    // wiped the pending-flow session mid-2FA (valid login code → 401
+    // mfa_authenticate pending WITHOUT a token change → cookie cleared →
+    // the WebAuthn options call went out anonymous and instantly 401'd).
+    // Session teardown has exactly two owners: the 410 branch above, and
+    // session.delete.ts's own finally block on explicit logout.
+    else {
+      log.info('auth', 'No token change in allauth response, keeping stored session token')
     }
   }
 


### PR DESCRIPTION
## Bug (reported: passkey 2FA fails instantly after a valid login code)
Backend logs show the exact chain: `Auth: step completed` (code valid) → 401 `mfa_authenticate` pending → **two 401s on `webauthn/authenticate` whose flows show an anonymous session** → the toast "Σφάλμα ταυτοποίησης".

## Root cause (validated against allauth source + reproduced on prod)
`allauth.headless.internal.sessionkit.expose_session_token` only includes `meta.session_token` when the Django session was modified **and the token changed** — absent means *"keep the token you sent"*. Our `syncAllAuthSessionFromError` treated absent-token + `is_authenticated: false` as "clear the user session". A valid code consumes `login_by_code` and returns 401 mfa-pending **without** a token change → we wiped the pending session cookie → the WebAuthn options GET went out anonymous → instant 401.

**Prod reproduction:** `code/request` (pending established) → `GET /session` twice → the pending flow vanishes after the first GET (session wiped by its own 401 handling). Also visible in logs as `No tokens in error response, clearing user session` immediately before each anonymous 401.

## Fix
Absent token → keep the stored one (log it). Session teardown now has exactly two owners:
- the 410 branch (server-declared expiry),
- `session.delete.ts`'s own `finally` (explicit logout — verified independent of this path).

## Validation
eslint + vue-tsc clean, 27 auth unit tests pass. Post-deploy I'll rerun the prod reproduction (expect the pending flow to survive both session GETs) and the full login-code → passkey path is ready for manual retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved active session tokens when authentication error responses do not include updated token information.
  * Continued clearing sessions for expired credentials and other applicable invalidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->