### PR TITLE
feat(search): click attribution and relaxed-query disclosure

### DIFF
--- a/app/components/Search/Modal.vue
+++ b/app/components/Search/Modal.vue
@@ -100,6 +100,28 @@ const totalResults = computed(() => {
   return productsTotal + blogPostsTotal
 })
 
+const relaxedQuery = computed(
+  () =>
+    searchResults.value?.products?.relaxedQuery
+    || searchResults.value?.blogPosts?.relaxedQuery
+    || null,
+)
+
+const { trackResultClick } = useSearchClickTracking()
+
+function onResultClick(result: SearchResult, position: number) {
+  trackResultClick({
+    queryId:
+      result.contentType === 'product'
+        ? searchResults.value?.products?.queryId
+        : searchResults.value?.blogPosts?.queryId,
+    resultId: result.master,
+    resultType: result.contentType === 'product' ? 'product' : 'blog_post',
+    position,
+  })
+  close()
+}
+
 function close() {
   localOpen.value = false
   activeResultIndex.value = -1
@@ -391,25 +413,37 @@ if (localQuery.value && localQuery.value.length >= 2) {
           </p>
         </div>
 
-        <div
-          v-else
-          id="search-results-listbox"
-          role="listbox"
-          :aria-label="t('search.title')"
-          class="
-            grid gap-2 divide-y divide-gray-100 px-1 pt-2
-            dark:divide-gray-800
-          "
-        >
-          <SearchResult
-            v-for="(result, index) in filteredResults"
-            :id="`search-result-${index}`"
-            :key="`${result.contentType}-${result.id}`"
-            role="option"
-            :aria-selected="index === activeResultIndex"
-            :result="result"
-            @click="close"
-          />
+        <div v-else>
+          <p
+            v-if="relaxedQuery"
+            class="flex items-center gap-1.5 px-4 pt-2 text-xs text-gray-500"
+            role="status"
+          >
+            <UIcon
+              name="i-heroicons-information-circle"
+              class="size-3.5 shrink-0"
+            />
+            {{ t('search.relaxed_notice', { query: relaxedQuery }) }}
+          </p>
+          <div
+            id="search-results-listbox"
+            role="listbox"
+            :aria-label="t('search.title')"
+            class="
+              grid gap-2 divide-y divide-gray-100 px-1 pt-2
+              dark:divide-gray-800
+            "
+          >
+            <SearchResult
+              v-for="(result, index) in filteredResults"
+              :id="`search-result-${index}`"
+              :key="`${result.contentType}-${result.id}`"
+              role="option"
+              :aria-selected="index === activeResultIndex"
+              :result="result"
+              @click="onResultClick(result, index)"
+            />
+          </div>
         </div>
       </div>
     </template>
@@ -457,6 +491,7 @@ el:
     trending: Δημοφιλείς αναζητήσεις
     clear: Εκκαθάριση
     no_results: Δεν βρέθηκαν αποτελέσματα
+    relaxed_notice: Εμφανίζονται αποτελέσματα για "{query}"
     try_different: Δοκίμασς διαφορετικούς όρους αναζήτησης
     load_more: Φόρτωση περισσότερων
     navigate: Πλοήγηση

--- a/app/composables/useSearchClickTracking.ts
+++ b/app/composables/useSearchClickTracking.ts
@@ -1,0 +1,32 @@
+interface SearchResultClick {
+  queryId?: string | null
+  resultId: number | string
+  resultType: 'product' | 'blog_post'
+  position: number
+}
+
+/**
+ * Fire-and-forget attribution of a search-result click to the query
+ * that produced it. Feeds the backend's click-through ranking signal
+ * and search analytics.
+ *
+ * `keepalive: true` lets the request survive the navigation the click
+ * triggers; failures are swallowed — tracking must never affect UX.
+ */
+export function useSearchClickTracking() {
+  const trackResultClick = (click: SearchResultClick) => {
+    if (!import.meta.client || !click.queryId) return
+    $fetch('/api/search/click', {
+      method: 'POST',
+      body: {
+        queryId: click.queryId,
+        resultId: String(click.resultId),
+        resultType: click.resultType,
+        position: click.position,
+      },
+      keepalive: true,
+    }).catch(() => {})
+  }
+
+  return { trackResultClick }
+}

--- a/app/pages/search/index.vue
+++ b/app/pages/search/index.vue
@@ -57,6 +57,27 @@ const totalResults = computed(() => {
 
 const totalPages = computed(() => Math.ceil(totalResults.value / limit.value))
 
+const relaxedQuery = computed(
+  () =>
+    searchResults.value?.products?.relaxedQuery
+    || searchResults.value?.blogPosts?.relaxedQuery
+    || null,
+)
+
+const { trackResultClick } = useSearchClickTracking()
+
+function onResultClick(result: SearchResult, index: number) {
+  trackResultClick({
+    queryId:
+      result.contentType === 'product'
+        ? searchResults.value?.products?.queryId
+        : searchResults.value?.blogPosts?.queryId,
+    resultId: result.master,
+    resultType: result.contentType === 'product' ? 'product' : 'blog_post',
+    position: offset.value + index,
+  })
+}
+
 const tabItems = computed(() => {
   const productsCount = searchResults.value?.products?.estimatedTotalHits || 0
   const blogPostsCount = searchResults.value?.blogPosts?.estimatedTotalHits || 0
@@ -231,6 +252,13 @@ useHead({
                 })
               }}
             </span>
+            <span
+              v-if="relaxedQuery"
+              class="text-warning"
+              role="status"
+            >
+              {{ t('page.relaxed_notice', { query: relaxedQuery }) }}
+            </span>
           </div>
 
           <div class="flex items-center gap-4">
@@ -385,7 +413,7 @@ useHead({
       >
         <div class="space-y-4">
           <UCard
-            v-for="result in displayResults"
+            v-for="(result, index) in displayResults"
             :key="`${result.contentType}-${result.id}`"
             class="
               cursor-pointer overflow-hidden transition-all
@@ -400,7 +428,10 @@ useHead({
               `,
             }"
           >
-            <SearchResult :result="result" />
+            <SearchResult
+              :result="result"
+              @click="onResultClick(result, index)"
+            />
           </UCard>
         </div>
 
@@ -448,6 +479,7 @@ el:
     search_query: "Αναζήτηση {query}"
     search_placeholder: "Πληκτρολογήστε για αναζήτηση..."
     results_count: "{count} αποτελέσματα για \"{query}\""
+    relaxed_notice: "— εμφανίζονται αποτελέσματα για \"{query}\""
     per_page: "Ανά σελίδα"
     federated_search: "Ενοποιημένη Αναζήτηση"
     federated_search_tooltip: "Δοκιμάστε ενοποιημένη αναζήτηση με σταθμισμένη κατάταξη"

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -103,8 +103,8 @@
         "/api/v1/blog/author": {
             "get": {
                 "operationId": "listBlogAuthor",
-                "description": "Ανάκτηση λίστας Συντάκτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Συντάκτες Blog",
+                "description": "Retrieve a list of Blog Authors with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Blog Authors",
                 "parameters": [
                     {
                         "in": "query",
@@ -112,7 +112,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -126,7 +126,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -169,7 +169,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -182,7 +182,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -196,7 +196,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -282,8 +282,8 @@
             },
             "post": {
                 "operationId": "createBlogAuthor",
-                "description": "Δημιουργία νέου Συντάκτης Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Συντάκτης Blog",
+                "description": "Create a new Blog Author. Requires authentication.",
+                "summary": "Create a Blog Author",
                 "parameters": [
                     {
                         "in": "query",
@@ -297,7 +297,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -395,8 +395,8 @@
         "/api/v1/blog/author/{id}": {
             "get": {
                 "operationId": "retrieveBlogAuthor",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συντάκτης Blog.",
-                "summary": "Ανάκτηση Συντάκτης Blog",
+                "description": "Get detailed information about a specific Blog Author.",
+                "summary": "Retrieve a Blog Author",
                 "parameters": [
                     {
                         "in": "path",
@@ -426,7 +426,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -493,8 +493,8 @@
             },
             "put": {
                 "operationId": "updateBlogAuthor",
-                "description": "Ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Συντάκτης Blog",
+                "description": "Update Blog Author information. Requires authentication.",
+                "summary": "Update a Blog Author",
                 "parameters": [
                     {
                         "in": "path",
@@ -524,7 +524,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -620,8 +620,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateBlogAuthor",
-                "description": "Μερική ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Συντάκτης Blog",
+                "description": "Partially update Blog Author information. Requires authentication.",
+                "summary": "Partially update a Blog Author",
                 "parameters": [
                     {
                         "in": "path",
@@ -651,7 +651,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -746,8 +746,8 @@
             },
             "delete": {
                 "operationId": "destroyBlogAuthor",
-                "description": "Διαγραφή Συντάκτης Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Συντάκτης Blog",
+                "description": "Delete a Blog Author. Requires authentication.",
+                "summary": "Delete a Blog Author",
                 "parameters": [
                     {
                         "in": "path",
@@ -814,8 +814,8 @@
         "/api/v1/blog/author/{id}/posts": {
             "get": {
                 "operationId": "getBlogAuthorPosts",
-                "description": "Ανάκτηση όλων των άρθρων που έχει γράψει αυτός ο συντάκτης, με σελιδοποίηση.",
-                "summary": "Λήψη άρθρων συντάκτη",
+                "description": "Retrieve all blog posts written by this author with proper pagination.",
+                "summary": "Get author's blog posts",
                 "parameters": [
                     {
                         "in": "path",
@@ -963,8 +963,8 @@
         "/api/v1/blog/category": {
             "get": {
                 "operationId": "listBlogCategory",
-                "description": "Ανάκτηση λίστας Κατηγορίες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Κατηγορίες Blog",
+                "description": "Retrieve a list of Blog Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Blog Categories",
                 "parameters": [
                     {
                         "in": "query",
@@ -978,7 +978,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -1021,7 +1021,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -1034,7 +1034,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -1048,7 +1048,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -1134,8 +1134,8 @@
             },
             "post": {
                 "operationId": "createBlogCategory",
-                "description": "Δημιουργία νέου Κατηγορία Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Κατηγορία Blog",
+                "description": "Create a new Blog Category. Requires authentication.",
+                "summary": "Create a Blog Category",
                 "parameters": [
                     {
                         "in": "query",
@@ -1149,7 +1149,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -1247,8 +1247,8 @@
         "/api/v1/blog/category/{id}": {
             "get": {
                 "operationId": "retrieveBlogCategory",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Blog.",
-                "summary": "Ανάκτηση Κατηγορία Blog",
+                "description": "Get detailed information about a specific Blog Category.",
+                "summary": "Retrieve a Blog Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -1278,7 +1278,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -1345,8 +1345,8 @@
             },
             "put": {
                 "operationId": "updateBlogCategory",
-                "description": "Ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Κατηγορία Blog",
+                "description": "Update Blog Category information. Requires authentication.",
+                "summary": "Update a Blog Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -1376,7 +1376,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -1472,8 +1472,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateBlogCategory",
-                "description": "Μερική ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Κατηγορία Blog",
+                "description": "Partially update Blog Category information. Requires authentication.",
+                "summary": "Partially update a Blog Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -1503,7 +1503,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -1598,8 +1598,8 @@
             },
             "delete": {
                 "operationId": "destroyBlogCategory",
-                "description": "Διαγραφή Κατηγορία Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Κατηγορία Blog",
+                "description": "Delete a Blog Category. Requires authentication.",
+                "summary": "Delete a Blog Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -1666,8 +1666,8 @@
         "/api/v1/blog/category/{id}/ancestors": {
             "get": {
                 "operationId": "listBlogCategoryAncestors",
-                "description": "Λήψη όλων των προγόνων (γονέας, παππούς κ.λπ.) αυτής της κατηγορίας.",
-                "summary": "Λήψη προγόνων κατηγορίας",
+                "description": "Get all ancestors (parent, grandparent, etc.) of this category.",
+                "summary": "Get category ancestors",
                 "parameters": [
                     {
                         "in": "path",
@@ -1815,8 +1815,8 @@
         "/api/v1/blog/category/{id}/children": {
             "get": {
                 "operationId": "listBlogCategoryChildren",
-                "description": "Λήψη άμεσων θυγατρικών κατηγοριών αυτής της κατηγορίας.",
-                "summary": "Λήψη θυγατρικών κατηγοριών",
+                "description": "Get direct children of this category.",
+                "summary": "Get category children",
                 "parameters": [
                     {
                         "in": "path",
@@ -1964,8 +1964,8 @@
         "/api/v1/blog/category/{id}/descendants": {
             "get": {
                 "operationId": "listBlogCategoryDescendants",
-                "description": "Λήψη όλων των απογόνων (θυγατρικές, εγγόνια κ.λπ.) αυτής της κατηγορίας.",
-                "summary": "Λήψη απογόνων κατηγορίας",
+                "description": "Get all descendants (children, grandchildren, etc.) of this category.",
+                "summary": "Get category descendants",
                 "parameters": [
                     {
                         "in": "path",
@@ -2113,8 +2113,8 @@
         "/api/v1/blog/category/{id}/posts": {
             "get": {
                 "operationId": "listBlogCategoryPosts",
-                "description": "Ανάκτηση όλων των άρθρων σε αυτή την κατηγορία και τις υποκατηγορίες της. Χρησιμοποιήστε 'recursive=true' για να συμπεριληφθούν άρθρα από όλες τις κατηγορίες-απογόνους.",
-                "summary": "Λήψη άρθρων κατηγορίας",
+                "description": "Retrieve all blog posts in this category and its subcategories. Use 'recursive=true' to include posts from all descendant categories.",
+                "summary": "Get category's blog posts",
                 "parameters": [
                     {
                         "in": "path",
@@ -2283,8 +2283,8 @@
         "/api/v1/blog/category/{id}/siblings": {
             "get": {
                 "operationId": "listBlogCategorySiblings",
-                "description": "Λήψη κατηγοριών-αδερφών (ίδιο επίπεδο γονέα).",
-                "summary": "Λήψη αδερφών κατηγοριών",
+                "description": "Get sibling categories (same parent level).",
+                "summary": "Get category siblings",
                 "parameters": [
                     {
                         "in": "path",
@@ -2432,8 +2432,8 @@
         "/api/v1/blog/category/reorder": {
             "post": {
                 "operationId": "reorderBlogCategories",
-                "description": "Μαζική αναδιάταξη κατηγοριών με ενημέρωση των τιμών sort_order.",
-                "summary": "Αναδιάταξη κατηγοριών",
+                "description": "Batch reorder categories by updating their sort_order values.",
+                "summary": "Reorder categories",
                 "tags": [
                     "Blog Categories"
                 ],
@@ -2529,8 +2529,8 @@
         "/api/v1/blog/category/tree": {
             "get": {
                 "operationId": "getBlogCategoryTree",
-                "description": "Λήψη της πλήρους δενδρικής δομής κατηγοριών με ένθετες σχέσεις. Είναι πιο αποδοτικό από τη χρήση list?tree=true για την εμφάνιση μενού πλοήγησης ή ιεραρχιών κατηγοριών.",
-                "summary": "Λήψη πλήρους δέντρου κατηγοριών",
+                "description": "Get the complete category tree structure with nested relationships. This is more efficient than using list?tree=true for displaying navigation menus or category hierarchies.",
+                "summary": "Get complete category tree",
                 "parameters": [
                     {
                         "name": "ordering",
@@ -2662,8 +2662,8 @@
         "/api/v1/blog/comment": {
             "get": {
                 "operationId": "listBlogComment",
-                "description": "Ανάκτηση λίστας Σχόλια Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Σχόλια Blog",
+                "description": "Retrieve a list of Blog Comments with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Blog Comments",
                 "parameters": [
                     {
                         "in": "query",
@@ -2679,7 +2679,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are ancestors of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -2700,7 +2700,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση έγκρισης"
+                        "description": "Filter by approval status"
                     },
                     {
                         "in": "query",
@@ -2708,7 +2708,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by comment content (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -2724,7 +2724,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβές μήκος περιεχομένου"
+                        "description": "Filter by exact content length"
                     },
                     {
                         "in": "query",
@@ -2774,7 +2774,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -2790,7 +2790,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are descendants of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -2811,7 +2811,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)"
+                        "description": "Filter comments that have content (true) or are empty (false)"
                     },
                     {
                         "in": "query",
@@ -2832,7 +2832,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)"
+                        "description": "Filter comments that have likes (true) or no likes (false)"
                     },
                     {
                         "in": "query",
@@ -2853,7 +2853,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)"
+                        "description": "Filter comments that have approved replies (true) or no replies (false)"
                     },
                     {
                         "in": "query",
@@ -2877,7 +2877,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -2910,7 +2910,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)"
+                        "description": "Filter anonymous comments (no user)"
                     },
                     {
                         "in": "query",
@@ -2931,7 +2931,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)"
+                        "description": "Filter leaf comments (no approved replies)"
                     },
                     {
                         "in": "query",
@@ -2945,7 +2945,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -2961,7 +2961,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)"
+                        "description": "Filter by comment nesting level (0 for top-level)"
                     },
                     {
                         "in": "query",
@@ -2977,7 +2977,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα"
+                        "description": "Filter comments at or below this nesting level"
                     },
                     {
                         "in": "query",
@@ -2993,7 +2993,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα"
+                        "description": "Filter comments at or above this nesting level"
                     },
                     {
                         "in": "query",
@@ -3009,7 +3009,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by left tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -3055,7 +3055,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη"
+                        "description": "Filter comments liked by specific user ID"
                     },
                     {
                         "in": "query",
@@ -3071,7 +3071,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at most this content length"
                     },
                     {
                         "in": "query",
@@ -3087,7 +3087,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες επισημάνσεις"
+                        "description": "Filter comments with at most this many likes"
                     },
                     {
                         "in": "query",
@@ -3103,7 +3103,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at most this many approved replies"
                     },
                     {
                         "in": "query",
@@ -3119,7 +3119,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at least this content length"
                     },
                     {
                         "in": "query",
@@ -3135,7 +3135,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις"
+                        "description": "Filter comments with at least this many likes"
                     },
                     {
                         "in": "query",
@@ -3151,7 +3151,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at least this many approved replies"
                     },
                     {
                         "in": "query",
@@ -3172,7 +3172,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα"
+                        "description": "Order comments by most likes first"
                     },
                     {
                         "in": "query",
@@ -3193,7 +3193,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα"
+                        "description": "Order comments by most approved replies first"
                     },
                     {
                         "name": "ordering",
@@ -3236,7 +3236,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -3249,7 +3249,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -3263,7 +3263,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -3279,7 +3279,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID γονικού σχολίου"
+                        "description": "Filter by parent comment ID"
                     },
                     {
                         "in": "query",
@@ -3300,7 +3300,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)"
+                        "description": "Filter top-level comments (true) or replies (false)"
                     },
                     {
                         "in": "query",
@@ -3316,7 +3316,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID άρθρου"
+                        "description": "Filter by blog post ID"
                     },
                     {
                         "in": "query",
@@ -3332,7 +3332,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη άρθρου"
+                        "description": "Filter by blog post author ID"
                     },
                     {
                         "in": "query",
@@ -3348,7 +3348,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας άρθρου"
+                        "description": "Filter by blog post category ID"
                     },
                     {
                         "in": "query",
@@ -3356,7 +3356,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug κατηγορίας άρθρου"
+                        "description": "Filter by blog post category slug"
                     },
                     {
                         "in": "query",
@@ -3377,7 +3377,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης άρθρου"
+                        "description": "Filter by blog post published status"
                     },
                     {
                         "in": "query",
@@ -3385,7 +3385,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug άρθρου"
+                        "description": "Filter by blog post slug"
                     },
                     {
                         "in": "query",
@@ -3393,7 +3393,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο άρθρου"
+                        "description": "Filter by blog post title"
                     },
                     {
                         "in": "query",
@@ -3409,7 +3409,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by right tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -3464,7 +3464,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by tree ID (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -3522,7 +3522,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -3530,7 +3530,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη"
+                        "description": "Filter by user email"
                     },
                     {
                         "in": "query",
@@ -3551,7 +3551,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από ενεργούς χρήστες"
+                        "description": "Filter comments by active users"
                     },
                     {
                         "in": "query",
@@ -3572,7 +3572,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από staff"
+                        "description": "Filter comments by staff users"
                     },
                     {
                         "in": "query",
@@ -3656,8 +3656,8 @@
             },
             "post": {
                 "operationId": "createBlogComment",
-                "description": "Δημιουργία νέου Σχόλιο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Σχόλιο Blog",
+                "description": "Create a new Blog Comment. Requires authentication.",
+                "summary": "Create a Blog Comment",
                 "parameters": [
                     {
                         "in": "query",
@@ -3671,7 +3671,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -3769,8 +3769,8 @@
         "/api/v1/blog/comment/{id}": {
             "get": {
                 "operationId": "retrieveBlogComment",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχόλιο Blog.",
-                "summary": "Ανάκτηση Σχόλιο Blog",
+                "description": "Get detailed information about a specific Blog Comment.",
+                "summary": "Retrieve a Blog Comment",
                 "parameters": [
                     {
                         "in": "path",
@@ -3800,7 +3800,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -3866,8 +3866,8 @@
             },
             "put": {
                 "operationId": "updateBlogComment",
-                "description": "Ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Σχόλιο Blog",
+                "description": "Update Blog Comment information. Requires authentication.",
+                "summary": "Update a Blog Comment",
                 "parameters": [
                     {
                         "in": "path",
@@ -3897,7 +3897,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -3993,8 +3993,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateBlogComment",
-                "description": "Μερική ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Σχόλιο Blog",
+                "description": "Partially update Blog Comment information. Requires authentication.",
+                "summary": "Partially update a Blog Comment",
                 "parameters": [
                     {
                         "in": "path",
@@ -4024,7 +4024,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -4119,8 +4119,8 @@
             },
             "delete": {
                 "operationId": "destroyBlogComment",
-                "description": "Διαγραφή Σχόλιο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Σχόλιο Blog",
+                "description": "Delete a Blog Comment. Requires authentication.",
+                "summary": "Delete a Blog Comment",
                 "parameters": [
                     {
                         "in": "path",
@@ -4187,8 +4187,8 @@
         "/api/v1/blog/comment/{id}/post": {
             "get": {
                 "operationId": "getBlogCommentPost",
-                "description": "Λήψη του άρθρου στο οποίο ανήκει αυτό το σχόλιο.",
-                "summary": "Λήψη άρθρου σχολίου",
+                "description": "Get the blog post that this comment belongs to.",
+                "summary": "Get comment's blog post",
                 "parameters": [
                     {
                         "in": "path",
@@ -4282,8 +4282,8 @@
         "/api/v1/blog/comment/{id}/replies": {
             "get": {
                 "operationId": "listBlogCommentReplies",
-                "description": "Λήψη όλων των απαντήσεων (θυγατρικά) αυτού του σχολίου σε δομή νήματος.",
-                "summary": "Λήψη απαντήσεων σχολίου",
+                "description": "Get all replies (children) of this comment in threaded structure.",
+                "summary": "Get comment replies",
                 "parameters": [
                     {
                         "in": "query",
@@ -4299,7 +4299,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are ancestors of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -4320,7 +4320,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση έγκρισης"
+                        "description": "Filter by approval status"
                     },
                     {
                         "in": "query",
@@ -4328,7 +4328,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by comment content (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -4344,7 +4344,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβές μήκος περιεχομένου"
+                        "description": "Filter by exact content length"
                     },
                     {
                         "in": "query",
@@ -4402,7 +4402,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are descendants of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -4423,7 +4423,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)"
+                        "description": "Filter comments that have content (true) or are empty (false)"
                     },
                     {
                         "in": "query",
@@ -4444,7 +4444,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)"
+                        "description": "Filter comments that have likes (true) or no likes (false)"
                     },
                     {
                         "in": "query",
@@ -4465,7 +4465,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)"
+                        "description": "Filter comments that have approved replies (true) or no replies (false)"
                     },
                     {
                         "in": "path",
@@ -4505,7 +4505,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -4538,7 +4538,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)"
+                        "description": "Filter anonymous comments (no user)"
                     },
                     {
                         "in": "query",
@@ -4559,7 +4559,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)"
+                        "description": "Filter leaf comments (no approved replies)"
                     },
                     {
                         "in": "query",
@@ -4575,7 +4575,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)"
+                        "description": "Filter by comment nesting level (0 for top-level)"
                     },
                     {
                         "in": "query",
@@ -4591,7 +4591,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα"
+                        "description": "Filter comments at or below this nesting level"
                     },
                     {
                         "in": "query",
@@ -4607,7 +4607,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα"
+                        "description": "Filter comments at or above this nesting level"
                     },
                     {
                         "in": "query",
@@ -4623,7 +4623,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by left tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -4669,7 +4669,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη"
+                        "description": "Filter comments liked by specific user ID"
                     },
                     {
                         "in": "query",
@@ -4685,7 +4685,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at most this content length"
                     },
                     {
                         "in": "query",
@@ -4701,7 +4701,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες επισημάνσεις"
+                        "description": "Filter comments with at most this many likes"
                     },
                     {
                         "in": "query",
@@ -4717,7 +4717,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at most this many approved replies"
                     },
                     {
                         "in": "query",
@@ -4733,7 +4733,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at least this content length"
                     },
                     {
                         "in": "query",
@@ -4749,7 +4749,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις"
+                        "description": "Filter comments with at least this many likes"
                     },
                     {
                         "in": "query",
@@ -4765,7 +4765,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at least this many approved replies"
                     },
                     {
                         "in": "query",
@@ -4786,7 +4786,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα"
+                        "description": "Order comments by most likes first"
                     },
                     {
                         "in": "query",
@@ -4807,7 +4807,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα"
+                        "description": "Order comments by most approved replies first"
                     },
                     {
                         "name": "ordering",
@@ -4867,7 +4867,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID γονικού σχολίου"
+                        "description": "Filter by parent comment ID"
                     },
                     {
                         "in": "query",
@@ -4888,7 +4888,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)"
+                        "description": "Filter top-level comments (true) or replies (false)"
                     },
                     {
                         "in": "query",
@@ -4904,7 +4904,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID άρθρου"
+                        "description": "Filter by blog post ID"
                     },
                     {
                         "in": "query",
@@ -4920,7 +4920,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη άρθρου"
+                        "description": "Filter by blog post author ID"
                     },
                     {
                         "in": "query",
@@ -4936,7 +4936,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας άρθρου"
+                        "description": "Filter by blog post category ID"
                     },
                     {
                         "in": "query",
@@ -4944,7 +4944,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug κατηγορίας άρθρου"
+                        "description": "Filter by blog post category slug"
                     },
                     {
                         "in": "query",
@@ -4965,7 +4965,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης άρθρου"
+                        "description": "Filter by blog post published status"
                     },
                     {
                         "in": "query",
@@ -4973,7 +4973,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug άρθρου"
+                        "description": "Filter by blog post slug"
                     },
                     {
                         "in": "query",
@@ -4981,7 +4981,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο άρθρου"
+                        "description": "Filter by blog post title"
                     },
                     {
                         "in": "query",
@@ -4997,7 +4997,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by right tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -5052,7 +5052,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by tree ID (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -5110,7 +5110,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -5118,7 +5118,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη"
+                        "description": "Filter by user email"
                     },
                     {
                         "in": "query",
@@ -5139,7 +5139,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από ενεργούς χρήστες"
+                        "description": "Filter comments by active users"
                     },
                     {
                         "in": "query",
@@ -5160,7 +5160,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από staff"
+                        "description": "Filter comments by staff users"
                     },
                     {
                         "in": "query",
@@ -5246,8 +5246,8 @@
         "/api/v1/blog/comment/{id}/thread": {
             "get": {
                 "operationId": "getBlogCommentThread",
-                "description": "Λήψη ολόκληρου του νήματος (όλοι οι πρόγονοι και απόγονοι) αυτού του σχολίου.",
-                "summary": "Λήψη νήματος σχολίων",
+                "description": "Get the complete thread (all ancestors and descendants) of this comment.",
+                "summary": "Get comment thread",
                 "parameters": [
                     {
                         "in": "query",
@@ -5263,7 +5263,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are ancestors of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -5284,7 +5284,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση έγκρισης"
+                        "description": "Filter by approval status"
                     },
                     {
                         "in": "query",
@@ -5292,7 +5292,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by comment content (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -5308,7 +5308,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβές μήκος περιεχομένου"
+                        "description": "Filter by exact content length"
                     },
                     {
                         "in": "query",
@@ -5366,7 +5366,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are descendants of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -5387,7 +5387,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)"
+                        "description": "Filter comments that have content (true) or are empty (false)"
                     },
                     {
                         "in": "query",
@@ -5408,7 +5408,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)"
+                        "description": "Filter comments that have likes (true) or no likes (false)"
                     },
                     {
                         "in": "query",
@@ -5429,7 +5429,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)"
+                        "description": "Filter comments that have approved replies (true) or no replies (false)"
                     },
                     {
                         "in": "path",
@@ -5469,7 +5469,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -5502,7 +5502,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)"
+                        "description": "Filter anonymous comments (no user)"
                     },
                     {
                         "in": "query",
@@ -5523,7 +5523,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)"
+                        "description": "Filter leaf comments (no approved replies)"
                     },
                     {
                         "in": "query",
@@ -5539,7 +5539,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)"
+                        "description": "Filter by comment nesting level (0 for top-level)"
                     },
                     {
                         "in": "query",
@@ -5555,7 +5555,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα"
+                        "description": "Filter comments at or below this nesting level"
                     },
                     {
                         "in": "query",
@@ -5571,7 +5571,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα"
+                        "description": "Filter comments at or above this nesting level"
                     },
                     {
                         "in": "query",
@@ -5587,7 +5587,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by left tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -5633,7 +5633,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη"
+                        "description": "Filter comments liked by specific user ID"
                     },
                     {
                         "in": "query",
@@ -5649,7 +5649,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at most this content length"
                     },
                     {
                         "in": "query",
@@ -5665,7 +5665,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες επισημάνσεις"
+                        "description": "Filter comments with at most this many likes"
                     },
                     {
                         "in": "query",
@@ -5681,7 +5681,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at most this many approved replies"
                     },
                     {
                         "in": "query",
@@ -5697,7 +5697,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at least this content length"
                     },
                     {
                         "in": "query",
@@ -5713,7 +5713,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις"
+                        "description": "Filter comments with at least this many likes"
                     },
                     {
                         "in": "query",
@@ -5729,7 +5729,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at least this many approved replies"
                     },
                     {
                         "in": "query",
@@ -5750,7 +5750,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα"
+                        "description": "Order comments by most likes first"
                     },
                     {
                         "in": "query",
@@ -5771,7 +5771,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα"
+                        "description": "Order comments by most approved replies first"
                     },
                     {
                         "name": "ordering",
@@ -5831,7 +5831,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID γονικού σχολίου"
+                        "description": "Filter by parent comment ID"
                     },
                     {
                         "in": "query",
@@ -5852,7 +5852,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)"
+                        "description": "Filter top-level comments (true) or replies (false)"
                     },
                     {
                         "in": "query",
@@ -5868,7 +5868,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID άρθρου"
+                        "description": "Filter by blog post ID"
                     },
                     {
                         "in": "query",
@@ -5884,7 +5884,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη άρθρου"
+                        "description": "Filter by blog post author ID"
                     },
                     {
                         "in": "query",
@@ -5900,7 +5900,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας άρθρου"
+                        "description": "Filter by blog post category ID"
                     },
                     {
                         "in": "query",
@@ -5908,7 +5908,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug κατηγορίας άρθρου"
+                        "description": "Filter by blog post category slug"
                     },
                     {
                         "in": "query",
@@ -5929,7 +5929,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης άρθρου"
+                        "description": "Filter by blog post published status"
                     },
                     {
                         "in": "query",
@@ -5937,7 +5937,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug άρθρου"
+                        "description": "Filter by blog post slug"
                     },
                     {
                         "in": "query",
@@ -5945,7 +5945,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο άρθρου"
+                        "description": "Filter by blog post title"
                     },
                     {
                         "in": "query",
@@ -5961,7 +5961,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by right tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -6016,7 +6016,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by tree ID (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -6074,7 +6074,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -6082,7 +6082,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη"
+                        "description": "Filter by user email"
                     },
                     {
                         "in": "query",
@@ -6103,7 +6103,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από ενεργούς χρήστες"
+                        "description": "Filter comments by active users"
                     },
                     {
                         "in": "query",
@@ -6124,7 +6124,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από staff"
+                        "description": "Filter comments by staff users"
                     },
                     {
                         "in": "query",
@@ -6210,8 +6210,8 @@
         "/api/v1/blog/comment/{id}/update_likes": {
             "post": {
                 "operationId": "toggleBlogCommentLike",
-                "description": "Επισήμανση ή αναίρεση επισήμανσης σχολίου. Εναλλάσσει την κατάσταση επισήμανσης.",
-                "summary": "Εναλλαγή επισήμανσης σχολίου",
+                "description": "Like or unlike a comment. Toggles the like status.",
+                "summary": "Toggle comment like",
                 "parameters": [
                     {
                         "in": "path",
@@ -6305,8 +6305,8 @@
         "/api/v1/blog/comment/liked_comments": {
             "post": {
                 "operationId": "checkBlogCommentLikes",
-                "description": "Έλεγχος ποια σχόλια από μια λίστα έχει επισημάνει ο τρέχων χρήστης.",
-                "summary": "Έλεγχος μαζικής κατάστασης επισήμανσης",
+                "description": "Check which comments from a list are liked by the current user.",
+                "summary": "Check bulk like status",
                 "tags": [
                     "Blog Comments"
                 ],
@@ -6402,8 +6402,8 @@
         "/api/v1/blog/comment/my_comments": {
             "get": {
                 "operationId": "listMyBlogComments",
-                "description": "Λήψη όλων των σχολίων που έχει κάνει ο συνδεδεμένος χρήστης.",
-                "summary": "Λήψη σχολίων τρέχοντος χρήστη",
+                "description": "Get all comments made by the currently authenticated user.",
+                "summary": "Get current user's comments",
                 "parameters": [
                     {
                         "in": "query",
@@ -6419,7 +6419,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are ancestors of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -6440,7 +6440,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση έγκρισης"
+                        "description": "Filter by approval status"
                     },
                     {
                         "in": "query",
@@ -6448,7 +6448,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by comment content (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -6464,7 +6464,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβές μήκος περιεχομένου"
+                        "description": "Filter by exact content length"
                     },
                     {
                         "in": "query",
@@ -6522,7 +6522,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου"
+                        "description": "Filter comments that are descendants of the given comment ID"
                     },
                     {
                         "in": "query",
@@ -6543,7 +6543,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)"
+                        "description": "Filter comments that have content (true) or are empty (false)"
                     },
                     {
                         "in": "query",
@@ -6564,7 +6564,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)"
+                        "description": "Filter comments that have likes (true) or no likes (false)"
                     },
                     {
                         "in": "query",
@@ -6585,7 +6585,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)"
+                        "description": "Filter comments that have approved replies (true) or no replies (false)"
                     },
                     {
                         "in": "query",
@@ -6609,7 +6609,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -6642,7 +6642,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)"
+                        "description": "Filter anonymous comments (no user)"
                     },
                     {
                         "in": "query",
@@ -6663,7 +6663,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)"
+                        "description": "Filter leaf comments (no approved replies)"
                     },
                     {
                         "in": "query",
@@ -6679,7 +6679,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)"
+                        "description": "Filter by comment nesting level (0 for top-level)"
                     },
                     {
                         "in": "query",
@@ -6695,7 +6695,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα"
+                        "description": "Filter comments at or below this nesting level"
                     },
                     {
                         "in": "query",
@@ -6711,7 +6711,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα"
+                        "description": "Filter comments at or above this nesting level"
                     },
                     {
                         "in": "query",
@@ -6727,7 +6727,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by left tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -6773,7 +6773,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη"
+                        "description": "Filter comments liked by specific user ID"
                     },
                     {
                         "in": "query",
@@ -6789,7 +6789,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at most this content length"
                     },
                     {
                         "in": "query",
@@ -6805,7 +6805,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες επισημάνσεις"
+                        "description": "Filter comments with at most this many likes"
                     },
                     {
                         "in": "query",
@@ -6821,7 +6821,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at most this many approved replies"
                     },
                     {
                         "in": "query",
@@ -6837,7 +6837,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου"
+                        "description": "Filter comments with at least this content length"
                     },
                     {
                         "in": "query",
@@ -6853,7 +6853,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις"
+                        "description": "Filter comments with at least this many likes"
                     },
                     {
                         "in": "query",
@@ -6869,7 +6869,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις"
+                        "description": "Filter comments with at least this many approved replies"
                     },
                     {
                         "in": "query",
@@ -6890,7 +6890,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα"
+                        "description": "Order comments by most likes first"
                     },
                     {
                         "in": "query",
@@ -6911,7 +6911,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα"
+                        "description": "Order comments by most approved replies first"
                     },
                     {
                         "name": "ordering",
@@ -6971,7 +6971,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID γονικού σχολίου"
+                        "description": "Filter by parent comment ID"
                     },
                     {
                         "in": "query",
@@ -6992,7 +6992,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)"
+                        "description": "Filter top-level comments (true) or replies (false)"
                     },
                     {
                         "in": "query",
@@ -7008,7 +7008,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID άρθρου"
+                        "description": "Filter by blog post ID"
                     },
                     {
                         "in": "query",
@@ -7024,7 +7024,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη άρθρου"
+                        "description": "Filter by blog post author ID"
                     },
                     {
                         "in": "query",
@@ -7040,7 +7040,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας άρθρου"
+                        "description": "Filter by blog post category ID"
                     },
                     {
                         "in": "query",
@@ -7048,7 +7048,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug κατηγορίας άρθρου"
+                        "description": "Filter by blog post category slug"
                     },
                     {
                         "in": "query",
@@ -7069,7 +7069,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης άρθρου"
+                        "description": "Filter by blog post published status"
                     },
                     {
                         "in": "query",
@@ -7077,7 +7077,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug άρθρου"
+                        "description": "Filter by blog post slug"
                     },
                     {
                         "in": "query",
@@ -7085,7 +7085,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο άρθρου"
+                        "description": "Filter by blog post title"
                     },
                     {
                         "in": "query",
@@ -7101,7 +7101,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by right tree value (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -7156,7 +7156,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)"
+                        "description": "Filter by tree ID (MPTT internal)"
                     },
                     {
                         "in": "query",
@@ -7214,7 +7214,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -7222,7 +7222,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη"
+                        "description": "Filter by user email"
                     },
                     {
                         "in": "query",
@@ -7243,7 +7243,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από ενεργούς χρήστες"
+                        "description": "Filter comments by active users"
                     },
                     {
                         "in": "query",
@@ -7264,7 +7264,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο σχολίων από staff"
+                        "description": "Filter comments by staff users"
                     },
                     {
                         "in": "query",
@@ -7350,8 +7350,8 @@
         "/api/v1/blog/post": {
             "get": {
                 "operationId": "listBlogPost",
-                "description": "Ανάκτηση λίστας Άρθρα Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Άρθρα Blog",
+                "description": "Retrieve a list of Blog Posts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Blog Posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -7367,7 +7367,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη"
+                        "description": "Filter by author ID"
                     },
                     {
                         "in": "query",
@@ -7375,7 +7375,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -7383,7 +7383,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author full name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -7399,7 +7399,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας"
+                        "description": "Filter by category ID"
                     },
                     {
                         "in": "query",
@@ -7407,7 +7407,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -7416,7 +7416,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -7449,7 +7449,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -7470,7 +7470,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -7478,7 +7478,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -7499,7 +7499,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προτεινόμενου"
+                        "description": "Filter by featured status"
                     },
                     {
                         "in": "query",
@@ -7523,7 +7523,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -7556,7 +7556,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -7570,7 +7570,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -7586,7 +7586,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων"
+                        "description": "Filter by minimum number of approved comments"
                     },
                     {
                         "in": "query",
@@ -7602,7 +7602,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων"
+                        "description": "Filter by minimum number of likes"
                     },
                     {
                         "in": "query",
@@ -7618,7 +7618,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών"
+                        "description": "Filter by minimum number of active tags"
                     },
                     {
                         "in": "query",
@@ -7634,7 +7634,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό προβολών"
+                        "description": "Filter by minimum number of views"
                     },
                     {
                         "name": "ordering",
@@ -7677,7 +7677,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -7690,7 +7690,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -7704,7 +7704,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -7713,7 +7713,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -7746,7 +7746,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "name": "search",
@@ -7777,7 +7777,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by tag label (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -7786,7 +7786,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -7796,7 +7796,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by tag IDs (comma-separated)",
                         "explode": true,
                         "style": "form"
                     },
@@ -7806,7 +7806,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -7815,7 +7815,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -7848,7 +7848,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -7978,8 +7978,8 @@
             },
             "post": {
                 "operationId": "createBlogPost",
-                "description": "Δημιουργία νέου Άρθρο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Άρθρο Blog",
+                "description": "Create a new Blog Post. Requires authentication.",
+                "summary": "Create a Blog Post",
                 "parameters": [
                     {
                         "in": "query",
@@ -7993,7 +7993,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -8091,8 +8091,8 @@
         "/api/v1/blog/post/{id}": {
             "get": {
                 "operationId": "retrieveBlogPost",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Άρθρο Blog.",
-                "summary": "Ανάκτηση Άρθρο Blog",
+                "description": "Get detailed information about a specific Blog Post.",
+                "summary": "Retrieve a Blog Post",
                 "parameters": [
                     {
                         "in": "path",
@@ -8122,7 +8122,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -8189,8 +8189,8 @@
             },
             "put": {
                 "operationId": "updateBlogPost",
-                "description": "Ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Άρθρο Blog",
+                "description": "Update Blog Post information. Requires authentication.",
+                "summary": "Update a Blog Post",
                 "parameters": [
                     {
                         "in": "path",
@@ -8220,7 +8220,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -8316,8 +8316,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateBlogPost",
-                "description": "Μερική ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Άρθρο Blog",
+                "description": "Partially update Blog Post information. Requires authentication.",
+                "summary": "Partially update a Blog Post",
                 "parameters": [
                     {
                         "in": "path",
@@ -8347,7 +8347,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -8442,8 +8442,8 @@
             },
             "delete": {
                 "operationId": "destroyBlogPost",
-                "description": "Διαγραφή Άρθρο Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Άρθρο Blog",
+                "description": "Delete a Blog Post. Requires authentication.",
+                "summary": "Delete a Blog Post",
                 "parameters": [
                     {
                         "in": "path",
@@ -8510,8 +8510,8 @@
         "/api/v1/blog/post/{id}/comments": {
             "get": {
                 "operationId": "listBlogPostComments",
-                "description": "Λήψη όλων των σχολίων ενός άρθρου.",
-                "summary": "Λήψη σχολίων άρθρου",
+                "description": "Get all comments for a blog post.",
+                "summary": "Get post comments",
                 "parameters": [
                     {
                         "in": "path",
@@ -8688,8 +8688,8 @@
         "/api/v1/blog/post/{id}/related_posts": {
             "get": {
                 "operationId": "listBlogPostRelated",
-                "description": "Λήψη σχετικών άρθρων για ένα άρθρο.",
-                "summary": "Λήψη σχετικών άρθρων",
+                "description": "Get related posts for a blog post.",
+                "summary": "Get related posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -8705,7 +8705,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη"
+                        "description": "Filter by author ID"
                     },
                     {
                         "in": "query",
@@ -8713,7 +8713,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -8721,7 +8721,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author full name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -8737,7 +8737,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας"
+                        "description": "Filter by category ID"
                     },
                     {
                         "in": "query",
@@ -8745,7 +8745,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -8754,7 +8754,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -8787,7 +8787,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -8808,7 +8808,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -8829,7 +8829,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προτεινόμενου"
+                        "description": "Filter by featured status"
                     },
                     {
                         "in": "query",
@@ -8870,7 +8870,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -8903,7 +8903,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -8919,7 +8919,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων"
+                        "description": "Filter by minimum number of approved comments"
                     },
                     {
                         "in": "query",
@@ -8935,7 +8935,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων"
+                        "description": "Filter by minimum number of likes"
                     },
                     {
                         "in": "query",
@@ -8951,7 +8951,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών"
+                        "description": "Filter by minimum number of active tags"
                     },
                     {
                         "in": "query",
@@ -8967,7 +8967,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό προβολών"
+                        "description": "Filter by minimum number of views"
                     },
                     {
                         "name": "ordering",
@@ -8986,7 +8986,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -9019,7 +9019,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "name": "search",
@@ -9050,7 +9050,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by tag label (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9059,7 +9059,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -9069,7 +9069,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by tag IDs (comma-separated)",
                         "explode": true,
                         "style": "form"
                     },
@@ -9079,7 +9079,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9088,7 +9088,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -9121,7 +9121,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -9256,8 +9256,8 @@
         "/api/v1/blog/post/{id}/update_likes": {
             "post": {
                 "operationId": "toggleBlogPostLike",
-                "description": "Επισήμανση ή αναίρεση επισήμανσης άρθρου. Εναλλάσσει την κατάσταση επισήμανσης.",
-                "summary": "Εναλλαγή επισήμανσης άρθρου",
+                "description": "Like or unlike a blog post. Toggles the like status.",
+                "summary": "Toggle post like",
                 "parameters": [
                     {
                         "in": "path",
@@ -9352,8 +9352,8 @@
         "/api/v1/blog/post/{id}/update_view_count": {
             "post": {
                 "operationId": "incrementBlogPostViews",
-                "description": "Αύξηση του μετρητή προβολών ενός άρθρου.",
-                "summary": "Αύξηση προβολών άρθρου",
+                "description": "Increment the view count for a blog post.",
+                "summary": "Increment post view count",
                 "parameters": [
                     {
                         "in": "path",
@@ -9448,8 +9448,8 @@
         "/api/v1/blog/post/featured": {
             "get": {
                 "operationId": "listFeaturedBlogPosts",
-                "description": "Λήψη άρθρων που έχουν επισημανθεί ως προτεινόμενα, ταξινομημένα κατά ημερομηνία δημοσίευσης.",
-                "summary": "Λήψη προτεινόμενων άρθρων",
+                "description": "Get posts marked as featured, ordered by publication date.",
+                "summary": "Get featured posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -9465,7 +9465,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη"
+                        "description": "Filter by author ID"
                     },
                     {
                         "in": "query",
@@ -9473,7 +9473,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9481,7 +9481,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author full name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9497,7 +9497,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας"
+                        "description": "Filter by category ID"
                     },
                     {
                         "in": "query",
@@ -9505,7 +9505,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9514,7 +9514,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -9547,7 +9547,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -9568,7 +9568,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -9589,7 +9589,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προτεινόμενου"
+                        "description": "Filter by featured status"
                     },
                     {
                         "in": "query",
@@ -9613,7 +9613,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -9646,7 +9646,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -9662,7 +9662,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων"
+                        "description": "Filter by minimum number of approved comments"
                     },
                     {
                         "in": "query",
@@ -9678,7 +9678,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων"
+                        "description": "Filter by minimum number of likes"
                     },
                     {
                         "in": "query",
@@ -9694,7 +9694,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών"
+                        "description": "Filter by minimum number of active tags"
                     },
                     {
                         "in": "query",
@@ -9710,7 +9710,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό προβολών"
+                        "description": "Filter by minimum number of views"
                     },
                     {
                         "name": "ordering",
@@ -9763,7 +9763,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -9796,7 +9796,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "name": "search",
@@ -9827,7 +9827,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by tag label (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9836,7 +9836,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -9846,7 +9846,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by tag IDs (comma-separated)",
                         "explode": true,
                         "style": "form"
                     },
@@ -9856,7 +9856,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -9865,7 +9865,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -9898,7 +9898,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -10030,8 +10030,8 @@
         "/api/v1/blog/post/liked_posts": {
             "post": {
                 "operationId": "checkBlogPostLikes",
-                "description": "Λήψη όλων των άρθρων που έχει επισημάνει ο συνδεδεμένος χρήστης.",
-                "summary": "Λήψη άρθρων με επισήμανση",
+                "description": "Get all posts that the authenticated user has liked.",
+                "summary": "Get liked posts",
                 "tags": [
                     "Blog Posts"
                 ],
@@ -10128,8 +10128,8 @@
         "/api/v1/blog/post/popular": {
             "get": {
                 "operationId": "listPopularBlogPosts",
-                "description": "Λήψη των πιο δημοφιλών άρθρων βάσει δεικτών αλληλεπίδρασης όλων των εποχών.",
-                "summary": "Λήψη δημοφιλών άρθρων",
+                "description": "Get most popular blog posts based on all-time engagement metrics.",
+                "summary": "Get popular posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -10145,7 +10145,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη"
+                        "description": "Filter by author ID"
                     },
                     {
                         "in": "query",
@@ -10153,7 +10153,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10161,7 +10161,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author full name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10177,7 +10177,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας"
+                        "description": "Filter by category ID"
                     },
                     {
                         "in": "query",
@@ -10185,7 +10185,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10194,7 +10194,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -10227,7 +10227,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -10248,7 +10248,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -10269,7 +10269,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προτεινόμενου"
+                        "description": "Filter by featured status"
                     },
                     {
                         "in": "query",
@@ -10293,7 +10293,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -10326,7 +10326,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -10342,7 +10342,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων"
+                        "description": "Filter by minimum number of approved comments"
                     },
                     {
                         "in": "query",
@@ -10358,7 +10358,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων"
+                        "description": "Filter by minimum number of likes"
                     },
                     {
                         "in": "query",
@@ -10374,7 +10374,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών"
+                        "description": "Filter by minimum number of active tags"
                     },
                     {
                         "in": "query",
@@ -10390,7 +10390,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό προβολών"
+                        "description": "Filter by minimum number of views"
                     },
                     {
                         "name": "ordering",
@@ -10443,7 +10443,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -10476,7 +10476,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "name": "search",
@@ -10507,7 +10507,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by tag label (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10516,7 +10516,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -10526,7 +10526,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by tag IDs (comma-separated)",
                         "explode": true,
                         "style": "form"
                     },
@@ -10536,7 +10536,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10545,7 +10545,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -10578,7 +10578,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -10710,8 +10710,8 @@
         "/api/v1/blog/post/trending": {
             "get": {
                 "operationId": "listTrendingBlogPosts",
-                "description": "Λήψη δημοφιλών άρθρων βάσει πρόσφατων δεικτών αλληλεπίδρασης. Συνδυάζει προβολές, επισημάνσεις και σχόλια πρόσφατης περιόδου.",
-                "summary": "Λήψη trending άρθρων",
+                "description": "Get trending blog posts based on recent engagement metrics. Combines views, likes, and comments from recent time period.",
+                "summary": "Get trending posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -10727,7 +10727,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID συντάκτη"
+                        "description": "Filter by author ID"
                     },
                     {
                         "in": "query",
@@ -10735,7 +10735,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10743,7 +10743,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by author full name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10759,7 +10759,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας"
+                        "description": "Filter by category ID"
                     },
                     {
                         "in": "query",
@@ -10767,7 +10767,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -10776,7 +10776,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -10809,7 +10809,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -10830,7 +10830,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -10867,7 +10867,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προτεινόμενου"
+                        "description": "Filter by featured status"
                     },
                     {
                         "in": "query",
@@ -10891,7 +10891,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -10924,7 +10924,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -10940,7 +10940,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων"
+                        "description": "Filter by minimum number of approved comments"
                     },
                     {
                         "in": "query",
@@ -10956,7 +10956,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων"
+                        "description": "Filter by minimum number of likes"
                     },
                     {
                         "in": "query",
@@ -10972,7 +10972,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών"
+                        "description": "Filter by minimum number of active tags"
                     },
                     {
                         "in": "query",
@@ -10988,7 +10988,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο αριθμό προβολών"
+                        "description": "Filter by minimum number of views"
                     },
                     {
                         "name": "ordering",
@@ -11041,7 +11041,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -11074,7 +11074,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "name": "search",
@@ -11105,7 +11105,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by tag label (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -11114,7 +11114,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -11124,7 +11124,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by tag IDs (comma-separated)",
                         "explode": true,
                         "style": "form"
                     },
@@ -11134,7 +11134,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -11143,7 +11143,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -11176,7 +11176,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -11308,8 +11308,8 @@
         "/api/v1/blog/tag": {
             "get": {
                 "operationId": "listBlogTag",
-                "description": "Ανάκτηση λίστας Ετικέτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Ετικέτες Blog",
+                "description": "Retrieve a list of Blog Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Blog Tags",
                 "parameters": [
                     {
                         "in": "query",
@@ -11330,7 +11330,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση ενεργοποίησης"
+                        "description": "Filter by active status"
                     },
                     {
                         "in": "query",
@@ -11380,7 +11380,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -11401,7 +11401,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα με/χωρίς επισημάνσεις"
+                        "description": "Filter tags used in posts that have/don't have likes"
                     },
                     {
                         "in": "query",
@@ -11422,7 +11422,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με/χωρίς όνομα"
+                        "description": "Filter tags that have/don't have a name"
                     },
                     {
                         "in": "query",
@@ -11443,7 +11443,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με/χωρίς άρθρα"
+                        "description": "Filter tags that have/don't have posts"
                     },
                     {
                         "in": "query",
@@ -11467,7 +11467,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -11493,7 +11493,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -11509,7 +11509,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με έως X άρθρα"
+                        "description": "Filter tags with at most X posts"
                     },
                     {
                         "in": "query",
@@ -11525,7 +11525,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με τουλάχιστον X άρθρα"
+                        "description": "Filter tags with at least X posts"
                     },
                     {
                         "in": "query",
@@ -11541,7 +11541,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με άρθρα που έχουν τουλάχιστον X συνολικές επισημάνσεις"
+                        "description": "Filter tags with posts having at least X total likes"
                     },
                     {
                         "in": "query",
@@ -11562,7 +11562,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση ετικετών κατά συνολικές επισημάνσεις στα άρθρα που τις χρησιμοποιούν"
+                        "description": "Order tags by total likes on posts using them"
                     },
                     {
                         "in": "query",
@@ -11583,7 +11583,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)"
+                        "description": "Order tags by usage count (most used first)"
                     },
                     {
                         "in": "query",
@@ -11591,7 +11591,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα ετικέτας (μερική αντιστοίχιση)"
+                        "description": "Filter by tag name (partial match)"
                     },
                     {
                         "in": "query",
@@ -11599,7 +11599,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβές όνομα ετικέτας"
+                        "description": "Filter by exact tag name"
                     },
                     {
                         "in": "query",
@@ -11607,7 +11607,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ετικετών με όνομα που ξεκινά με"
+                        "description": "Filter tags with names starting with"
                     },
                     {
                         "name": "ordering",
@@ -11650,7 +11650,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -11663,7 +11663,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -11677,7 +11677,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -11693,7 +11693,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται από συγκεκριμένο άρθρο"
+                        "description": "Filter tags used by specific post ID"
                     },
                     {
                         "in": "query",
@@ -11709,7 +11709,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένου συντάκτη"
+                        "description": "Filter tags used in posts by specific author"
                     },
                     {
                         "in": "query",
@@ -11725,7 +11725,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένης κατηγορίας"
+                        "description": "Filter tags used in posts from specific category"
                     },
                     {
                         "in": "query",
@@ -11746,7 +11746,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται σε δημοσιευμένα/μη δημοσιευμένα άρθρα"
+                        "description": "Filter tags used in published/unpublished posts"
                     },
                     {
                         "name": "search",
@@ -11842,7 +11842,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που δεν χρησιμοποιούνται σε κανένα άρθρο"
+                        "description": "Filter tags not used in any posts"
                     },
                     {
                         "in": "query",
@@ -11969,8 +11969,8 @@
             },
             "post": {
                 "operationId": "createBlogTag",
-                "description": "Δημιουργία νέου Ετικέτα Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Ετικέτα Blog",
+                "description": "Create a new Blog Tag. Requires authentication.",
+                "summary": "Create a Blog Tag",
                 "parameters": [
                     {
                         "in": "query",
@@ -11984,7 +11984,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -12082,8 +12082,8 @@
         "/api/v1/blog/tag/{id}": {
             "get": {
                 "operationId": "retrieveBlogTag",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα Blog.",
-                "summary": "Ανάκτηση Ετικέτα Blog",
+                "description": "Get detailed information about a specific Blog Tag.",
+                "summary": "Retrieve a Blog Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -12113,7 +12113,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -12180,8 +12180,8 @@
             },
             "put": {
                 "operationId": "updateBlogTag",
-                "description": "Ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Ετικέτα Blog",
+                "description": "Update Blog Tag information. Requires authentication.",
+                "summary": "Update a Blog Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -12211,7 +12211,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -12307,8 +12307,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateBlogTag",
-                "description": "Μερική ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Ετικέτα Blog",
+                "description": "Partially update Blog Tag information. Requires authentication.",
+                "summary": "Partially update a Blog Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -12338,7 +12338,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -12433,8 +12433,8 @@
             },
             "delete": {
                 "operationId": "destroyBlogTag",
-                "description": "Διαγραφή Ετικέτα Blog. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Ετικέτα Blog",
+                "description": "Delete a Blog Tag. Requires authentication.",
+                "summary": "Delete a Blog Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -12501,8 +12501,8 @@
         "/api/v1/cart": {
             "get": {
                 "operationId": "retrieveCart",
-                "description": "Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Λήψη καλαθιού",
+                "description": "Get a cart. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Get cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -12578,8 +12578,8 @@
             },
             "put": {
                 "operationId": "updateCart",
-                "description": "Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Ενημέρωση καλαθιού",
+                "description": "Update a cart. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Update cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -12665,8 +12665,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateCart",
-                "description": "Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Ενημέρωση καλαθιού",
+                "description": "Update a cart. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Update cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -12752,8 +12752,8 @@
             },
             "delete": {
                 "operationId": "destroyCart",
-                "description": "Διαγραφή καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Διαγραφή καλαθιού",
+                "description": "Delete a cart. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Delete cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -12811,8 +12811,8 @@
         "/api/v1/cart/create-payment-intent": {
             "post": {
                 "operationId": "createCartPaymentIntent",
-                "description": "Δημιουργία Stripe payment intent βάσει του συνόλου του καλαθιού πριν τη δημιουργία παραγγελίας. Απαιτείται για μεθόδους online πληρωμής (Stripe) στη ροή πληρωμής πριν την παραγγελία. Επιστρέφει client_secret για επιβεβαίωση πληρωμής στο frontend και payment_intent_id προς συμπερίληψη στο αίτημα δημιουργίας παραγγελίας.",
-                "summary": "Δημιουργία payment intent από καλάθι",
+                "description": "Create a Stripe payment intent based on cart total before order creation. This is required for online payment methods (Stripe) in the payment-first flow. Returns client_secret for frontend payment confirmation and payment_intent_id to be included in order creation request.",
+                "summary": "Create payment intent from cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -12920,8 +12920,8 @@
         "/api/v1/cart/item": {
             "get": {
                 "operationId": "listCartItem",
-                "description": "Ανάκτηση λίστας ειδών καλαθιού με δυνατότητες φιλτραρίσματος και αναζήτησης. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Λίστα αντικειμένων καλαθιού",
+                "description": "Retrieve a list of cart items with filtering and search capabilities. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "List cart items",
                 "parameters": [
                     {
                         "in": "header",
@@ -12946,7 +12946,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID καλαθιού"
+                        "description": "Filter by cart ID"
                     },
                     {
                         "in": "query",
@@ -12967,7 +12967,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων σε καλάθια επισκεπτών"
+                        "description": "Filter items in guest carts"
                     },
                     {
                         "in": "query",
@@ -12983,7 +12983,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη καλαθιού"
+                        "description": "Filter by cart user ID"
                     },
                     {
                         "in": "query",
@@ -12991,7 +12991,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη καλαθιού (μερική αντιστοίχιση)"
+                        "description": "Filter by cart user email (partial match)"
                     },
                     {
                         "in": "query",
@@ -12999,7 +12999,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χρήστη καλαθιού (όνομα ή επώνυμο)"
+                        "description": "Filter by cart user name (first or last)"
                     },
                     {
                         "in": "query",
@@ -13008,7 +13008,7 @@
                             "type": "string",
                             "format": "uuid"
                         },
-                        "description": "Φίλτρο ανά UUID καλαθιού"
+                        "description": "Filter by cart UUID"
                     },
                     {
                         "in": "query",
@@ -13017,7 +13017,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ανά τελευταία δραστηριότητα καλαθιού μετά από ημερομηνία"
+                        "description": "Filter by cart last activity after date"
                     },
                     {
                         "in": "query",
@@ -13026,7 +13026,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ανά τελευταία δραστηριότητα καλαθιού πριν από ημερομηνία"
+                        "description": "Filter by cart last activity before date"
                     },
                     {
                         "in": "query",
@@ -13076,7 +13076,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -13100,7 +13100,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -13133,7 +13133,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών σε εγκαταλελειμμένα καλάθια (30+ ημέρες)"
+                        "description": "Filter items in abandoned carts (30+ days)"
                     },
                     {
                         "in": "query",
@@ -13154,7 +13154,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών σε ενεργά καλάθια (24ωρο)"
+                        "description": "Filter items in active carts (24hr)"
                     },
                     {
                         "in": "query",
@@ -13168,7 +13168,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -13184,7 +13184,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστο ποσοστό έκπτωσης"
+                        "description": "Filter by maximum discount percentage"
                     },
                     {
                         "in": "query",
@@ -13200,7 +13200,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη τιμή προϊόντος"
+                        "description": "Filter by maximum product price"
                     },
                     {
                         "in": "query",
@@ -13216,7 +13216,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη ποσότητα"
+                        "description": "Filter by maximum quantity"
                     },
                     {
                         "in": "query",
@@ -13232,7 +13232,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη συνολική τιμή (ποσότητα * τιμή)"
+                        "description": "Filter by maximum total price (quantity * price)"
                     },
                     {
                         "in": "query",
@@ -13248,7 +13248,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο ποσοστό έκπτωσης"
+                        "description": "Filter by minimum discount percentage"
                     },
                     {
                         "in": "query",
@@ -13264,7 +13264,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη τιμή προϊόντος"
+                        "description": "Filter by minimum product price"
                     },
                     {
                         "in": "query",
@@ -13280,7 +13280,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη ποσότητα"
+                        "description": "Filter by minimum quantity"
                     },
                     {
                         "in": "query",
@@ -13296,7 +13296,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη συνολική τιμή (ποσότητα * τιμή)"
+                        "description": "Filter by minimum total price (quantity * price)"
                     },
                     {
                         "name": "ordering",
@@ -13339,7 +13339,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -13352,7 +13352,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -13366,7 +13366,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -13382,7 +13382,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID προϊόντος"
+                        "description": "Filter by product ID"
                     },
                     {
                         "in": "query",
@@ -13403,7 +13403,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση προϊόντος"
+                        "description": "Filter by product active status"
                     },
                     {
                         "in": "query",
@@ -13419,7 +13419,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας προϊόντος"
+                        "description": "Filter by product category ID"
                     },
                     {
                         "in": "query",
@@ -13427,7 +13427,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug κατηγορίας προϊόντος"
+                        "description": "Filter by product category slug"
                     },
                     {
                         "in": "query",
@@ -13435,7 +13435,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)"
+                        "description": "Filter by product name (partial match)"
                     },
                     {
                         "in": "query",
@@ -13443,7 +13443,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά sku προϊόντος (ακριβής αντιστοίχιση)"
+                        "description": "Filter by product sku (exact match)"
                     },
                     {
                         "in": "query",
@@ -13452,7 +13452,7 @@
                             "type": "string",
                             "format": "uuid"
                         },
-                        "description": "Φίλτρο ανά UUID προϊόντος"
+                        "description": "Filter by product UUID"
                     },
                     {
                         "in": "query",
@@ -13468,7 +13468,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή ποσότητα"
+                        "description": "Filter by exact quantity"
                     },
                     {
                         "in": "query",
@@ -13578,7 +13578,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών με εκπτώσεις προϊόντος"
+                        "description": "Filter items with product discounts"
                     }
                 ],
                 "tags": [
@@ -13655,8 +13655,8 @@
             },
             "post": {
                 "operationId": "createCartItem",
-                "description": "Δημιουργία νέου είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Δημιουργία αντικειμένου καλαθιού",
+                "description": "Create a new cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Create a cart item",
                 "parameters": [
                     {
                         "in": "header",
@@ -13764,8 +13764,8 @@
         "/api/v1/cart/item/{id}": {
             "get": {
                 "operationId": "retrieveCartItem",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο είδος καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Ανάκτηση είδους καλαθιού",
+                "description": "Get detailed information about a specific cart item. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Retrieve a cart item",
                 "parameters": [
                     {
                         "in": "header",
@@ -13804,7 +13804,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -13871,8 +13871,8 @@
             },
             "put": {
                 "operationId": "updateCartItem",
-                "description": "Ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Ενημέρωση αντικειμένου καλαθιού",
+                "description": "Update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Update a cart item",
                 "parameters": [
                     {
                         "in": "header",
@@ -13993,8 +13993,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateCartItem",
-                "description": "Μερική ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Μερική ενημέρωση είδους καλαθιού",
+                "description": "Partially update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Partially update a cart item",
                 "parameters": [
                     {
                         "in": "header",
@@ -14033,7 +14033,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -14129,8 +14129,8 @@
             },
             "delete": {
                 "operationId": "destroyCartItem",
-                "description": "Διαγραφή είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Διαγραφή αντικειμένου καλαθιού",
+                "description": "Delete a cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Delete a cart item",
                 "parameters": [
                     {
                         "in": "header",
@@ -14204,8 +14204,8 @@
         "/api/v1/cart/list": {
             "get": {
                 "operationId": "listCart",
-                "description": "Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.",
-                "summary": "Λήψη καλαθιού",
+                "description": "Get a cart. For guest users, include X-Cart-Id header to maintain cart session.",
+                "summary": "Get cart",
                 "parameters": [
                     {
                         "in": "header",
@@ -14227,7 +14227,7 @@
                                 "user"
                             ]
                         },
-                        "description": "Φίλτρο ανά τύπο καλαθιού\n\n* `user` - User Cart\n* `guest` - Guest Cart\n* `anonymous` - Anonymous Cart"
+                        "description": "Filter by cart type\n\n* `user` - User Cart\n* `guest` - Guest Cart\n* `anonymous` - Anonymous Cart"
                     },
                     {
                         "in": "query",
@@ -14277,7 +14277,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -14293,7 +14293,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών αδρανών για τουλάχιστον X ημέρες"
+                        "description": "Filter carts inactive for at least X days"
                     },
                     {
                         "in": "query",
@@ -14314,7 +14314,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με/χωρίς είδη σε έκπτωση"
+                        "description": "Filter carts with/without discounted items"
                     },
                     {
                         "in": "query",
@@ -14335,7 +14335,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με/χωρίς είδη"
+                        "description": "Filter carts that have/don't have items"
                     },
                     {
                         "in": "query",
@@ -14359,7 +14359,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -14392,7 +14392,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο εγκαταλελειμμένων καλαθιών (αδρανή για 30+ ημέρες)"
+                        "description": "Filter abandoned carts (inactive for 30+ days)"
                     },
                     {
                         "in": "query",
@@ -14413,7 +14413,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ενεργών/εγκαταλελειμμένων καλαθιών (βάσει 30 ημερών αδράνειας)"
+                        "description": "Filter active/abandoned carts (based on 30-day inactivity)"
                     },
                     {
                         "in": "query",
@@ -14434,7 +14434,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών επισκεπτών (True) ή καλαθιών χρηστών (False)"
+                        "description": "Filter guest carts (True) or user carts (False)"
                     },
                     {
                         "in": "query",
@@ -14448,7 +14448,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -14457,7 +14457,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ανά ακριβή ημερομηνία τελευταίας δραστηριότητας"
+                        "description": "Filter by exact last activity date"
                     },
                     {
                         "in": "query",
@@ -14490,7 +14490,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο καλαθιών με τελευταία δραστηριότητα μετά από αυτή την ημερομηνία"
+                        "description": "Filter carts with last activity after this date"
                     },
                     {
                         "in": "query",
@@ -14499,7 +14499,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο καλαθιών με τελευταία δραστηριότητα πριν από αυτή την ημερομηνία"
+                        "description": "Filter carts with last activity before this date"
                     },
                     {
                         "in": "query",
@@ -14515,7 +14515,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με έως X συνολικά είδη (ποσότητα)"
+                        "description": "Filter carts with at most X total items (quantity)"
                     },
                     {
                         "in": "query",
@@ -14531,7 +14531,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με συνολική αξία έως X"
+                        "description": "Filter carts with total value at most X"
                     },
                     {
                         "in": "query",
@@ -14547,7 +14547,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με έως X μοναδικά είδη"
+                        "description": "Filter carts with at most X unique items"
                     },
                     {
                         "in": "query",
@@ -14563,7 +14563,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με τουλάχιστον X συνολικά είδη (ποσότητα)"
+                        "description": "Filter carts with at least X total items (quantity)"
                     },
                     {
                         "in": "query",
@@ -14579,7 +14579,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με συνολική αξία τουλάχιστον X"
+                        "description": "Filter carts with total value at least X"
                     },
                     {
                         "in": "query",
@@ -14595,7 +14595,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με τουλάχιστον X μοναδικά είδη"
+                        "description": "Filter carts with at least X unique items"
                     },
                     {
                         "name": "ordering",
@@ -14638,7 +14638,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -14651,7 +14651,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -14665,7 +14665,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -14732,7 +14732,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -14753,7 +14753,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργούς χρήστες"
+                        "description": "Filter by active users"
                     },
                     {
                         "in": "query",
@@ -14774,7 +14774,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο καλαθιών με/χωρίς χρήστες"
+                        "description": "Filter carts with/without users"
                     },
                     {
                         "in": "query",
@@ -14782,7 +14782,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)"
+                        "description": "Filter by user email (partial match)"
                     },
                     {
                         "in": "query",
@@ -14790,7 +14790,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα χρήστη (όνομα ή επώνυμο)"
+                        "description": "Filter by user full name (first or last name)"
                     },
                     {
                         "in": "query",
@@ -14876,8 +14876,8 @@
         "/api/v1/cart/release-reservations": {
             "post": {
                 "operationId": "releaseCartReservations",
-                "description": "Απελευθέρωση δεσμεύσεων αποθέματος όταν το checkout εγκαταλείπεται ή η πληρωμή αποτυγχάνει. Αυτό καθιστά το δεσμευμένο απόθεμα διαθέσιμο για άλλους πελάτες.",
-                "summary": "Αποδέσμευση δεσμεύσεων αποθέματος",
+                "description": "Release stock reservations when checkout is abandoned or payment fails. This makes the reserved stock available for other customers.",
+                "summary": "Release stock reservations",
                 "parameters": [
                     {
                         "in": "header",
@@ -14985,8 +14985,8 @@
         "/api/v1/cart/reserve-stock": {
             "post": {
                 "operationId": "reserveCartStock",
-                "description": "Δέσμευση αποθέματος για όλα τα είδη του καλαθιού κατά το checkout. Δημιουργεί προσωρινές δεσμεύσεις αποθέματος με διάρκεια ζωής 15 λεπτών. Επιστρέφει λίστα ID δεσμεύσεων για χρήση κατά τη δημιουργία της παραγγελίας.",
-                "summary": "Δέσμευση αποθέματος για αντικείμενα καλαθιού",
+                "description": "Reserve stock for all items in the cart during checkout. Creates temporary stock reservations with 15-minute TTL. Returns list of reservation IDs to be used during order creation.",
+                "summary": "Reserve stock for cart items",
                 "parameters": [
                     {
                         "in": "header",
@@ -15074,8 +15074,8 @@
         "/api/v1/contact": {
             "post": {
                 "operationId": "createContact",
-                "description": "Αποστολή μηνύματος επικοινωνίας στους διαχειριστές του ιστότοπου.",
-                "summary": "Δημιουργία μηνύματος επικοινωνίας",
+                "description": "Send a contact message to the site administrators.",
+                "summary": "Create a contact message",
                 "tags": [
                     "Contact"
                 ],
@@ -15132,8 +15132,8 @@
         "/api/v1/country": {
             "get": {
                 "operationId": "listCountry",
-                "description": "Ανάκτηση λίστας Χώρες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Χώρες",
+                "description": "Retrieve a list of Countries with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Countries",
                 "parameters": [
                     {
                         "in": "query",
@@ -15141,7 +15141,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή διψήφιο κωδικό χώρας"
+                        "description": "Filter by exact 2-letter country code"
                     },
                     {
                         "in": "query",
@@ -15149,7 +15149,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά διψήφιο κωδικό χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by 2-letter country code (partial match)"
                     },
                     {
                         "in": "query",
@@ -15165,7 +15165,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -15185,7 +15185,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή τριψήφιο κωδικό χώρας"
+                        "description": "Filter by exact 3-letter country code"
                     },
                     {
                         "in": "query",
@@ -15193,7 +15193,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τριψήφιο κωδικό χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by 3-letter country code (partial match)"
                     },
                     {
                         "in": "query",
@@ -15209,7 +15209,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -15238,7 +15238,7 @@
                                 "SA"
                             ]
                         },
-                        "description": "Φίλτρο ανά ήπειρο (βάσει κωδικών ISO)\n\n* `AF` - Africa\n* `AS` - Asia\n* `EU` - Europe\n* `NA` - North America\n* `OC` - Oceania\n* `SA` - South America\n* `AN` - Antarctica"
+                        "description": "Filter by continent (based on ISO codes)\n\n* `AF` - Africa\n* `AS` - Asia\n* `EU` - Europe\n* `NA` - North America\n* `OC` - Oceania\n* `SA` - South America\n* `AN` - Antarctica"
                     },
                     {
                         "in": "query",
@@ -15288,7 +15288,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -15309,7 +15309,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με πλήρη δεδομένα (ISO, κλήση, σημαία, όνομα)"
+                        "description": "Filter countries that have complete data (ISO, phone, flag, name)"
                     },
                     {
                         "in": "query",
@@ -15330,7 +15330,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με/χωρίς εικόνα σημαίας"
+                        "description": "Filter countries that have/don't have flag image"
                     },
                     {
                         "in": "query",
@@ -15351,7 +15351,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με/χωρίς κωδικό ISO"
+                        "description": "Filter countries that have/don't have ISO country code"
                     },
                     {
                         "in": "query",
@@ -15372,7 +15372,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με/χωρίς μετάφραση ονόματος"
+                        "description": "Filter countries that have/don't have name translation"
                     },
                     {
                         "in": "query",
@@ -15393,7 +15393,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με/χωρίς κωδικό κλήσης"
+                        "description": "Filter countries that have/don't have phone code"
                     },
                     {
                         "in": "query",
@@ -15414,7 +15414,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών μελών ΕΕ"
+                        "description": "Filter EU member countries"
                     },
                     {
                         "in": "query",
@@ -15430,7 +15430,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή ISO κωδικό χώρας"
+                        "description": "Filter by exact ISO country code"
                     },
                     {
                         "in": "query",
@@ -15454,7 +15454,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -15497,7 +15497,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με κωδικό ISO μικρότερο ή ίσο με"
+                        "description": "Filter countries with ISO code less than or equal to"
                     },
                     {
                         "in": "query",
@@ -15513,7 +15513,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με κωδικό ISO μεγαλύτερο ή ίσο με"
+                        "description": "Filter countries with ISO code greater than or equal to"
                     },
                     {
                         "in": "query",
@@ -15527,7 +15527,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -15535,7 +15535,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλούς κωδικούς χωρών (διαχωρισμένους με κόμμα, alpha-2 ή alpha-3)"
+                        "description": "Filter by multiple country codes (comma-separated, alpha-2 or alpha-3)"
                     },
                     {
                         "in": "query",
@@ -15543,7 +15543,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by country name (partial match)"
                     },
                     {
                         "in": "query",
@@ -15551,7 +15551,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβές όνομα χώρας"
+                        "description": "Filter by exact country name"
                     },
                     {
                         "in": "query",
@@ -15559,7 +15559,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο χωρών με όνομα που ξεκινά με"
+                        "description": "Filter countries with names starting with"
                     },
                     {
                         "name": "ordering",
@@ -15602,7 +15602,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -15615,7 +15615,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -15629,7 +15629,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -15645,7 +15645,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή κωδικό κλήσης"
+                        "description": "Filter by exact phone code"
                     },
                     {
                         "in": "query",
@@ -15669,7 +15669,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -15712,7 +15712,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με κωδικό κλήσης μικρότερο ή ίσο με"
+                        "description": "Filter countries with phone code less than or equal to"
                     },
                     {
                         "in": "query",
@@ -15728,7 +15728,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χωρών με κωδικό κλήσης μεγαλύτερο ή ίσο με"
+                        "description": "Filter countries with phone code greater than or equal to"
                     },
                     {
                         "name": "search",
@@ -15909,8 +15909,8 @@
             },
             "post": {
                 "operationId": "createCountry",
-                "description": "Δημιουργία νέου Χώρα. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Χώρα",
+                "description": "Create a new Country. Requires authentication.",
+                "summary": "Create a Country",
                 "parameters": [
                     {
                         "in": "query",
@@ -15924,7 +15924,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -16022,17 +16022,17 @@
         "/api/v1/country/{alpha_2}": {
             "get": {
                 "operationId": "retrieveCountry",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χώρα.",
-                "summary": "Ανάκτηση Χώρα",
+                "description": "Get detailed information about a specific Country.",
+                "summary": "Retrieve a Country",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha2",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός Χώρας (Alpha 2)"
+                            "title": "Country Code Alpha 2"
                         },
-                        "description": "A unique value identifying this Χώρα.",
+                        "description": "A unique value identifying this Country.",
                         "required": true
                     },
                     {
@@ -16047,7 +16047,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -16114,17 +16114,17 @@
             },
             "put": {
                 "operationId": "updateCountry",
-                "description": "Ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Χώρα",
+                "description": "Update Country information. Requires authentication.",
+                "summary": "Update a Country",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha2",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός Χώρας (Alpha 2)"
+                            "title": "Country Code Alpha 2"
                         },
-                        "description": "A unique value identifying this Χώρα.",
+                        "description": "A unique value identifying this Country.",
                         "required": true
                     },
                     {
@@ -16139,7 +16139,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -16235,17 +16235,17 @@
             },
             "patch": {
                 "operationId": "partialUpdateCountry",
-                "description": "Μερική ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Χώρα",
+                "description": "Partially update Country information. Requires authentication.",
+                "summary": "Partially update a Country",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha2",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός Χώρας (Alpha 2)"
+                            "title": "Country Code Alpha 2"
                         },
-                        "description": "A unique value identifying this Χώρα.",
+                        "description": "A unique value identifying this Country.",
                         "required": true
                     },
                     {
@@ -16260,7 +16260,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -16355,17 +16355,17 @@
             },
             "delete": {
                 "operationId": "destroyCountry",
-                "description": "Διαγραφή Χώρα. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Χώρα",
+                "description": "Delete a Country. Requires authentication.",
+                "summary": "Delete a Country",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha2",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός Χώρας (Alpha 2)"
+                            "title": "Country Code Alpha 2"
                         },
-                        "description": "A unique value identifying this Χώρα.",
+                        "description": "A unique value identifying this Country.",
                         "required": true
                     }
                 ],
@@ -16417,8 +16417,8 @@
         "/api/v1/health": {
             "get": {
                 "operationId": "api_v1_health_retrieve",
-                "description": "Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery",
-                "summary": "Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery",
+                "description": "Check the health status of database, Redis, and Celery",
+                "summary": "Check the health status of database, Redis, and Celery",
                 "tags": [
                     "Health"
                 ],
@@ -16445,8 +16445,8 @@
         "/api/v1/loyalty/product/{id}/points": {
             "get": {
                 "operationId": "getProductLoyaltyPoints",
-                "description": "Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος",
-                "summary": "Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος",
+                "description": "Get product loyalty points preview",
+                "summary": "Get product loyalty points preview",
                 "parameters": [
                     {
                         "in": "path",
@@ -16540,8 +16540,8 @@
         "/api/v1/loyalty/redeem": {
             "post": {
                 "operationId": "redeemLoyaltyPoints",
-                "description": "Εξαργύρωση πόντων πιστότητας",
-                "summary": "Εξαργύρωση πόντων πιστότητας",
+                "description": "Redeem loyalty points",
+                "summary": "Redeem loyalty points",
                 "tags": [
                     "Loyalty"
                 ],
@@ -16637,8 +16637,8 @@
         "/api/v1/loyalty/summary": {
             "get": {
                 "operationId": "getLoyaltySummary",
-                "description": "Λήψη σύνοψης πιστότητας",
-                "summary": "Λήψη σύνοψης πιστότητας",
+                "description": "Get loyalty summary",
+                "summary": "Get loyalty summary",
                 "tags": [
                     "Loyalty"
                 ],
@@ -16714,8 +16714,8 @@
         "/api/v1/loyalty/tiers": {
             "get": {
                 "operationId": "listLoyaltyTiers",
-                "description": "Λίστα όλων των tier πιστότητας",
-                "summary": "Λίστα όλων των tier πιστότητας",
+                "description": "List all loyalty tiers",
+                "summary": "List all loyalty tiers",
                 "parameters": [
                     {
                         "name": "page",
@@ -16836,8 +16836,8 @@
         "/api/v1/loyalty/transactions": {
             "get": {
                 "operationId": "listLoyaltyTransactions",
-                "description": "Λίστα συναλλαγών πιστότητας",
-                "summary": "Λίστα συναλλαγών πιστότητας",
+                "description": "List loyalty transactions",
+                "summary": "List loyalty transactions",
                 "parameters": [
                     {
                         "name": "page",
@@ -16958,8 +16958,8 @@
         "/api/v1/notification/ids": {
             "post": {
                 "operationId": "getNotificationsByIds",
-                "description": "Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.",
-                "summary": "Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.",
+                "description": "Returns the notifications for a list of ids.",
+                "summary": "Returns the notifications for a list of ids.",
                 "parameters": [
                     {
                         "in": "query",
@@ -16980,7 +16980,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδοποιήσεων κατά κατάσταση προβολής. Αν είναι false, επιστρέφει μόνο τις μη ορατές ειδοποιήσεις."
+                        "description": "Filter notifications by seen status. If false, returns only unseen notifications."
                     }
                 ],
                 "tags": [
@@ -17031,8 +17031,8 @@
         "/api/v1/notification/user": {
             "get": {
                 "operationId": "listNotificationUser",
-                "description": "Ανάκτηση λίστας Χρήστες ειδοποίησης με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Χρήστες ειδοποίησης",
+                "description": "Retrieve a list of Notification Users with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Notification Users",
                 "parameters": [
                     {
                         "in": "query",
@@ -17082,7 +17082,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -17103,7 +17103,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδοποιήσεων που έχουν προβληθεί (true) ή όχι (false)"
+                        "description": "Filter notifications that have been seen (true) or not seen (false)"
                     },
                     {
                         "in": "query",
@@ -17124,7 +17124,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδοποιήσεων υψηλής προτεραιότητας"
+                        "description": "Filter high priority notifications"
                     },
                     {
                         "in": "query",
@@ -17148,7 +17148,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -17174,7 +17174,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -17190,7 +17190,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID ειδοποίησης"
+                        "description": "Filter by notification ID"
                     },
                     {
                         "in": "query",
@@ -17198,7 +17198,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κατηγορία ειδοποίησης"
+                        "description": "Filter by notification category"
                     },
                     {
                         "in": "query",
@@ -17207,7 +17207,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ειδοποιήσεων που λήγουν μετά από αυτή την ημερομηνία"
+                        "description": "Filter notifications expiring after this date"
                     },
                     {
                         "in": "query",
@@ -17216,7 +17216,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ειδοποιήσεων που λήγουν πριν από αυτή την ημερομηνία"
+                        "description": "Filter notifications expiring before this date"
                     },
                     {
                         "in": "query",
@@ -17237,7 +17237,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση λήξης ειδοποίησης"
+                        "description": "Filter by notification expiry status"
                     },
                     {
                         "in": "query",
@@ -17245,7 +17245,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο ειδοποίησης"
+                        "description": "Filter by notification kind"
                     },
                     {
                         "in": "query",
@@ -17253,7 +17253,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά σύνδεσμο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by notification link (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17261,7 +17261,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά μήνυμα ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by notification message (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17269,7 +17269,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά προτεραιότητα ειδοποίησης"
+                        "description": "Filter by notification priority"
                     },
                     {
                         "in": "query",
@@ -17277,7 +17277,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τίτλο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by notification title (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17285,7 +17285,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by notification type (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17293,7 +17293,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID ειδοποιήσεων (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple notification IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -17301,7 +17301,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο ειδοποίησης"
+                        "description": "Filter by notification kind"
                     },
                     {
                         "name": "ordering",
@@ -17344,7 +17344,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -17357,7 +17357,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -17371,7 +17371,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -17392,7 +17392,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδοποιήσεων των τελευταίων 7 ημερών"
+                        "description": "Filter notifications from the last 7 days"
                     },
                     {
                         "name": "search",
@@ -17422,7 +17422,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση προβολής"
+                        "description": "Filter by seen status"
                     },
                     {
                         "in": "query",
@@ -17431,7 +17431,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ειδοποιήσεων που προβλήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter notifications seen after this date"
                     },
                     {
                         "in": "query",
@@ -17464,7 +17464,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο ειδοποιήσεων που προβλήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter notifications seen before this date"
                     },
                     {
                         "in": "query",
@@ -17485,7 +17485,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μόνο ορατών ειδοποιήσεων"
+                        "description": "Filter only seen notifications"
                     },
                     {
                         "in": "query",
@@ -17506,7 +17506,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μόνο μη ορατών ειδοποιήσεων"
+                        "description": "Filter only unseen notifications"
                     },
                     {
                         "in": "query",
@@ -17564,7 +17564,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -17572,7 +17572,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17580,7 +17580,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17601,7 +17601,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση χρήστη"
+                        "description": "Filter by user active status"
                     },
                     {
                         "in": "query",
@@ -17622,7 +17622,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά staff status χρήστη"
+                        "description": "Filter by user staff status"
                     },
                     {
                         "in": "query",
@@ -17630,7 +17630,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user last name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -17638,7 +17638,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple user IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -17724,8 +17724,8 @@
         "/api/v1/notification/user/{id}": {
             "get": {
                 "operationId": "retrieveNotificationUser",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραλήπτης Ειδοποίησης.",
-                "summary": "Ανάκτηση Παραλήπτης Ειδοποίησης",
+                "description": "Get detailed information about a specific Notification User.",
+                "summary": "Retrieve a Notification User",
                 "parameters": [
                     {
                         "in": "path",
@@ -17747,7 +17747,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -17813,8 +17813,8 @@
             },
             "put": {
                 "operationId": "updateNotificationUser",
-                "description": "Ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Παραλήπτης Ειδοποίησης",
+                "description": "Update Notification User information. Requires authentication.",
+                "summary": "Update a Notification User",
                 "parameters": [
                     {
                         "in": "path",
@@ -17836,7 +17836,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -17931,8 +17931,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateNotificationUser",
-                "description": "Μερική ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Παραλήπτης Ειδοποίησης",
+                "description": "Partially update Notification User information. Requires authentication.",
+                "summary": "Partially update a Notification User",
                 "parameters": [
                     {
                         "in": "path",
@@ -17954,7 +17954,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -18049,8 +18049,8 @@
             },
             "delete": {
                 "operationId": "destroyNotificationUser",
-                "description": "Διαγραφή Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Παραλήπτης Ειδοποίησης",
+                "description": "Delete a Notification User. Requires authentication.",
+                "summary": "Delete a Notification User",
                 "parameters": [
                     {
                         "in": "path",
@@ -18109,8 +18109,8 @@
         "/api/v1/notification/user/mark_all_as_seen": {
             "post": {
                 "operationId": "markAllNotificationUsersAsSeen",
-                "description": "Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως ορατών.",
-                "summary": "Σήμανση όλων ως ορατές",
+                "description": "Mark all of the authenticated user's notifications as seen.",
+                "summary": "Mark all notifications as seen",
                 "tags": [
                     "Notification Users"
                 ],
@@ -18186,8 +18186,8 @@
         "/api/v1/notification/user/mark_all_as_unseen": {
             "post": {
                 "operationId": "markAllNotificationUsersAsUnseen",
-                "description": "Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως μη ορατών.",
-                "summary": "Σήμανση όλων ως μη ορατές",
+                "description": "Mark all of the authenticated user's notifications as unseen.",
+                "summary": "Mark all notifications as unseen",
                 "tags": [
                     "Notification Users"
                 ],
@@ -18263,8 +18263,8 @@
         "/api/v1/notification/user/mark_as_seen": {
             "post": {
                 "operationId": "markNotificationUsersAsSeen",
-                "description": "Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών για τον συνδεδεμένο χρήστη.",
-                "summary": "Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών",
+                "description": "Mark specific notifications as seen for the authenticated user.",
+                "summary": "Mark specific notifications as seen",
                 "tags": [
                     "Notification Users"
                 ],
@@ -18360,8 +18360,8 @@
         "/api/v1/notification/user/mark_as_unseen": {
             "post": {
                 "operationId": "markNotificationUsersAsUnseen",
-                "description": "Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών για τον συνδεδεμένο χρήστη.",
-                "summary": "Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών",
+                "description": "Mark specific notifications as unseen for the authenticated user.",
+                "summary": "Mark specific notifications as unseen",
                 "tags": [
                     "Notification Users"
                 ],
@@ -18457,8 +18457,8 @@
         "/api/v1/notification/user/unseen_count": {
             "get": {
                 "operationId": "getNotificationUserUnseenCount",
-                "description": "Λήψη του πλήθους μη ορατών ειδοποιήσεων για τον συνδεδεμένο χρήστη.",
-                "summary": "Λήψη πλήθους μη ορατών ειδοποιήσεων",
+                "description": "Get the count of unseen notifications for the authenticated user.",
+                "summary": "Get unseen notifications count",
                 "tags": [
                     "Notification Users"
                 ],
@@ -18534,8 +18534,8 @@
         "/api/v1/order": {
             "get": {
                 "operationId": "listOrder",
-                "description": "Ανάκτηση λίστας Παραγγελίες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Παραγγελίες",
+                "description": "Retrieve a list of Orders with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Orders",
                 "parameters": [
                     {
                         "in": "query",
@@ -18556,7 +18556,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)"
+                        "description": "Filter active orders (pending, processing, shipped, delivered)"
                     },
                     {
                         "in": "query",
@@ -18577,7 +18577,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών που μπορούν να ακυρωθούν"
+                        "description": "Filter orders that can be canceled"
                     },
                     {
                         "in": "query",
@@ -18585,7 +18585,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)"
+                        "description": "Filter by city (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -18600,7 +18600,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό χώρας"
+                        "description": "Filter by country code"
                     },
                     {
                         "in": "query",
@@ -18608,7 +18608,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά alpha-2 κωδικό χώρας"
+                        "description": "Filter by country alpha-2 code"
                     },
                     {
                         "in": "query",
@@ -18616,7 +18616,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by country name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -18624,7 +18624,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple country IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -18674,7 +18674,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -18696,7 +18696,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο εγγράφου"
+                        "description": "Filter by document type"
                     },
                     {
                         "in": "query",
@@ -18704,7 +18704,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -18732,7 +18732,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)"
+                        "description": "Filter final orders (completed, canceled, refunded)"
                     },
                     {
                         "in": "query",
@@ -18740,7 +18740,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -18755,7 +18755,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όροφο"
+                        "description": "Filter by floor"
                     },
                     {
                         "in": "query",
@@ -18776,7 +18776,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη"
+                        "description": "Filter orders that have/don't have customer notes"
                     },
                     {
                         "in": "query",
@@ -18797,7 +18797,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς ID πληρωμής"
+                        "description": "Filter orders that have/don't have payment ID"
                     },
                     {
                         "in": "query",
@@ -18818,7 +18818,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης"
+                        "description": "Filter orders that have status update timestamp"
                     },
                     {
                         "in": "query",
@@ -18839,7 +18839,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης"
+                        "description": "Filter orders that have/don't have tracking number"
                     },
                     {
                         "in": "query",
@@ -18860,7 +18860,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς χρήστη"
+                        "description": "Filter orders that have/don't have a user"
                     },
                     {
                         "in": "query",
@@ -18884,7 +18884,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -18917,7 +18917,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ακυρωμένων παραγγελιών"
+                        "description": "Filter canceled orders"
                     },
                     {
                         "in": "query",
@@ -18938,7 +18938,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ολοκληρωμένων παραγγελιών"
+                        "description": "Filter completed orders"
                     },
                     {
                         "in": "query",
@@ -18959,7 +18959,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών"
+                        "description": "Filter paid/unpaid orders"
                     },
                     {
                         "in": "query",
@@ -18973,7 +18973,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -18981,7 +18981,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer last name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -18996,7 +18996,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο τοποθεσίας"
+                        "description": "Filter by location type"
                     },
                     {
                         "in": "query",
@@ -19017,7 +19017,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών που χρειάζονται επεξεργασία"
+                        "description": "Filter orders that need processing"
                     },
                     {
                         "name": "ordering",
@@ -19060,7 +19060,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -19073,7 +19073,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -19087,7 +19087,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -19133,7 +19133,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστο πληρωμένο ποσό"
+                        "description": "Filter by maximum paid amount"
                     },
                     {
                         "in": "query",
@@ -19149,7 +19149,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο πληρωμένο ποσό"
+                        "description": "Filter by minimum paid amount"
                     },
                     {
                         "in": "query",
@@ -19165,7 +19165,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID μεθόδου πληρωμής"
+                        "description": "Filter by payment method ID"
                     },
                     {
                         "in": "query",
@@ -19186,7 +19186,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά online μεθόδους πληρωμής"
+                        "description": "Filter by online payment methods"
                     },
                     {
                         "in": "query",
@@ -19194,7 +19194,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by payment method name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19202,7 +19202,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ID πληρωμής"
+                        "description": "Filter by payment ID"
                     },
                     {
                         "in": "query",
@@ -19217,7 +19217,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά μέθοδο πληρωμής"
+                        "description": "Filter by payment method"
                     },
                     {
                         "in": "query",
@@ -19231,7 +19231,6 @@
                         "name": "paymentStatus",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση πληρωμής",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -19242,7 +19241,7 @@
                                 "REFUNDED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση πληρωμής\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε"
+                        "description": "Filter by payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled"
                     },
                     {
                         "in": "query",
@@ -19251,7 +19250,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -19271,7 +19270,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό τηλεφώνου"
+                        "description": "Filter by phone number"
                     },
                     {
                         "in": "query",
@@ -19286,7 +19285,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by place (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19314,7 +19313,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών των τελευταίων 30 ημερών"
+                        "description": "Filter orders from the last 30 days"
                     },
                     {
                         "in": "query",
@@ -19322,7 +19321,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό περιφέρειας"
+                        "description": "Filter by region code"
                     },
                     {
                         "in": "query",
@@ -19330,7 +19329,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by region name (case-insensitive)"
                     },
                     {
                         "name": "search",
@@ -19347,7 +19346,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά εταιρεία μεταφοράς"
+                        "description": "Filter by shipping carrier"
                     },
                     {
                         "in": "query",
@@ -19400,7 +19399,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστα έξοδα αποστολής"
+                        "description": "Filter by maximum shipping price"
                     },
                     {
                         "in": "query",
@@ -19416,14 +19415,13 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστα έξοδα αποστολής"
+                        "description": "Filter by minimum shipping price"
                     },
                     {
                         "in": "query",
                         "name": "status",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -19435,7 +19433,7 @@
                                 "SHIPPED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων"
+                        "description": "Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded"
                     },
                     {
                         "in": "query",
@@ -19444,7 +19442,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -19464,7 +19462,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)"
+                        "description": "Filter by multiple statuses (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -19473,7 +19471,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία"
+                        "description": "Filter orders with status updated after this date"
                     },
                     {
                         "in": "query",
@@ -19506,7 +19504,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία"
+                        "description": "Filter orders with status updated before this date"
                     },
                     {
                         "in": "query",
@@ -19514,7 +19512,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by street (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19529,7 +19527,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό"
+                        "description": "Filter by street number"
                     },
                     {
                         "in": "query",
@@ -19544,7 +19542,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό παρακολούθησης"
+                        "description": "Filter by tracking number"
                     },
                     {
                         "in": "query",
@@ -19609,7 +19607,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -19617,7 +19615,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19625,7 +19623,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19646,7 +19644,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση χρήστη"
+                        "description": "Filter by user active status"
                     },
                     {
                         "in": "query",
@@ -19654,7 +19652,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user last name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -19662,7 +19660,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple user IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -19678,7 +19676,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά Τ.Κ."
+                        "description": "Filter by zipcode"
                     }
                 ],
                 "tags": [
@@ -19754,8 +19752,8 @@
             },
             "post": {
                 "operationId": "createOrder",
-                "description": "Δημιουργία νέου Παραγγελία. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Παραγγελία",
+                "description": "Create a new Ταξινόμηση. Requires authentication.",
+                "summary": "Create a Ταξινόμηση",
                 "parameters": [
                     {
                         "in": "query",
@@ -19769,7 +19767,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -19867,8 +19865,8 @@
         "/api/v1/order-items": {
             "get": {
                 "operationId": "listOrderItem",
-                "description": "Ανάκτηση λίστας Προϊόντα Παραγγελίας με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Προϊόντα Παραγγελίας",
+                "description": "Retrieve a list of Order Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Order Items",
                 "parameters": [
                     {
                         "in": "query",
@@ -19889,7 +19887,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χονδρικής (ποσότητα > 5)"
+                        "description": "Filter bulk items (quantity > 5)"
                     },
                     {
                         "in": "query",
@@ -19939,7 +19937,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -19960,7 +19958,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών με/χωρίς σημειώσεις"
+                        "description": "Filter items that have/don't have notes"
                     },
                     {
                         "in": "query",
@@ -19981,7 +19979,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών με/χωρίς ποσότητα επιστροφής"
+                        "description": "Filter items that have/don't have refunded quantity"
                     },
                     {
                         "in": "query",
@@ -20002,7 +20000,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών υψηλής αξίας (τιμή > 100)"
+                        "description": "Filter high value items (price > 100)"
                     },
                     {
                         "in": "query",
@@ -20026,7 +20024,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -20059,7 +20057,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο πλήρως επιστραμμένων αντικειμένων"
+                        "description": "Filter fully refunded items"
                     },
                     {
                         "in": "query",
@@ -20080,7 +20078,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μερικώς επιστραμμένων αντικειμένων"
+                        "description": "Filter partially refunded items"
                     },
                     {
                         "in": "query",
@@ -20101,7 +20099,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση επιστροφής χρημάτων"
+                        "description": "Filter by refund status"
                     },
                     {
                         "in": "query",
@@ -20115,7 +20113,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -20123,7 +20121,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σημειώσεων (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by notes content (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20146,7 +20144,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID παραγγελίας"
+                        "description": "Filter by order ID"
                     },
                     {
                         "in": "query",
@@ -20154,7 +20152,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό χώρας παραγγελίας"
+                        "description": "Filter by order country code"
                     },
                     {
                         "in": "query",
@@ -20162,7 +20160,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by order customer email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20170,7 +20168,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by order customer first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20178,14 +20176,13 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by order customer last name (case-insensitive)"
                     },
                     {
                         "in": "query",
                         "name": "order_PaymentStatus",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση πληρωμής",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -20196,7 +20193,7 @@
                                 "REFUNDED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση πληρωμής παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε"
+                        "description": "Filter by order payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled"
                     },
                     {
                         "in": "query",
@@ -20204,14 +20201,13 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό περιφέρειας παραγγελίας"
+                        "description": "Filter by order region code"
                     },
                     {
                         "in": "query",
                         "name": "order_Status",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -20223,7 +20219,7 @@
                                 "SHIPPED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων"
+                        "description": "Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded"
                     },
                     {
                         "in": "query",
@@ -20239,7 +20235,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη παραγγελίας"
+                        "description": "Filter by order user ID"
                     },
                     {
                         "in": "query",
@@ -20247,7 +20243,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by order user email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20255,7 +20251,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID παραγγελιών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple order IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -20263,7 +20259,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλές καταστάσεις παραγγελιών (διαχωρισμένες με κόμμα)"
+                        "description": "Filter by multiple order statuses (comma-separated)"
                     },
                     {
                         "name": "ordering",
@@ -20334,7 +20330,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη αρχική ποσότητα"
+                        "description": "Filter by maximum original quantity"
                     },
                     {
                         "in": "query",
@@ -20350,7 +20346,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη αρχική ποσότητα"
+                        "description": "Filter by minimum original quantity"
                     },
                     {
                         "name": "page",
@@ -20383,7 +20379,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -20396,7 +20392,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -20410,7 +20406,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -20471,7 +20467,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή τιμή"
+                        "description": "Filter by exact price"
                     },
                     {
                         "in": "query",
@@ -20487,7 +20483,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη τιμή"
+                        "description": "Filter by maximum price"
                     },
                     {
                         "in": "query",
@@ -20503,7 +20499,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη τιμή"
+                        "description": "Filter by minimum price"
                     },
                     {
                         "in": "query",
@@ -20519,7 +20515,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID προϊόντος"
+                        "description": "Filter by product ID"
                     },
                     {
                         "in": "query",
@@ -20540,7 +20536,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση προϊόντος"
+                        "description": "Filter by product active status"
                     },
                     {
                         "in": "query",
@@ -20556,7 +20552,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας προϊόντος"
+                        "description": "Filter by product category ID"
                     },
                     {
                         "in": "query",
@@ -20564,7 +20560,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα κατηγορίας προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by product category name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20572,7 +20568,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by product name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -20580,7 +20576,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά SKU προϊόντος"
+                        "description": "Filter by product SKU"
                     },
                     {
                         "in": "query",
@@ -20588,7 +20584,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID προϊόντων (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple product IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -20649,7 +20645,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή ποσότητα"
+                        "description": "Filter by exact quantity"
                     },
                     {
                         "in": "query",
@@ -20665,7 +20661,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη ποσότητα"
+                        "description": "Filter by maximum quantity"
                     },
                     {
                         "in": "query",
@@ -20681,7 +20677,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη ποσότητα"
+                        "description": "Filter by minimum quantity"
                     },
                     {
                         "in": "query",
@@ -20702,7 +20698,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδών των τελευταίων 7 ημερών"
+                        "description": "Filter items from the last 7 days"
                     },
                     {
                         "in": "query",
@@ -20763,7 +20759,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη ποσότητα επιστροφής"
+                        "description": "Filter by maximum refunded quantity"
                     },
                     {
                         "in": "query",
@@ -20779,7 +20775,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη ποσότητα επιστροφής"
+                        "description": "Filter by minimum refunded quantity"
                     },
                     {
                         "name": "search",
@@ -20959,8 +20955,8 @@
             },
             "post": {
                 "operationId": "createOrderItem",
-                "description": "Δημιουργία νέου Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Είδος Παραγγελίας",
+                "description": "Create a new Order Item. Requires authentication.",
+                "summary": "Create a Order Item",
                 "parameters": [
                     {
                         "in": "query",
@@ -20974,7 +20970,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21072,8 +21068,8 @@
         "/api/v1/order-items/{id}": {
             "get": {
                 "operationId": "retrieveOrderItem",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Είδος Παραγγελίας.",
-                "summary": "Ανάκτηση Είδος Παραγγελίας",
+                "description": "Get detailed information about a specific Order Item.",
+                "summary": "Retrieve a Order Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -21103,7 +21099,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21169,8 +21165,8 @@
             },
             "put": {
                 "operationId": "updateOrderItem",
-                "description": "Ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Είδος Παραγγελίας",
+                "description": "Update Order Item information. Requires authentication.",
+                "summary": "Update a Order Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -21200,7 +21196,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21296,8 +21292,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateOrderItem",
-                "description": "Μερική ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Είδος Παραγγελίας",
+                "description": "Partially update Order Item information. Requires authentication.",
+                "summary": "Partially update a Order Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -21327,7 +21323,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21422,8 +21418,8 @@
             },
             "delete": {
                 "operationId": "destroyOrderItem",
-                "description": "Διαγραφή Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Είδος Παραγγελίας",
+                "description": "Delete a Order Item. Requires authentication.",
+                "summary": "Delete a Order Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -21490,8 +21486,8 @@
         "/api/v1/order-items/{id}/refund": {
             "post": {
                 "operationId": "refundOrderItem",
-                "description": "Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας.",
-                "summary": "Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας",
+                "description": "Process a refund for an order item.",
+                "summary": "Process a refund for an order item",
                 "parameters": [
                     {
                         "in": "path",
@@ -21604,8 +21600,8 @@
         "/api/v1/order/{id}": {
             "get": {
                 "operationId": "retrieveOrder",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραγγελία.",
-                "summary": "Ανάκτηση Παραγγελία",
+                "description": "Get detailed information about a specific Ταξινόμηση.",
+                "summary": "Retrieve a Ταξινόμηση",
                 "parameters": [
                     {
                         "in": "path",
@@ -21635,7 +21631,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21701,8 +21697,8 @@
             },
             "put": {
                 "operationId": "updateOrder",
-                "description": "Ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Παραγγελία",
+                "description": "Update Ταξινόμηση information. Requires authentication.",
+                "summary": "Update a Ταξινόμηση",
                 "parameters": [
                     {
                         "in": "path",
@@ -21732,7 +21728,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21828,8 +21824,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateOrder",
-                "description": "Μερική ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Παραγγελία",
+                "description": "Partially update Ταξινόμηση information. Requires authentication.",
+                "summary": "Partially update a Ταξινόμηση",
                 "parameters": [
                     {
                         "in": "path",
@@ -21859,7 +21855,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -21954,8 +21950,8 @@
             },
             "delete": {
                 "operationId": "destroyOrder",
-                "description": "Διαγραφή Παραγγελία. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Παραγγελία",
+                "description": "Delete a Ταξινόμηση. Requires authentication.",
+                "summary": "Delete a Ταξινόμηση",
                 "parameters": [
                     {
                         "in": "path",
@@ -22022,8 +22018,8 @@
         "/api/v1/order/{id}/acs_cancel": {
             "post": {
                 "operationId": "cancelAcsShipmentForOrder",
-                "description": "Μόνο για διαχειριστές. Καλεί το ACS_Delete_Voucher. Έγκυρο μόνο πριν το voucher οριστικοποιηθεί σε λίστα παραλαβής.",
-                "summary": "Ακύρωση της αποστολής ACS για παραγγελία",
+                "description": "Admin-only. Calls ACS_Delete_Voucher. Only valid before the voucher is finalised in a pickup list.",
+                "summary": "Cancel the ACS shipment for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22107,8 +22103,8 @@
         "/api/v1/order/{id}/acs_label": {
             "get": {
                 "operationId": "getAcsLabelForOrder",
-                "description": "Μεταδίδει το PDF ετικέτας ACS μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή ACS για την παραγγελία ή δεν έχει εκδοθεί ακόμα το voucher.",
-                "summary": "Λήψη του PDF ετικέτας voucher ACS για παραγγελία",
+                "description": "Streams the ACS label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no ACS shipment exists for the order or the voucher has not been minted yet.",
+                "summary": "Download the ACS voucher label PDF for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22192,8 +22188,8 @@
         "/api/v1/order/{id}/add_tracking": {
             "post": {
                 "operationId": "addOrderTracking",
-                "description": "Προσθήκη πληροφοριών παρακολούθησης σε υπάρχουσα παραγγελία",
-                "summary": "Προσθήκη πληροφοριών παρακολούθησης σε παραγγελία",
+                "description": "Add tracking information to an existing order",
+                "summary": "Add tracking information to an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22307,8 +22303,8 @@
         "/api/v1/order/{id}/boxnow_cancel": {
             "post": {
                 "operationId": "cancelBoxNowShipmentForOrder",
-                "description": "Μόνο για διαχειριστές. Ζητά ακύρωση δέματος μέσω του API του BoxNow. Έγκυρο μόνο όταν η κατάσταση δέματος είναι NEW (διαφορετικά σφάλμα BoxNow P420). Δέχεται προαιρετικό πεδίο ``reason`` στο σώμα του αιτήματος.",
-                "summary": "Ακύρωση της αποστολής BoxNow για παραγγελία",
+                "description": "Admin-only. Requests parcel cancellation via the BoxNow API. Only valid when the parcel state is NEW (BoxNow error P420 otherwise). Accepts an optional ``reason`` field in the request body.",
+                "summary": "Cancel the BoxNow shipment for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22392,8 +22388,8 @@
         "/api/v1/order/{id}/boxnow_label": {
             "get": {
                 "operationId": "getBoxNowLabelForOrder",
-                "description": "Μεταδίδει το PDF ετικέτας BoxNow μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή BoxNow για την παραγγελία ή δεν έχει ακόμα ανατεθεί ID δέματος.",
-                "summary": "Λήψη του PDF ετικέτας δέματος BoxNow για παραγγελία",
+                "description": "Streams the BoxNow label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no BoxNow shipment exists for the order or the parcel ID has not yet been assigned.",
+                "summary": "Download the BoxNow parcel label PDF for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22477,8 +22473,8 @@
         "/api/v1/order/{id}/cancel": {
             "post": {
                 "operationId": "cancelOrder",
-                "description": "Ακύρωση υπάρχουσας παραγγελίας και αποκατάσταση αποθέματος προϊόντων",
-                "summary": "Ακύρωση παραγγελίας",
+                "description": "Cancel an existing order and restore product stock",
+                "summary": "Cancel an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22706,8 +22702,8 @@
         "/api/v1/order/{id}/create_checkout_session": {
             "post": {
                 "operationId": "createOrderCheckoutSession",
-                "description": "Δημιουργία φιλοξενούμενης συνεδρίας checkout (Stripe ή Viva Wallet). Ο πελάτης θα ανακατευθυνθεί στη σελίδα πληρωμής του παρόχου για να ολοκληρώσει την πληρωμή.",
-                "summary": "Δημιουργία φιλοξενούμενης συνεδρίας checkout για παραγγελία",
+                "description": "Create a hosted checkout session (Stripe or Viva Wallet). The customer will be redirected to the provider's checkout page to complete payment.",
+                "summary": "Create a hosted checkout session for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22821,8 +22817,8 @@
         "/api/v1/order/{id}/create_payment_intent": {
             "post": {
                 "operationId": "createOrderPaymentIntent",
-                "description": "Δημιουργία payment intent για πληρωμές Stripe σε υπάρχουσα παραγγελία",
-                "summary": "Δημιουργία payment intent για παραγγελία",
+                "description": "Create a payment intent for Stripe payments on an existing order",
+                "summary": "Create a payment intent for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -22935,8 +22931,8 @@
         "/api/v1/order/{id}/invoice": {
             "get": {
                 "operationId": "retrieveOrderInvoice",
-                "description": "Επιστρέφει τα μεταδεδομένα τιμολογίου της παραγγελίας και ένα απόλυτο URL προς το endpoint λήψης μέσω ροής (``/order/{id}/invoice/download``). Το URL προστατεύεται από τον ίδιο έλεγχο δικαιώματος ιδιοκτήτη/διαχειριστή όπως και αυτό το endpoint μεταδεδομένων — δεν εκτίθενται ακατέργαστα URL αποθήκευσης στον client. 404 αν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα (π.χ. η παραγγελία δεν έχει ολοκληρωθεί).",
-                "summary": "Λήψη μεταδεδομένων λήψης τιμολογίου για παραγγελία",
+                "description": "Return the order's invoice metadata and an absolute URL to the streaming download endpoint (``/order/{id}/invoice/download``). The URL is gated by the same owner/admin permission check as this metadata endpoint — no raw storage URLs are exposed to the client. 404 if the invoice has not been generated yet (e.g. order not completed).",
+                "summary": "Get invoice download metadata for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23030,8 +23026,8 @@
         "/api/v1/order/{id}/invoice/download": {
             "get": {
                 "operationId": "downloadOrderInvoice",
-                "description": "Μεταδίδει το παραχθέν PDF μέσω ταυτοποίησης Django. 404 όταν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα. Ίδιος έλεγχος ιδιοκτησίας όπως και το endpoint μεταδεδομένων — επιστρέφει υπογεγραμμένη ροή S3 σε παραγωγή και ροή αρχείου συστήματος σε ανάπτυξη, χωρίς να εκθέτει το URL αποθήκευσης στον client.",
-                "summary": "Λήψη PDF τιμολογίου",
+                "description": "Streams the rendered PDF through Django auth. 404 when the invoice has not been generated yet. Same ownership check as the metadata endpoint — returns a signed S3 stream on prod and a filesystem stream in dev without exposing the storage URL to the client.",
+                "summary": "Download the invoice PDF",
                 "parameters": [
                     {
                         "in": "path",
@@ -23071,8 +23067,8 @@
         "/api/v1/order/{id}/payment_status": {
             "get": {
                 "operationId": "getOrderPaymentStatus",
-                "description": "Ανάκτηση της τρέχουσας κατάστασης πληρωμής από τον πάροχο πληρωμών. Αυτό λαμβάνει την πιο πρόσφατη κατάσταση απευθείας από το Stripe/PayPal.",
-                "summary": "Λήψη κατάστασης πληρωμής παραγγελίας",
+                "description": "Retrieve the current payment status from the payment provider. This fetches the latest status directly from Stripe/PayPal.",
+                "summary": "Get payment status for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23166,8 +23162,8 @@
         "/api/v1/order/{id}/reorder": {
             "post": {
                 "operationId": "reorderOrder",
-                "description": "Αντιγραφή κάθε είδους από προηγούμενη παραγγελία πίσω στο ενεργό καλάθι του συνδεδεμένου χρήστη. Τα είδη των οποίων τα προϊόντα είναι ανενεργά ή εξαντλημένα επιστρέφονται στο skipped_items· οι ποσότητες περιορίζονται στο τρέχον απόθεμα.",
-                "summary": "Επανάληψη παραγγελίας των ειδών από προηγούμενη παραγγελία",
+                "description": "Copy each item from a past order back into the authenticated user's active cart. Items whose products are inactive or out of stock are returned in skipped_items; quantities are capped at current stock.",
+                "summary": "Reorder the items from a past order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23261,8 +23257,8 @@
         "/api/v1/order/{id}/retry-payment": {
             "post": {
                 "operationId": "retryOrderPayment",
-                "description": "Δημιουργία νέου Stripe PaymentIntent για παραγγελία της οποίας η προηγούμενη πληρωμή απέτυχε ή δεν ολοκληρώθηκε ποτέ, ώστε ο πελάτης να μπορεί να δοκιμάσει ξανά χωρίς να ξεκινήσει νέα παραγγελία.",
-                "summary": "Επανάληψη πληρωμής για αποτυχημένη ή εκκρεμή παραγγελία",
+                "description": "Create a fresh Stripe PaymentIntent for an order whose previous payment failed or was never completed, so the customer can try again without starting a new order.",
+                "summary": "Retry payment for a failed or pending order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23375,8 +23371,8 @@
         "/api/v1/order/{id}/shipment_cancel": {
             "post": {
                 "operationId": "cancelShipmentForOrder",
-                "description": "Μόνο για διαχειριστές. Ακύρωση ανεξάρτητη παρόχου: αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον προσαρμογέα μεταφορέα. Ισχύουν οι κανόνες του κάθε παρόχου (το BoxNow ακυρώνει μόνο δέματα σε κατάσταση NEW· η ACS ακυρώνει μόνο vouchers που δεν έχουν οριστικοποιηθεί σε λίστα παραλαβής).",
-                "summary": "Ακύρωση της αποστολής μεταφορέα για παραγγελία",
+                "description": "Admin-only. Provider-agnostic cancellation: looks up the order's shipping provider and dispatches to the carrier adapter. The provider's own rules apply (BoxNow only cancels parcels in NEW state; ACS only cancels vouchers not yet finalised in a pickup list).",
+                "summary": "Cancel the carrier shipment for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23470,8 +23466,8 @@
         "/api/v1/order/{id}/shipment_label": {
             "get": {
                 "operationId": "getShipmentLabelForOrder",
-                "description": "Λήψη ετικέτας ανεξάρτητη παρόχου. Αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον αντίστοιχο προσαρμογέα μεταφορέα μέσω του μητρώου αποστολών — τα frontends μπορούν να καλούν το ίδιο endpoint ανεξάρτητα από τον courier που εκτελεί την παραγγελία.",
-                "summary": "Λήψη του PDF ετικέτας μεταφορέα για παραγγελία",
+                "description": "Provider-agnostic label download. Looks up the order's shipping provider and dispatches to the matching carrier adapter via the shipping registry — frontends can call the same endpoint regardless of which courier is fulfilling the order.",
+                "summary": "Download the carrier label PDF for an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23565,8 +23561,8 @@
         "/api/v1/order/{id}/update_status": {
             "post": {
                 "operationId": "updateOrderStatus",
-                "description": "Ενημέρωση της κατάστασης υπάρχουσας παραγγελίας",
-                "summary": "Ενημέρωση κατάστασης παραγγελίας",
+                "description": "Update the status of an existing order",
+                "summary": "Update the status of an order",
                 "parameters": [
                     {
                         "in": "path",
@@ -23680,8 +23676,8 @@
         "/api/v1/order/my_orders": {
             "get": {
                 "operationId": "listMyOrders",
-                "description": "Επιστρέφει λίστα με τις παραγγελίες του συνδεδεμένου χρήστη",
-                "summary": "Λίστα παραγγελιών τρέχοντος χρήστη",
+                "description": "Returns a list of the authenticated user's orders",
+                "summary": "List current user's orders",
                 "parameters": [
                     {
                         "in": "query",
@@ -23702,7 +23698,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)"
+                        "description": "Filter active orders (pending, processing, shipped, delivered)"
                     },
                     {
                         "in": "query",
@@ -23723,7 +23719,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών που μπορούν να ακυρωθούν"
+                        "description": "Filter orders that can be canceled"
                     },
                     {
                         "in": "query",
@@ -23731,7 +23727,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)"
+                        "description": "Filter by city (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -23746,7 +23742,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό χώρας"
+                        "description": "Filter by country code"
                     },
                     {
                         "in": "query",
@@ -23754,7 +23750,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά alpha-2 κωδικό χώρας"
+                        "description": "Filter by country alpha-2 code"
                     },
                     {
                         "in": "query",
@@ -23762,7 +23758,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by country name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -23770,7 +23766,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple country IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -23834,7 +23830,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο εγγράφου"
+                        "description": "Filter by document type"
                     },
                     {
                         "in": "query",
@@ -23842,7 +23838,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -23870,7 +23866,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)"
+                        "description": "Filter final orders (completed, canceled, refunded)"
                     },
                     {
                         "in": "query",
@@ -23878,7 +23874,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -23893,7 +23889,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όροφο"
+                        "description": "Filter by floor"
                     },
                     {
                         "in": "query",
@@ -23914,7 +23910,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη"
+                        "description": "Filter orders that have/don't have customer notes"
                     },
                     {
                         "in": "query",
@@ -23935,7 +23931,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς ID πληρωμής"
+                        "description": "Filter orders that have/don't have payment ID"
                     },
                     {
                         "in": "query",
@@ -23956,7 +23952,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης"
+                        "description": "Filter orders that have status update timestamp"
                     },
                     {
                         "in": "query",
@@ -23977,7 +23973,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης"
+                        "description": "Filter orders that have/don't have tracking number"
                     },
                     {
                         "in": "query",
@@ -23998,7 +23994,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών με/χωρίς χρήστη"
+                        "description": "Filter orders that have/don't have a user"
                     },
                     {
                         "in": "query",
@@ -24022,7 +24018,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -24055,7 +24051,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ακυρωμένων παραγγελιών"
+                        "description": "Filter canceled orders"
                     },
                     {
                         "in": "query",
@@ -24076,7 +24072,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ολοκληρωμένων παραγγελιών"
+                        "description": "Filter completed orders"
                     },
                     {
                         "in": "query",
@@ -24097,7 +24093,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών"
+                        "description": "Filter paid/unpaid orders"
                     },
                     {
                         "in": "query",
@@ -24105,7 +24101,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by customer last name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24120,7 +24116,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο τοποθεσίας"
+                        "description": "Filter by location type"
                     },
                     {
                         "in": "query",
@@ -24141,7 +24137,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών που χρειάζονται επεξεργασία"
+                        "description": "Filter orders that need processing"
                     },
                     {
                         "name": "ordering",
@@ -24231,7 +24227,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστο πληρωμένο ποσό"
+                        "description": "Filter by maximum paid amount"
                     },
                     {
                         "in": "query",
@@ -24247,7 +24243,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο πληρωμένο ποσό"
+                        "description": "Filter by minimum paid amount"
                     },
                     {
                         "in": "query",
@@ -24263,7 +24259,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID μεθόδου πληρωμής"
+                        "description": "Filter by payment method ID"
                     },
                     {
                         "in": "query",
@@ -24284,7 +24280,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά online μεθόδους πληρωμής"
+                        "description": "Filter by online payment methods"
                     },
                     {
                         "in": "query",
@@ -24292,7 +24288,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by payment method name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24300,7 +24296,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ID πληρωμής"
+                        "description": "Filter by payment ID"
                     },
                     {
                         "in": "query",
@@ -24315,7 +24311,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά μέθοδο πληρωμής"
+                        "description": "Filter by payment method"
                     },
                     {
                         "in": "query",
@@ -24329,7 +24325,6 @@
                         "name": "paymentStatus",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση πληρωμής",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -24340,7 +24335,7 @@
                                 "REFUNDED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση πληρωμής\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε"
+                        "description": "Filter by payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled"
                     },
                     {
                         "in": "query",
@@ -24349,7 +24344,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -24369,7 +24364,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό τηλεφώνου"
+                        "description": "Filter by phone number"
                     },
                     {
                         "in": "query",
@@ -24384,7 +24379,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by place (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24412,7 +24407,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο παραγγελιών των τελευταίων 30 ημερών"
+                        "description": "Filter orders from the last 30 days"
                     },
                     {
                         "in": "query",
@@ -24420,7 +24415,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό περιφέρειας"
+                        "description": "Filter by region code"
                     },
                     {
                         "in": "query",
@@ -24428,7 +24423,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by region name (case-insensitive)"
                     },
                     {
                         "name": "search",
@@ -24445,7 +24440,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά εταιρεία μεταφοράς"
+                        "description": "Filter by shipping carrier"
                     },
                     {
                         "in": "query",
@@ -24498,7 +24493,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστα έξοδα αποστολής"
+                        "description": "Filter by maximum shipping price"
                     },
                     {
                         "in": "query",
@@ -24514,14 +24509,13 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστα έξοδα αποστολής"
+                        "description": "Filter by minimum shipping price"
                     },
                     {
                         "in": "query",
                         "name": "status",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση",
                             "enum": [
                                 "CANCELED",
                                 "COMPLETED",
@@ -24533,7 +24527,7 @@
                                 "SHIPPED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων"
+                        "description": "Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded"
                     },
                     {
                         "in": "query",
@@ -24542,7 +24536,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -24562,7 +24556,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)"
+                        "description": "Filter by multiple statuses (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -24571,7 +24565,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία"
+                        "description": "Filter orders with status updated after this date"
                     },
                     {
                         "in": "query",
@@ -24604,7 +24598,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία"
+                        "description": "Filter orders with status updated before this date"
                     },
                     {
                         "in": "query",
@@ -24612,7 +24606,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by street (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24627,7 +24621,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό"
+                        "description": "Filter by street number"
                     },
                     {
                         "in": "query",
@@ -24642,7 +24636,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό παρακολούθησης"
+                        "description": "Filter by tracking number"
                     },
                     {
                         "in": "query",
@@ -24707,7 +24701,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -24715,7 +24709,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user email (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24723,7 +24717,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user first name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24744,7 +24738,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση χρήστη"
+                        "description": "Filter by user active status"
                     },
                     {
                         "in": "query",
@@ -24752,7 +24746,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by user last name (case-insensitive)"
                     },
                     {
                         "in": "query",
@@ -24760,7 +24754,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)"
+                        "description": "Filter by multiple user IDs (comma-separated)"
                     },
                     {
                         "in": "query",
@@ -24776,7 +24770,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά Τ.Κ."
+                        "description": "Filter by zipcode"
                     }
                 ],
                 "tags": [
@@ -24854,8 +24848,8 @@
         "/api/v1/order/uuid/{uuid}": {
             "get": {
                 "operationId": "retrieveOrderByUuid",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένη παραγγελία βάσει του UUID της",
-                "summary": "Ανάκτηση παραγγελίας με UUID",
+                "description": "Get detailed information about a specific order using its UUID",
+                "summary": "Retrieve an order by UUID",
                 "parameters": [
                     {
                         "in": "path",
@@ -24942,8 +24936,8 @@
         "/api/v1/order/viva_return": {
             "get": {
                 "operationId": "vivaReturnLookup",
-                "description": "Το Smart Checkout του Viva ανακατευθύνει σε ένα στατικό URL επιτυχίας που έχει διαμορφωθεί στο merchant portal και προσθέτει ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (βλ. ενσωμάτωση Smart Checkout στο developer.viva.com). Αυτό το endpoint μετατρέπει αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t`` επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code`` που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση και το payment_status της παραγγελίας.",
-                "summary": "Αναζήτηση παραγγελίας από τις παραμέτρους ανακατεύθυνσης μετά την πληρωμή του Viva Wallet",
+                "description": "Viva's Smart Checkout redirects to a static success URL configured in the merchant portal and appends ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (see developer.viva.com Smart Checkout integration). This endpoint translates those params into the order's UUID so the storefront can forward the customer to the canonical ``/checkout/success/{uuid}`` route. ``t`` resolves via ``payment_id`` (set by the webhook, may lag the redirect); ``s`` resolves via the ``viva_order_code`` stored at session creation, so it works during the webhook race. Permission is open because both keys are unguessable Viva-generated identifiers and the response carries no PII — just the order's UUID, public id, status, and payment_status.",
+                "summary": "Look up an order from Viva Wallet's post-payment redirect params",
                 "parameters": [
                     {
                         "in": "query",
@@ -24993,8 +24987,8 @@
         "/api/v1/pay_way": {
             "get": {
                 "operationId": "listPayWay",
-                "description": "Ανάκτηση λίστας Τρόποι πληρωμής με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Τρόποι πληρωμής",
+                "description": "Retrieve a list of Pay Ways with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Pay Ways",
                 "parameters": [
                     {
                         "in": "query",
@@ -25015,7 +25009,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση ενεργοποίησης"
+                        "description": "Filter by active status"
                     },
                     {
                         "in": "query",
@@ -25061,7 +25055,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστο κόστος"
+                        "description": "Filter by maximum cost"
                     },
                     {
                         "in": "query",
@@ -25077,7 +25071,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο κόστος"
+                        "description": "Filter by minimum cost"
                     },
                     {
                         "in": "query",
@@ -25085,7 +25079,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -25093,7 +25087,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)"
+                        "description": "Filter by description (partial match)"
                     },
                     {
                         "in": "query",
@@ -25139,7 +25133,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστο όριο δωρεάν"
+                        "description": "Filter by maximum free threshold"
                     },
                     {
                         "in": "query",
@@ -25155,7 +25149,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστο όριο δωρεάν"
+                        "description": "Filter by minimum free threshold"
                     },
                     {
                         "in": "query",
@@ -25176,7 +25170,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μεθόδων πληρωμής με/χωρίς διαμόρφωση"
+                        "description": "Filter payment methods that have/don't have configuration"
                     },
                     {
                         "in": "query",
@@ -25197,7 +25191,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μεθόδων πληρωμής με/χωρίς εικονίδιο"
+                        "description": "Filter payment methods that have/don't have an icon"
                     },
                     {
                         "in": "query",
@@ -25213,7 +25207,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID μεθόδου πληρωμής"
+                        "description": "Filter by payment method ID"
                     },
                     {
                         "in": "query",
@@ -25234,7 +25228,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση online πληρωμής"
+                        "description": "Filter by online payment status"
                     },
                     {
                         "in": "query",
@@ -25248,7 +25242,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -25256,7 +25250,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα (μερική αντιστοίχιση)"
+                        "description": "Filter by name (partial match)"
                     },
                     {
                         "name": "ordering",
@@ -25299,7 +25293,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -25312,7 +25306,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -25326,7 +25320,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -25334,7 +25328,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό παρόχου (μερική αντιστοίχιση)"
+                        "description": "Filter by provider code (partial match)"
                     },
                     {
                         "in": "query",
@@ -25362,7 +25356,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά απαίτηση επιβεβαίωσης"
+                        "description": "Filter by confirmation requirement"
                     },
                     {
                         "name": "search",
@@ -25379,7 +25373,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Συνδυάστε με το ``shippingProviderCode`` για να φιλτράρετε τις μεθόδους πληρωμής βάσει των κανόνων συμβατότητας του μεταφορέα για αυτόν τον τύπο."
+                        "description": "Pair with ``shippingProviderCode`` to filter pay ways by the carrier's compatibility rules for that kind."
                     },
                     {
                         "in": "query",
@@ -25387,7 +25381,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο μεθόδων πληρωμής συμβατών με τον δεδομένο μεταφορέα αποστολής. Κάθε μεταφορέας διαθέτει τους δικούς του κανόνες συμβατότητας — το BoxNow (``boxnow``) υποστηρίζει αντικαταβολή σε lockers μέσω PAY ON THE GO και έτσι περνά κανονικά· η ACS περνά αμετάβλητη. Συνδυάστε με το ``shippingKind``."
+                        "description": "Filter pay ways compatible with the given shipping carrier. Each carrier owns its own compatibility rules — BoxNow (``boxnow``) supports COD on lockers via PAY ON THE GO and so passes through; ACS passes through unchanged. Pair with ``shippingKind``."
                     },
                     {
                         "in": "query",
@@ -25517,8 +25511,8 @@
             },
             "post": {
                 "operationId": "createPayWay",
-                "description": "Δημιουργία νέου Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Μέθοδος Πληρωμής",
+                "description": "Create a new Pay Way. Requires authentication.",
+                "summary": "Create a Pay Way",
                 "parameters": [
                     {
                         "in": "query",
@@ -25532,7 +25526,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -25630,8 +25624,8 @@
         "/api/v1/pay_way/{id}": {
             "get": {
                 "operationId": "retrievePayWay",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Μέθοδος Πληρωμής.",
-                "summary": "Ανάκτηση Μέθοδος Πληρωμής",
+                "description": "Get detailed information about a specific Pay Way.",
+                "summary": "Retrieve a Pay Way",
                 "parameters": [
                     {
                         "in": "path",
@@ -25653,7 +25647,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -25720,8 +25714,8 @@
             },
             "put": {
                 "operationId": "updatePayWay",
-                "description": "Ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Μέθοδος Πληρωμής",
+                "description": "Update Pay Way information. Requires authentication.",
+                "summary": "Update a Pay Way",
                 "parameters": [
                     {
                         "in": "path",
@@ -25743,7 +25737,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -25839,8 +25833,8 @@
             },
             "patch": {
                 "operationId": "partialUpdatePayWay",
-                "description": "Μερική ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Μέθοδος Πληρωμής",
+                "description": "Partially update Pay Way information. Requires authentication.",
+                "summary": "Partially update a Pay Way",
                 "parameters": [
                     {
                         "in": "path",
@@ -25862,7 +25856,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -25957,8 +25951,8 @@
             },
             "delete": {
                 "operationId": "destroyPayWay",
-                "description": "Διαγραφή Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Μέθοδος Πληρωμής",
+                "description": "Delete a Pay Way. Requires authentication.",
+                "summary": "Delete a Pay Way",
                 "parameters": [
                     {
                         "in": "path",
@@ -26017,8 +26011,8 @@
         "/api/v1/product": {
             "get": {
                 "operationId": "listProduct",
-                "description": "Ανάκτηση λίστας Προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Προϊόντα",
+                "description": "Retrieve a list of Products with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Products",
                 "parameters": [
                     {
                         "in": "query",
@@ -26063,7 +26057,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -26100,7 +26094,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -26186,7 +26180,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -26346,7 +26340,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -26677,7 +26671,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -26690,7 +26684,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -26704,7 +26698,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -27034,8 +27028,8 @@
             },
             "post": {
                 "operationId": "createProduct",
-                "description": "Δημιουργία νέου Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Προϊόν",
+                "description": "Create a new Product. Requires authentication.",
+                "summary": "Create a Product",
                 "parameters": [
                     {
                         "in": "query",
@@ -27049,7 +27043,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -27147,8 +27141,8 @@
         "/api/v1/product/{id}": {
             "get": {
                 "operationId": "retrieveProduct",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Προϊόν.",
-                "summary": "Ανάκτηση Προϊόν",
+                "description": "Get detailed information about a specific Product.",
+                "summary": "Retrieve a Product",
                 "parameters": [
                     {
                         "in": "path",
@@ -27178,7 +27172,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -27245,8 +27239,8 @@
             },
             "put": {
                 "operationId": "updateProduct",
-                "description": "Ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Προϊόν",
+                "description": "Update Product information. Requires authentication.",
+                "summary": "Update a Product",
                 "parameters": [
                     {
                         "in": "path",
@@ -27276,7 +27270,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -27372,8 +27366,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProduct",
-                "description": "Μερική ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Προϊόν",
+                "description": "Partially update Product information. Requires authentication.",
+                "summary": "Partially update a Product",
                 "parameters": [
                     {
                         "in": "path",
@@ -27403,7 +27397,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -27498,8 +27492,8 @@
             },
             "delete": {
                 "operationId": "destroyProduct",
-                "description": "Διαγραφή Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Προϊόν",
+                "description": "Delete a Product. Requires authentication.",
+                "summary": "Delete a Product",
                 "parameters": [
                     {
                         "in": "path",
@@ -27566,8 +27560,8 @@
         "/api/v1/product/{id}/images": {
             "get": {
                 "operationId": "listProductImages",
-                "description": "Λήψη όλων των εικόνων προϊόντος.",
-                "summary": "Λήψη εικόνων προϊόντος",
+                "description": "Get all images for a product.",
+                "summary": "Get product images",
                 "parameters": [
                     {
                         "in": "path",
@@ -27598,7 +27592,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -27699,8 +27693,8 @@
         "/api/v1/product/{id}/reviews": {
             "get": {
                 "operationId": "listProductReviews",
-                "description": "Λήψη όλων των αξιολογήσεων ενός προϊόντος με υποστήριξη σελιδοποίησης.",
-                "summary": "Λήψη κριτικών προϊόντος",
+                "description": "Get all reviews for a product with pagination support.",
+                "summary": "Get product reviews",
                 "parameters": [
                     {
                         "in": "path",
@@ -27760,7 +27754,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -27773,7 +27767,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -27787,7 +27781,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -27875,8 +27869,8 @@
         "/api/v1/product/{id}/tags": {
             "get": {
                 "operationId": "listProductTags",
-                "description": "Λήψη όλων των ετικετών που σχετίζονται με ένα προϊόν.",
-                "summary": "Λήψη ετικετών προϊόντος",
+                "description": "Get all tags associated with a product.",
+                "summary": "Get product tags",
                 "parameters": [
                     {
                         "in": "path",
@@ -27994,8 +27988,8 @@
         "/api/v1/product/{id}/update_view_count": {
             "post": {
                 "operationId": "incrementProductViews",
-                "description": "Αύξηση του μετρητή προβολών ενός προϊόντος.",
-                "summary": "Αύξηση προβολών προϊόντος",
+                "description": "Increment the view count for a product.",
+                "summary": "Increment product view count",
                 "parameters": [
                     {
                         "in": "path",
@@ -28090,8 +28084,8 @@
         "/api/v1/product/{id}/variants": {
             "get": {
                 "operationId": "listProductVariants",
-                "description": "Λήψη των αδερφών προϊόντων στην ομάδα παραλλαγών αυτού του προϊόντος, καθώς και των αξόνων παραλλαγής (π.χ. Χρώμα, Μνήμη) προς εμφάνιση ως επιλογείς. Επιστρέφει μόνο το ίδιο το προϊόν όταν δεν έχει ομάδα παραλλαγών.",
-                "summary": "Λήψη παραλλαγών προϊόντος",
+                "description": "Get the sibling products in this product's variant group, plus the variant axes (e.g. Colour, Memory) to render as selectors. Returns just the product itself when it has no variant group.",
+                "summary": "Get product variants",
                 "parameters": [
                     {
                         "in": "path",
@@ -28122,7 +28116,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -28201,8 +28195,8 @@
         "/api/v1/product/alert": {
             "get": {
                 "operationId": "listProductAlert",
-                "description": "Ανάκτηση λίστας Ειδοποιήσεις προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Ειδοποιήσεις προϊόντος",
+                "description": "Retrieve a list of Product alerts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product alerts",
                 "parameters": [
                     {
                         "in": "query",
@@ -28210,7 +28204,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -28237,13 +28231,12 @@
                         "name": "kind",
                         "schema": {
                             "type": "string",
-                            "title": "Είδος",
                             "enum": [
                                 "price_drop",
                                 "restock"
                             ]
                         },
-                        "description": "* `restock` - Αναπλήρωση\n* `price_drop` - Πτώση τιμής"
+                        "description": "* `restock` - Restock\n* `price_drop` - Price drop"
                     },
                     {
                         "in": "query",
@@ -28257,7 +28250,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -28300,7 +28293,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -28313,7 +28306,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -28327,7 +28320,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -28427,8 +28420,8 @@
             },
             "post": {
                 "operationId": "createProductAlert",
-                "description": "Δημιουργία νέου Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Ειδοποίηση προϊόντος",
+                "description": "Create a new Product alert. Requires authentication.",
+                "summary": "Create a Product alert",
                 "parameters": [
                     {
                         "in": "query",
@@ -28442,7 +28435,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -28541,8 +28534,8 @@
         "/api/v1/product/alert/{id}": {
             "get": {
                 "operationId": "retrieveProductAlert",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ειδοποίηση προϊόντος.",
-                "summary": "Ανάκτηση Ειδοποίηση προϊόντος",
+                "description": "Get detailed information about a specific Product alert.",
+                "summary": "Retrieve a Product alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -28572,7 +28565,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -28638,8 +28631,8 @@
             },
             "delete": {
                 "operationId": "destroyProductAlert",
-                "description": "Διαγραφή Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Ειδοποίηση προϊόντος",
+                "description": "Delete a Product alert. Requires authentication.",
+                "summary": "Delete a Product alert",
                 "parameters": [
                     {
                         "in": "path",
@@ -28703,8 +28696,8 @@
         "/api/v1/product/attribute": {
             "get": {
                 "operationId": "listAttribute",
-                "description": "Ανάκτηση λίστας Χαρακτηριστικά με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Χαρακτηριστικά",
+                "description": "Retrieve a list of Attributes with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Attributes",
                 "parameters": [
                     {
                         "in": "query",
@@ -28774,7 +28767,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -28818,7 +28811,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -28844,7 +28837,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -28894,7 +28887,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -28907,7 +28900,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -28921,7 +28914,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -29104,8 +29097,8 @@
             },
             "post": {
                 "operationId": "createAttribute",
-                "description": "Δημιουργία νέου Χαρακτηριστικό. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Χαρακτηριστικό",
+                "description": "Create a new Attribute. Requires authentication.",
+                "summary": "Create a Attribute",
                 "parameters": [
                     {
                         "in": "query",
@@ -29119,7 +29112,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -29197,8 +29190,8 @@
         "/api/v1/product/attribute/{id}": {
             "get": {
                 "operationId": "retrieveAttribute",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χαρακτηριστικό.",
-                "summary": "Ανάκτηση Χαρακτηριστικό",
+                "description": "Get detailed information about a specific Attribute.",
+                "summary": "Retrieve a Attribute",
                 "parameters": [
                     {
                         "in": "path",
@@ -29228,7 +29221,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -29294,8 +29287,8 @@
             },
             "put": {
                 "operationId": "updateAttribute",
-                "description": "Ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Χαρακτηριστικό",
+                "description": "Update Attribute information. Requires authentication.",
+                "summary": "Update a Attribute",
                 "parameters": [
                     {
                         "in": "path",
@@ -29325,7 +29318,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -29401,8 +29394,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateAttribute",
-                "description": "Μερική ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Χαρακτηριστικό",
+                "description": "Partially update Attribute information. Requires authentication.",
+                "summary": "Partially update a Attribute",
                 "parameters": [
                     {
                         "in": "path",
@@ -29432,7 +29425,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -29508,8 +29501,8 @@
             },
             "delete": {
                 "operationId": "destroyAttribute",
-                "description": "Διαγραφή Χαρακτηριστικό. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Χαρακτηριστικό",
+                "description": "Delete a Attribute. Requires authentication.",
+                "summary": "Delete a Attribute",
                 "parameters": [
                     {
                         "in": "path",
@@ -29576,8 +29569,8 @@
         "/api/v1/product/attribute/value": {
             "get": {
                 "operationId": "listAttributeValue",
-                "description": "Ανάκτηση λίστας Τιμές Χαρακτηριστικών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Τιμές Χαρακτηριστικών",
+                "description": "Retrieve a list of Attribute Values with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Attribute Values",
                 "parameters": [
                     {
                         "in": "query",
@@ -29621,7 +29614,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -29683,7 +29676,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -29707,7 +29700,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -29733,7 +29726,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -29776,7 +29769,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -29789,7 +29782,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -29803,7 +29796,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -29993,8 +29986,8 @@
             },
             "post": {
                 "operationId": "createAttributeValue",
-                "description": "Δημιουργία νέου Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Τιμή Χαρακτηριστικού",
+                "description": "Create a new Attribute Value. Requires authentication.",
+                "summary": "Create a Attribute Value",
                 "parameters": [
                     {
                         "in": "query",
@@ -30008,7 +30001,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -30086,8 +30079,8 @@
         "/api/v1/product/attribute/value/{id}": {
             "get": {
                 "operationId": "retrieveAttributeValue",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Τιμή Χαρακτηριστικού.",
-                "summary": "Ανάκτηση Τιμή Χαρακτηριστικού",
+                "description": "Get detailed information about a specific Attribute Value.",
+                "summary": "Retrieve a Attribute Value",
                 "parameters": [
                     {
                         "in": "path",
@@ -30117,7 +30110,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -30183,8 +30176,8 @@
             },
             "put": {
                 "operationId": "updateAttributeValue",
-                "description": "Ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Τιμή Χαρακτηριστικού",
+                "description": "Update Attribute Value information. Requires authentication.",
+                "summary": "Update a Attribute Value",
                 "parameters": [
                     {
                         "in": "path",
@@ -30214,7 +30207,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -30290,8 +30283,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateAttributeValue",
-                "description": "Μερική ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Τιμή Χαρακτηριστικού",
+                "description": "Partially update Attribute Value information. Requires authentication.",
+                "summary": "Partially update a Attribute Value",
                 "parameters": [
                     {
                         "in": "path",
@@ -30321,7 +30314,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -30397,8 +30390,8 @@
             },
             "delete": {
                 "operationId": "destroyAttributeValue",
-                "description": "Διαγραφή Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Τιμή Χαρακτηριστικού",
+                "description": "Delete a Attribute Value. Requires authentication.",
+                "summary": "Delete a Attribute Value",
                 "parameters": [
                     {
                         "in": "path",
@@ -30465,8 +30458,8 @@
         "/api/v1/product/category": {
             "get": {
                 "operationId": "listProductCategory",
-                "description": "Ανάκτηση λίστας Κατηγορίες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Κατηγορίες προϊόντος",
+                "description": "Retrieve a list of Product Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product Categories",
                 "parameters": [
                     {
                         "in": "query",
@@ -30552,7 +30545,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -30634,7 +30627,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -30702,7 +30695,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -30855,7 +30848,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -30868,7 +30861,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -30882,7 +30875,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -31120,8 +31113,8 @@
             },
             "post": {
                 "operationId": "createProductCategory",
-                "description": "Δημιουργία νέου Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Κατηγορία Προϊόντος",
+                "description": "Create a new Product Category. Requires authentication.",
+                "summary": "Create a Product Category",
                 "parameters": [
                     {
                         "in": "query",
@@ -31135,7 +31128,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -31233,8 +31226,8 @@
         "/api/v1/product/category/{id}": {
             "get": {
                 "operationId": "retrieveProductCategory",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Προϊόντος.",
-                "summary": "Ανάκτηση Κατηγορία Προϊόντος",
+                "description": "Get detailed information about a specific Product Category.",
+                "summary": "Retrieve a Product Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -31264,7 +31257,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -31331,8 +31324,8 @@
             },
             "put": {
                 "operationId": "updateProductCategory",
-                "description": "Ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Κατηγορία Προϊόντος",
+                "description": "Update Product Category information. Requires authentication.",
+                "summary": "Update a Product Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -31362,7 +31355,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -31458,8 +31451,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProductCategory",
-                "description": "Μερική ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Κατηγορία Προϊόντος",
+                "description": "Partially update Product Category information. Requires authentication.",
+                "summary": "Partially update a Product Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -31489,7 +31482,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -31584,8 +31577,8 @@
             },
             "delete": {
                 "operationId": "destroyProductCategory",
-                "description": "Διαγραφή Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Κατηγορία Προϊόντος",
+                "description": "Delete a Product Category. Requires authentication.",
+                "summary": "Delete a Product Category",
                 "parameters": [
                     {
                         "in": "path",
@@ -31813,7 +31806,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -32230,8 +32223,8 @@
         "/api/v1/product/category/image": {
             "get": {
                 "operationId": "listProductCategoryImage",
-                "description": "Ανάκτηση λίστας Εικόνες Κατηγορίας Προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Εικόνες Κατηγορίας Προϊόντος",
+                "description": "Retrieve a list of Product Category Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product Category Images",
                 "parameters": [
                     {
                         "in": "query",
@@ -32274,7 +32267,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -32296,7 +32289,6 @@
                         "name": "imageType",
                         "schema": {
                             "type": "string",
-                            "title": "Τύπος εικόνας",
                             "enum": [
                                 "BACKGROUND",
                                 "BANNER",
@@ -32310,7 +32302,7 @@
                                 "THUMBNAIL"
                             ]
                         },
-                        "description": "* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα"
+                        "description": "* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image"
                     },
                     {
                         "in": "query",
@@ -32324,7 +32316,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -32367,7 +32359,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -32380,7 +32372,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -32394,7 +32386,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -32480,8 +32472,8 @@
             },
             "post": {
                 "operationId": "createProductCategoryImage",
-                "description": "Δημιουργία νέου Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Εικόνα Κατηγορίας Προϊόντος",
+                "description": "Create a new Product Category Image. Requires authentication.",
+                "summary": "Create a Product Category Image",
                 "parameters": [
                     {
                         "in": "query",
@@ -32495,7 +32487,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -32593,8 +32585,8 @@
         "/api/v1/product/category/image/{id}": {
             "get": {
                 "operationId": "retrieveProductCategoryImage",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Κατηγορίας Προϊόντος.",
-                "summary": "Ανάκτηση Εικόνα Κατηγορίας Προϊόντος",
+                "description": "Get detailed information about a specific Product Category Image.",
+                "summary": "Retrieve a Product Category Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -32624,7 +32616,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -32691,8 +32683,8 @@
             },
             "put": {
                 "operationId": "updateProductCategoryImage",
-                "description": "Ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Εικόνα Κατηγορίας Προϊόντος",
+                "description": "Update Product Category Image information. Requires authentication.",
+                "summary": "Update a Product Category Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -32722,7 +32714,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -32818,8 +32810,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProductCategoryImage",
-                "description": "Μερική ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Εικόνα Κατηγορίας Προϊόντος",
+                "description": "Partially update Product Category Image information. Requires authentication.",
+                "summary": "Partially update a Product Category Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -32849,7 +32841,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -32944,8 +32936,8 @@
             },
             "delete": {
                 "operationId": "destroyProductCategoryImage",
-                "description": "Διαγραφή Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Εικόνα Κατηγορίας Προϊόντος",
+                "description": "Delete a Product Category Image. Requires authentication.",
+                "summary": "Delete a Product Category Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -33012,8 +33004,8 @@
         "/api/v1/product/category/image/bulk_update": {
             "patch": {
                 "operationId": "bulkUpdateProductCategoryImages",
-                "description": "Ενημέρωση πολλαπλών εικόνων κατηγορίας ταυτόχρονα. Μπορεί να ενημερώσει την κατάσταση ενεργοποίησης και τη σειρά ταξινόμησης.",
-                "summary": "Μαζική ενημέρωση εικόνων κατηγορίας",
+                "description": "Update multiple category images at once. Can update active status and sort order.",
+                "summary": "Bulk update category images",
                 "tags": [
                     "Product Category Images"
                 ],
@@ -33108,8 +33100,8 @@
         "/api/v1/product/category/image/by_category": {
             "get": {
                 "operationId": "getProductCategoryImagesByCategory",
-                "description": "Ανάκτηση όλων των εικόνων για συγκεκριμένη κατηγορία.",
-                "summary": "Λήψη εικόνων ανά κατηγορία",
+                "description": "Retrieve all images for a specific category.",
+                "summary": "Get images by category",
                 "parameters": [
                     {
                         "in": "query",
@@ -33166,7 +33158,6 @@
                         "name": "imageType",
                         "schema": {
                             "type": "string",
-                            "title": "Τύπος εικόνας",
                             "enum": [
                                 "BACKGROUND",
                                 "BANNER",
@@ -33180,7 +33171,7 @@
                                 "THUMBNAIL"
                             ]
                         },
-                        "description": "* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα"
+                        "description": "* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image"
                     },
                     {
                         "name": "ordering",
@@ -33281,8 +33272,8 @@
         "/api/v1/product/category/image/by_type": {
             "get": {
                 "operationId": "getProductCategoryImagesByType",
-                "description": "Ανάκτηση όλων των εικόνων συγκεκριμένου τύπου (κύρια, banner, εικονίδιο κ.λπ.).",
-                "summary": "Λήψη εικόνων ανά τύπο",
+                "description": "Retrieve all images of a specific type (main, banner, icon, etc.).",
+                "summary": "Get images by type",
                 "parameters": [
                     {
                         "in": "query",
@@ -33339,7 +33330,6 @@
                         "name": "imageType",
                         "schema": {
                             "type": "string",
-                            "title": "Τύπος εικόνας",
                             "enum": [
                                 "BACKGROUND",
                                 "BANNER",
@@ -33353,7 +33343,7 @@
                                 "THUMBNAIL"
                             ]
                         },
-                        "description": "* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα"
+                        "description": "* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image"
                     },
                     {
                         "name": "ordering",
@@ -33454,8 +33444,8 @@
         "/api/v1/product/favourite": {
             "get": {
                 "operationId": "listProductFavourite",
-                "description": "Ανάκτηση λίστας Αγαπημένα προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Αγαπημένα προϊόντα",
+                "description": "Retrieve a list of Product Favourites with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product Favourites",
                 "parameters": [
                     {
                         "in": "query",
@@ -33481,7 +33471,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -33510,7 +33500,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -33553,7 +33543,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -33566,7 +33556,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -33580,7 +33570,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -33751,8 +33741,8 @@
             },
             "post": {
                 "operationId": "createProductFavourite",
-                "description": "Δημιουργία νέου Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Αγαπημένο Προϊόν",
+                "description": "Create a new Product Favourite. Requires authentication.",
+                "summary": "Create a Product Favourite",
                 "parameters": [
                     {
                         "in": "query",
@@ -33766,7 +33756,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -33864,8 +33854,8 @@
         "/api/v1/product/favourite/{id}": {
             "get": {
                 "operationId": "retrieveProductFavourite",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Αγαπημένο Προϊόν.",
-                "summary": "Ανάκτηση Αγαπημένο Προϊόν",
+                "description": "Get detailed information about a specific Product Favourite.",
+                "summary": "Retrieve a Product Favourite",
                 "parameters": [
                     {
                         "in": "path",
@@ -33887,7 +33877,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -33953,8 +33943,8 @@
             },
             "put": {
                 "operationId": "updateProductFavourite",
-                "description": "Ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Αγαπημένο Προϊόν",
+                "description": "Update Product Favourite information. Requires authentication.",
+                "summary": "Update a Product Favourite",
                 "parameters": [
                     {
                         "in": "path",
@@ -33976,7 +33966,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -34072,8 +34062,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProductFavourite",
-                "description": "Μερική ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Αγαπημένο Προϊόν",
+                "description": "Partially update Product Favourite information. Requires authentication.",
+                "summary": "Partially update a Product Favourite",
                 "parameters": [
                     {
                         "in": "path",
@@ -34095,7 +34085,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -34190,8 +34180,8 @@
             },
             "delete": {
                 "operationId": "destroyProductFavourite",
-                "description": "Διαγραφή Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Αγαπημένο Προϊόν",
+                "description": "Delete a Product Favourite. Requires authentication.",
+                "summary": "Delete a Product Favourite",
                 "parameters": [
                     {
                         "in": "path",
@@ -34250,8 +34240,8 @@
         "/api/v1/product/favourite/{id}/product": {
             "get": {
                 "operationId": "getProductFavouriteProduct",
-                "description": "Λήψη λεπτομερών πληροφοριών για το προϊόν σε αυτή την εγγραφή αγαπημένων.",
-                "summary": "Λήψη λεπτομερειών αγαπημένου προϊόντος",
+                "description": "Get detailed information about the product in this favourite entry.",
+                "summary": "Get favourite product details",
                 "parameters": [
                     {
                         "in": "path",
@@ -34337,8 +34327,8 @@
         "/api/v1/product/favourite/favourites_by_products": {
             "post": {
                 "operationId": "getProductFavouritesByProducts",
-                "description": "Λήψη εγγραφών αγαπημένων για τα καθορισμένα ID προϊόντων. Απαιτεί ταυτοποίηση.",
-                "summary": "Λήψη αγαπημένων ανά IDs προϊόντων",
+                "description": "Get favourite entries for the specified product IDs. Requires authentication.",
+                "summary": "Get favourites by product IDs",
                 "parameters": [
                     {
                         "in": "query",
@@ -34577,8 +34567,8 @@
         "/api/v1/product/image": {
             "get": {
                 "operationId": "listProductImage",
-                "description": "Ανάκτηση λίστας Εικόνες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Εικόνες προϊόντος",
+                "description": "Retrieve a list of Product Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product Images",
                 "parameters": [
                     {
                         "in": "query",
@@ -34594,7 +34584,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -34643,7 +34633,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -34686,7 +34676,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -34699,7 +34689,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -34713,7 +34703,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -34837,8 +34827,8 @@
             },
             "post": {
                 "operationId": "createProductImage",
-                "description": "Δημιουργία νέου Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Εικόνα Προϊόντος",
+                "description": "Create a new Product Image. Requires authentication.",
+                "summary": "Create a Product Image",
                 "parameters": [
                     {
                         "in": "query",
@@ -34852,7 +34842,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -34950,8 +34940,8 @@
         "/api/v1/product/image/{id}": {
             "get": {
                 "operationId": "retrieveProductImage",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Προϊόντος.",
-                "summary": "Ανάκτηση Εικόνα Προϊόντος",
+                "description": "Get detailed information about a specific Product Image.",
+                "summary": "Retrieve a Product Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -34981,7 +34971,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -35048,8 +35038,8 @@
             },
             "put": {
                 "operationId": "updateProductImage",
-                "description": "Ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Εικόνα Προϊόντος",
+                "description": "Update Product Image information. Requires authentication.",
+                "summary": "Update a Product Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -35079,7 +35069,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -35175,8 +35165,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProductImage",
-                "description": "Μερική ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Εικόνα Προϊόντος",
+                "description": "Partially update Product Image information. Requires authentication.",
+                "summary": "Partially update a Product Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -35206,7 +35196,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -35301,8 +35291,8 @@
             },
             "delete": {
                 "operationId": "destroyProductImage",
-                "description": "Διαγραφή Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Εικόνα Προϊόντος",
+                "description": "Delete a Product Image. Requires authentication.",
+                "summary": "Delete a Product Image",
                 "parameters": [
                     {
                         "in": "path",
@@ -35369,8 +35359,8 @@
         "/api/v1/product/review": {
             "get": {
                 "operationId": "listProductReview",
-                "description": "Ανάκτηση λίστας Κριτικές προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Κριτικές προϊόντος",
+                "description": "Retrieve a list of Product Reviews with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Product Reviews",
                 "parameters": [
                     {
                         "in": "query",
@@ -35378,7 +35368,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιεχόμενο σχολίου (μερική αντιστοίχιση)"
+                        "description": "Filter by comment content (partial match)"
                     },
                     {
                         "in": "query",
@@ -35387,7 +35377,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items created after this date"
                     },
                     {
                         "in": "query",
@@ -35420,7 +35410,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items created before this date"
                     },
                     {
                         "in": "query",
@@ -35441,7 +35431,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)"
+                        "description": "Filter items that are currently published (published_at <= now and is_published=True)"
                     },
                     {
                         "in": "query",
@@ -35449,7 +35439,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -35470,7 +35460,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αξιολογήσεων με/χωρίς σχόλια"
+                        "description": "Filter reviews that have/don't have comments"
                     },
                     {
                         "in": "query",
@@ -35486,7 +35476,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κριτικής"
+                        "description": "Filter by review ID"
                     },
                     {
                         "in": "query",
@@ -35507,7 +35497,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση δημοσίευσης"
+                        "description": "Filter by published status"
                     },
                     {
                         "in": "query",
@@ -35521,7 +35511,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -35537,7 +35527,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη βαθμολογία (alias)"
+                        "description": "Filter by maximum rating (alias)"
                     },
                     {
                         "in": "query",
@@ -35553,7 +35543,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη βαθμολογία (alias)"
+                        "description": "Filter by minimum rating (alias)"
                     },
                     {
                         "name": "ordering",
@@ -35596,7 +35586,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -35609,7 +35599,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -35623,7 +35613,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -35639,7 +35629,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID προϊόντος"
+                        "description": "Filter by product ID"
                     },
                     {
                         "in": "query",
@@ -35660,7 +35650,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση προϊόντος"
+                        "description": "Filter by product active status"
                     },
                     {
                         "in": "query",
@@ -35676,7 +35666,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο προϊόντων με μέγιστη μέση βαθμολογία"
+                        "description": "Filter products with maximum average rating"
                     },
                     {
                         "in": "query",
@@ -35692,7 +35682,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο προϊόντων με ελάχιστη μέση βαθμολογία"
+                        "description": "Filter products with minimum average rating"
                     },
                     {
                         "in": "query",
@@ -35708,7 +35698,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID κατηγορίας προϊόντος"
+                        "description": "Filter by product category ID"
                     },
                     {
                         "in": "query",
@@ -35724,7 +35714,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID προϊόντος"
+                        "description": "Filter by product ID"
                     },
                     {
                         "in": "query",
@@ -35732,7 +35722,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)"
+                        "description": "Filter by product name (partial match)"
                     },
                     {
                         "in": "query",
@@ -35741,7 +35731,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items published after this date"
                     },
                     {
                         "in": "query",
@@ -35774,7 +35764,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items published before this date"
                     },
                     {
                         "in": "query",
@@ -35790,7 +35780,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αξιολογήσεων που δημοσιεύθηκαν τις τελευταίες N ημέρες"
+                        "description": "Filter reviews published in the last N days"
                     },
                     {
                         "in": "query",
@@ -35806,7 +35796,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ακριβή βαθμολογία\n\n* `1` - Ένα\n* `2` - Δύο\n* `3` - Τρία\n* `4` - Τέσσερα\n* `5` - Πέντε\n* `6` - Έξι\n* `7` - Επτά\n* `8` - Οκτώ\n* `9` - Εννέα\n* `10` - Δέκα"
+                        "description": "Filter by exact rating\n\n* `1` - One\n* `2` - Two\n* `3` - Three\n* `4` - Four\n* `5` - Five\n* `6` - Six\n* `7` - Seven\n* `8` - Eight\n* `9` - Nine\n* `10` - Ten"
                     },
                     {
                         "in": "query",
@@ -35852,7 +35842,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά μέγιστη βαθμολογία"
+                        "description": "Filter by maximum rating"
                     },
                     {
                         "in": "query",
@@ -35868,7 +35858,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ελάχιστη βαθμολογία"
+                        "description": "Filter by minimum rating"
                     },
                     {
                         "in": "query",
@@ -35884,7 +35874,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αξιολογήσεων των τελευταίων N ημερών"
+                        "description": "Filter reviews from the last N days"
                     },
                     {
                         "name": "search",
@@ -35900,14 +35890,13 @@
                         "name": "status",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση",
                             "enum": [
                                 "FALSE",
                                 "NEW",
                                 "TRUE"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση αξιολόγησης\n\n* `NEW` - Νέο\n* `TRUE` - Ναι\n* `FALSE` - Όχι"
+                        "description": "Filter by review status\n\n* `NEW` - New\n* `TRUE` - True\n* `FALSE` - False"
                     },
                     {
                         "in": "query",
@@ -35916,7 +35905,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter items updated after this date"
                     },
                     {
                         "in": "query",
@@ -35949,7 +35938,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter items updated before this date"
                     },
                     {
                         "in": "query",
@@ -35965,7 +35954,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -35973,7 +35962,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)"
+                        "description": "Filter by user email (partial match)"
                     },
                     {
                         "in": "query",
@@ -35981,7 +35970,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χρήστη (μερική αντιστοίχιση)"
+                        "description": "Filter by user first name (partial match)"
                     },
                     {
                         "in": "query",
@@ -35997,7 +35986,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID χρήστη"
+                        "description": "Filter by user ID"
                     },
                     {
                         "in": "query",
@@ -36005,7 +35994,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο χρήστη (μερική αντιστοίχιση)"
+                        "description": "Filter by user last name (partial match)"
                     },
                     {
                         "in": "query",
@@ -36021,7 +36010,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο χρηστών με ελάχιστο αριθμό αξιολογήσεων"
+                        "description": "Filter users with minimum number of reviews"
                     },
                     {
                         "in": "query",
@@ -36050,7 +36039,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο αξιολογήσεων από επαληθευμένες αγορές"
+                        "description": "Filter reviews from verified purchases"
                     }
                 ],
                 "tags": [
@@ -36127,8 +36116,8 @@
             },
             "post": {
                 "operationId": "createProductReview",
-                "description": "Δημιουργία νέου Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Κριτική Προϊόντος",
+                "description": "Create a new Product Review. Requires authentication.",
+                "summary": "Create a Product Review",
                 "parameters": [
                     {
                         "in": "query",
@@ -36142,7 +36131,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -36240,8 +36229,8 @@
         "/api/v1/product/review/{id}": {
             "get": {
                 "operationId": "retrieveProductReview",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κριτική Προϊόντος.",
-                "summary": "Ανάκτηση Κριτική Προϊόντος",
+                "description": "Get detailed information about a specific Product Review.",
+                "summary": "Retrieve a Product Review",
                 "parameters": [
                     {
                         "in": "path",
@@ -36271,7 +36260,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -36338,8 +36327,8 @@
             },
             "put": {
                 "operationId": "updateProductReview",
-                "description": "Ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Κριτική Προϊόντος",
+                "description": "Update Product Review information. Requires authentication.",
+                "summary": "Update a Product Review",
                 "parameters": [
                     {
                         "in": "path",
@@ -36369,7 +36358,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -36465,8 +36454,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateProductReview",
-                "description": "Μερική ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Κριτική Προϊόντος",
+                "description": "Partially update Product Review information. Requires authentication.",
+                "summary": "Partially update a Product Review",
                 "parameters": [
                     {
                         "in": "path",
@@ -36496,7 +36485,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -36591,8 +36580,8 @@
             },
             "delete": {
                 "operationId": "destroyProductReview",
-                "description": "Διαγραφή Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Κριτική Προϊόντος",
+                "description": "Delete a Product Review. Requires authentication.",
+                "summary": "Delete a Product Review",
                 "parameters": [
                     {
                         "in": "path",
@@ -36659,8 +36648,8 @@
         "/api/v1/product/review/{id}/product": {
             "get": {
                 "operationId": "getProductReviewProduct",
-                "description": "Λήψη λεπτομερών πληροφοριών για το προϊόν στο οποίο αναφέρεται αυτή η αξιολόγηση.",
-                "summary": "Λήψη λεπτομερειών προϊόντος κριτικής",
+                "description": "Get detailed information about the product this review is for.",
+                "summary": "Get reviewed product details",
                 "parameters": [
                     {
                         "in": "path",
@@ -36747,8 +36736,8 @@
         "/api/v1/product/review/{id}/user_product_review": {
             "get": {
                 "operationId": "getUserProductReview",
-                "description": "Λήψη της αξιολόγησης του τρέχοντος χρήστη για συγκεκριμένο προϊόν. Απαιτεί ταυτοποίηση.",
-                "summary": "Λήψη κριτικής χρήστη για προϊόν",
+                "description": "Get the current user's review for a specific product. Requires authentication.",
+                "summary": "Get user's review for a product",
                 "parameters": [
                     {
                         "in": "path",
@@ -36834,8 +36823,8 @@
         "/api/v1/region": {
             "get": {
                 "operationId": "listRegion",
-                "description": "Ανάκτηση λίστας Περιοχές με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Περιοχές",
+                "description": "Retrieve a list of Regions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Regions",
                 "parameters": [
                     {
                         "in": "query",
@@ -36843,7 +36832,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)"
+                        "description": "Filter by region alpha code (partial match)"
                     },
                     {
                         "in": "query",
@@ -36858,7 +36847,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας"
+                        "description": "Filter by exact region alpha code"
                     },
                     {
                         "in": "query",
@@ -36866,7 +36855,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά alpha-2 κωδικό χώρας"
+                        "description": "Filter by country alpha-2 code"
                     },
                     {
                         "in": "query",
@@ -36874,7 +36863,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by country name (partial match)"
                     },
                     {
                         "in": "query",
@@ -36900,7 +36889,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -36914,7 +36903,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -36922,7 +36911,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)"
+                        "description": "Filter by region name (partial match)"
                     },
                     {
                         "name": "ordering",
@@ -36965,7 +36954,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -36978,7 +36967,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -36992,7 +36981,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -37149,8 +37138,8 @@
             },
             "post": {
                 "operationId": "createRegion",
-                "description": "Δημιουργία νέου Περιοχή. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Περιοχή",
+                "description": "Create a new Region. Requires authentication.",
+                "summary": "Create a Region",
                 "parameters": [
                     {
                         "in": "query",
@@ -37164,7 +37153,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -37262,17 +37251,17 @@
         "/api/v1/region/{alpha}": {
             "get": {
                 "operationId": "retrieveRegion",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Περιοχή.",
-                "summary": "Ανάκτηση Περιοχή",
+                "description": "Get detailed information about a specific Region.",
+                "summary": "Retrieve a Region",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
-                        "description": "A unique value identifying this Περιοχή.",
+                        "description": "A unique value identifying this Region.",
                         "required": true
                     },
                     {
@@ -37287,7 +37276,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -37354,17 +37343,17 @@
             },
             "put": {
                 "operationId": "updateRegion",
-                "description": "Ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Περιοχή",
+                "description": "Update Region information. Requires authentication.",
+                "summary": "Update a Region",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
-                        "description": "A unique value identifying this Περιοχή.",
+                        "description": "A unique value identifying this Region.",
                         "required": true
                     },
                     {
@@ -37379,7 +37368,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -37475,17 +37464,17 @@
             },
             "patch": {
                 "operationId": "partialUpdateRegion",
-                "description": "Μερική ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Περιοχή",
+                "description": "Partially update Region information. Requires authentication.",
+                "summary": "Partially update a Region",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
-                        "description": "A unique value identifying this Περιοχή.",
+                        "description": "A unique value identifying this Region.",
                         "required": true
                     },
                     {
@@ -37500,7 +37489,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -37595,17 +37584,17 @@
             },
             "delete": {
                 "operationId": "destroyRegion",
-                "description": "Διαγραφή Περιοχή. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Περιοχή",
+                "description": "Delete a Region. Requires authentication.",
+                "summary": "Delete a Region",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
-                        "description": "A unique value identifying this Περιοχή.",
+                        "description": "A unique value identifying this Region.",
                         "required": true
                     }
                 ],
@@ -37657,17 +37646,17 @@
         "/api/v1/region/{alpha}/get_regions_by_country_alpha_2": {
             "get": {
                 "operationId": "listRegionsByCountry",
-                "description": "Λήψη όλων των περιφερειών για συγκεκριμένη χώρα βάσει του κωδικού alpha-2 της.",
-                "summary": "Λήψη περιφερειών ανά χώρα",
+                "description": "Get all regions for a specific country using its alpha-2 code.",
+                "summary": "Get regions by country",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "alpha",
                         "schema": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
-                        "description": "A unique value identifying this Περιοχή.",
+                        "description": "A unique value identifying this Region.",
                         "required": true
                     },
                     {
@@ -37676,7 +37665,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)"
+                        "description": "Filter by region alpha code (partial match)"
                     },
                     {
                         "in": "query",
@@ -37691,7 +37680,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας"
+                        "description": "Filter by exact region alpha code"
                     },
                     {
                         "in": "query",
@@ -37699,7 +37688,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά alpha-2 κωδικό χώρας"
+                        "description": "Filter by country alpha-2 code"
                     },
                     {
                         "in": "query",
@@ -37707,7 +37696,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by country name (partial match)"
                     },
                     {
                         "in": "query",
@@ -37733,7 +37722,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)"
+                        "description": "Filter by region name (partial match)"
                     },
                     {
                         "name": "ordering",
@@ -37936,8 +37925,8 @@
         "/api/v1/search/analytics": {
             "get": {
                 "operationId": "api_v1_search_analytics_retrieve",
-                "description": "Ανάκτηση συγκεντρωτικών αναλυτικών αναζήτησης, συμπεριλαμβανομένων των κορυφαίων ερωτημάτων, ερωτημάτων χωρίς αποτελέσματα, όγκου αναζήτησης ανά τύπο περιεχομένου και γλώσσα, μέσου αριθμού αποτελεσμάτων, μέσου χρόνου επεξεργασίας και ποσοστού κλικ. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά εύρος ημερομηνιών και τύπο περιεχομένου.",
-                "summary": "Λήψη μετρικών αναζήτησης",
+                "description": "Retrieve aggregated search analytics including top queries, zero-result queries, search volume by content type and language, average results count, average processing time, and click-through rate. Results can be filtered by date range and content type.",
+                "summary": "Get search analytics metrics",
                 "parameters": [
                     {
                         "in": "query",
@@ -37945,7 +37934,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο περιεχομένου: 'product', 'blog_post', ή 'federated'. Αν δεν δοθεί, συμπεριλαμβάνει όλους τους τύπους περιεχομένου."
+                        "description": "Filter by content type: 'product', 'blog_post', or 'federated'. If not provided, includes all content types."
                     },
                     {
                         "in": "query",
@@ -37953,7 +37942,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Ημερομηνία λήξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει δεδομένα έως τη σημερινή ημερομηνία."
+                        "description": "End date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes data up to current date."
                     },
                     {
                         "in": "query",
@@ -37961,7 +37950,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Ημερομηνία έναρξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει όλα τα ιστορικά δεδομένα."
+                        "description": "Start date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes all historical data."
                     }
                 ],
                 "tags": [
@@ -37999,8 +37988,8 @@
         "/api/v1/search/blog/post": {
             "get": {
                 "operationId": "api_v1_search_blog_post_retrieve",
-                "description": "Αναζήτηση άρθρων με χρήση MeiliSearch. Παρέχει αναζήτηση πλήρους κειμένου με επισήμανση, κατάταξη και δυνατότητες facet. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά γλώσσα.",
-                "summary": "Αναζήτηση άρθρων",
+                "description": "Search blog posts using MeiliSearch. Provides full-text search with highlighting, ranking, and faceting capabilities. Results can be filtered by language.",
+                "summary": "Search blog posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -38008,7 +37997,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες."
+                        "description": "Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages."
                     },
                     {
                         "in": "query",
@@ -38024,7 +38013,7 @@
                                 }
                             ]
                         },
-                        "description": "Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή"
+                        "description": "Maximum number of results to return"
                     },
                     {
                         "in": "query",
@@ -38040,7 +38029,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων προς παράλειψη"
+                        "description": "Number of results to skip"
                     },
                     {
                         "in": "query",
@@ -38048,7 +38037,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "String αναζήτησης",
+                        "description": "Search query string",
                         "required": true
                     }
                 ],
@@ -38085,11 +38074,69 @@
                 }
             }
         },
+        "/api/v1/search/click": {
+            "post": {
+                "operationId": "api_v1_search_click_create",
+                "description": "Attribute a click on a search result to the query that produced it. The query_id comes from the search response. Feeds the click-through ranking signal and search analytics.",
+                "summary": "Log a click on a search result",
+                "tags": [
+                    "Search"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SearchClickRequestRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SearchClickRequestRequest"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SearchClickRequestRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SearchClickResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1/search/federated": {
             "get": {
                 "operationId": "api_v1_search_federated_retrieve",
-                "description": "Ταυτόχρονη αναζήτηση σε πολλαπλούς τύπους περιεχομένου με χρήση του API multi_search του Meilisearch σε λειτουργία ομοσπονδίας. Τα αποτελέσματα σταθμίζονται και συγχωνεύονται, με τα προϊόντα να έχουν βάρος 1.0 και τα άρθρα βάρος 0.7.",
-                "summary": "Ομοσπονδιακή αναζήτηση σε προϊόντα και άρθρα",
+                "description": "Search multiple content types simultaneously using Meilisearch multi_search API with federation mode. Results are weighted and merged with products having weight 1.0 and blog posts having weight 0.7.",
+                "summary": "Federated search across products and blog posts",
                 "parameters": [
                     {
                         "in": "query",
@@ -38097,7 +38144,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες."
+                        "description": "Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages."
                     },
                     {
                         "in": "query",
@@ -38113,7 +38160,7 @@
                                 }
                             ]
                         },
-                        "description": "Μέγιστος συνολικός αριθμός αποτελεσμάτων προς επιστροφή"
+                        "description": "Maximum total number of results to return"
                     },
                     {
                         "in": "query",
@@ -38129,7 +38176,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων προς παράλειψη"
+                        "description": "Number of results to skip"
                     },
                     {
                         "in": "query",
@@ -38137,7 +38184,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "String αναζήτησης",
+                        "description": "Search query string",
                         "required": true
                     }
                 ],
@@ -38177,8 +38224,8 @@
         "/api/v1/search/product": {
             "get": {
                 "operationId": "api_v1_search_product_retrieve",
-                "description": "Αναζήτηση προϊόντων με χρήση MeiliSearch, με υποστήριξη αναζήτησης πλήρους κειμένου, εύρους τιμής, δημοτικότητας, πλήθους προβολών και φίλτρων κατηγορίας. Επιστρέφει κατανομή facet και στατιστικά για δυναμικό UI φίλτρων.",
-                "summary": "Αναζήτηση προϊόντων με προηγμένα φίλτρα",
+                "description": "Search products using MeiliSearch with support for full-text search, price range, popularity, view count, and category filters. Returns facet distribution and statistics for dynamic filter UI.",
+                "summary": "Search products with advanced filters",
                 "parameters": [
                     {
                         "in": "query",
@@ -38186,7 +38233,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "ID τιμών χαρακτηριστικών διαχωρισμένα με κόμμα (attribute_values IN [ids])"
+                        "description": "Comma-separated attribute value IDs (attribute_values IN [ids])"
                     },
                     {
                         "in": "query",
@@ -38194,7 +38241,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "ID κατηγοριών διαχωρισμένα με κόμμα (category IN [ids])"
+                        "description": "Comma-separated category IDs (category IN [ids])"
                     },
                     {
                         "in": "query",
@@ -38202,7 +38249,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Πεδία facet διαχωρισμένα με κόμμα για πλήθη και στατιστικά"
+                        "description": "Comma-separated facet fields for counts and stats"
                     },
                     {
                         "in": "query",
@@ -38210,7 +38257,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες."
+                        "description": "Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages."
                     },
                     {
                         "in": "query",
@@ -38226,7 +38273,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ελάχιστων επισημάνσεων (likes_count >= value)"
+                        "description": "Minimum likes filter (likes_count >= value)"
                     },
                     {
                         "in": "query",
@@ -38242,7 +38289,7 @@
                                 }
                             ]
                         },
-                        "description": "Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή"
+                        "description": "Maximum number of results to return"
                     },
                     {
                         "in": "query",
@@ -38258,7 +38305,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων προς παράλειψη"
+                        "description": "Number of results to skip"
                     },
                     {
                         "in": "query",
@@ -38274,7 +38321,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο μέγιστης τιμής (final_price <= value)"
+                        "description": "Maximum price filter (final_price <= value)"
                     },
                     {
                         "in": "query",
@@ -38290,7 +38337,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ελάχιστης τιμής (final_price >= value)"
+                        "description": "Minimum price filter (final_price >= value)"
                     },
                     {
                         "in": "query",
@@ -38298,7 +38345,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Ερώτημα αναζήτησης πλήρους κειμένου (κενό για χωρίς φίλτρο αναζήτησης)"
+                        "description": "Full-text search query (empty for no search filter)"
                     },
                     {
                         "in": "query",
@@ -38306,7 +38353,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Πεδίο ταξινόμησης (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)"
+                        "description": "Sort field (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)"
                     },
                     {
                         "in": "query",
@@ -38322,7 +38369,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ελάχιστων προβολών (view_count >= value)"
+                        "description": "Minimum views filter (view_count >= value)"
                     }
                 ],
                 "tags": [
@@ -38361,8 +38408,8 @@
         "/api/v1/search/trending": {
             "get": {
                 "operationId": "listTrendingSearches",
-                "description": "Επιστρέφει τα πιο δημοφιλή ερωτήματα αναζήτησης των τελευταίων 24 ωρών, κατάλληλα για εμφάνιση στην κενή κατάσταση του modal αναζήτησης. Αποθηκεύεται σε cache για 5 λεπτά ανά (language_code, content_type, limit).",
-                "summary": "Λίστα trending αναζητήσεων",
+                "description": "Return the most popular search queries from the last 24 hours, suitable for surfacing in the search modal empty state. Cached for 5 minutes per (language_code, content_type, limit).",
+                "summary": "List trending search queries",
                 "parameters": [
                     {
                         "in": "query",
@@ -38370,7 +38417,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο περιεχομένου: product, blog_post, federated. Προεπιλογή product."
+                        "description": "Filter by content type: product, blog_post, federated. Defaults to product."
                     },
                     {
                         "in": "query",
@@ -38378,7 +38425,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ερωτημάτων ανά γλώσσα (π.χ. 'el')."
+                        "description": "Filter queries by language (e.g. 'el')."
                     },
                     {
                         "in": "query",
@@ -38394,7 +38441,7 @@
                                 }
                             ]
                         },
-                        "description": "Μέγιστα αποτελέσματα. Προεπιλογή 8, ανώτατο 20."
+                        "description": "Max results. Default 8, cap 20."
                     }
                 ],
                 "tags": [
@@ -38423,8 +38470,8 @@
         "/api/v1/settings": {
             "get": {
                 "operationId": "api_v1_settings_list",
-                "description": "Ανάκτηση όλων των ρυθμίσεων με τα ονόματα, τις τιμές και τους τύπους τους",
-                "summary": "Λίστα όλων των ρυθμίσεων",
+                "description": "Retrieve all settings with their names, values, and types",
+                "summary": "List all available settings",
                 "tags": [
                     "Settings"
                 ],
@@ -38463,8 +38510,8 @@
         "/api/v1/settings/get": {
             "get": {
                 "operationId": "api_v1_settings_get_retrieve",
-                "description": "Ανάκτηση συγκεκριμένης τιμής ρύθμισης βάσει του ονόματος κλειδιού της",
-                "summary": "Λήψη ρύθμισης με κλειδί",
+                "description": "Retrieve a specific setting value by its key name",
+                "summary": "Get setting by key",
                 "parameters": [
                     {
                         "in": "query",
@@ -38472,7 +38519,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Όνομα κλειδιού ρύθμισης (π.χ. CHECKOUT_SHIPPING_PRICE)",
+                        "description": "Setting key name (e.g., CHECKOUT_SHIPPING_PRICE)",
                         "required": true
                     }
                 ],
@@ -38963,8 +39010,8 @@
         "/api/v1/shipping/boxnow/lockers": {
             "get": {
                 "operationId": "listBoxNowLocker",
-                "description": "Ανάκτηση λίστας Lockers BoxNow με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Lockers BoxNow",
+                "description": "Retrieve a list of BoxNow Lockers with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List BoxNow Lockers",
                 "parameters": [
                     {
                         "in": "query",
@@ -38972,7 +39019,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -38986,7 +39033,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -39029,7 +39076,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -39042,7 +39089,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -39056,7 +39103,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -39144,8 +39191,8 @@
         "/api/v1/shipping/boxnow/lockers/{id}": {
             "get": {
                 "operationId": "retrieveBoxNowLocker",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Locker BoxNow.",
-                "summary": "Ανάκτηση Locker BoxNow",
+                "description": "Get detailed information about a specific BoxNow Locker.",
+                "summary": "Retrieve a BoxNow Locker",
                 "parameters": [
                     {
                         "in": "path",
@@ -39167,7 +39214,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -39584,8 +39631,8 @@
         "/api/v1/tag": {
             "get": {
                 "operationId": "listTag",
-                "description": "Ανάκτηση λίστας Ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Ετικέτες",
+                "description": "Retrieve a list of Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Tags",
                 "parameters": [
                     {
                         "in": "query",
@@ -39606,7 +39653,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση ενεργοποίησης"
+                        "description": "Filter by active status"
                     },
                     {
                         "in": "query",
@@ -39614,7 +39661,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο τύπο περιεχομένου"
+                        "description": "Filter tags used for specific content type"
                     },
                     {
                         "in": "query",
@@ -39622,7 +39669,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται για περιεχόμενο από συγκεκριμένη εφαρμογή"
+                        "description": "Filter tags used for content from specific app"
                     },
                     {
                         "in": "query",
@@ -39672,7 +39719,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -39693,7 +39740,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών με/χωρίς ετικέτα"
+                        "description": "Filter tags that have/don't have a label"
                     },
                     {
                         "in": "query",
@@ -39714,7 +39761,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών χρησιμοποιούμενων/μη"
+                        "description": "Filter tags that are/aren't used"
                     },
                     {
                         "in": "query",
@@ -39738,7 +39785,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -39758,7 +39805,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)"
+                        "description": "Filter by tag label (partial match)"
                     },
                     {
                         "in": "query",
@@ -39766,7 +39813,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή ετικέτα"
+                        "description": "Filter by exact tag label"
                     },
                     {
                         "in": "query",
@@ -39774,7 +39821,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ετικετών με ετικέτα που ξεκινά με"
+                        "description": "Filter tags with labels starting with"
                     },
                     {
                         "in": "query",
@@ -39788,7 +39835,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -39804,7 +39851,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται έως X φορές"
+                        "description": "Filter tags used at most X times"
                     },
                     {
                         "in": "query",
@@ -39820,7 +39867,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται τουλάχιστον X φορές"
+                        "description": "Filter tags used at least X times"
                     },
                     {
                         "in": "query",
@@ -39841,7 +39888,7 @@
                                 }
                             ]
                         },
-                        "description": "Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)"
+                        "description": "Order tags by usage count (most used first)"
                     },
                     {
                         "in": "query",
@@ -39857,7 +39904,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο ID αντικειμένου"
+                        "description": "Filter tags used for specific object ID"
                     },
                     {
                         "name": "ordering",
@@ -39900,7 +39947,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -39913,7 +39960,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -39927,7 +39974,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -40023,7 +40070,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ετικετών που δεν χρησιμοποιούνται"
+                        "description": "Filter tags not used anywhere"
                     },
                     {
                         "in": "query",
@@ -40150,8 +40197,8 @@
             },
             "post": {
                 "operationId": "createTag",
-                "description": "Δημιουργία νέου Ετικέτα. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Ετικέτα",
+                "description": "Create a new Tag. Requires authentication.",
+                "summary": "Create a Tag",
                 "parameters": [
                     {
                         "in": "query",
@@ -40165,7 +40212,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -40263,8 +40310,8 @@
         "/api/v1/tag/{id}": {
             "get": {
                 "operationId": "retrieveTag",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα.",
-                "summary": "Ανάκτηση Ετικέτα",
+                "description": "Get detailed information about a specific Tag.",
+                "summary": "Retrieve a Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -40294,7 +40341,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -40361,8 +40408,8 @@
             },
             "put": {
                 "operationId": "updateTag",
-                "description": "Ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Ετικέτα",
+                "description": "Update Tag information. Requires authentication.",
+                "summary": "Update a Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -40392,7 +40439,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -40488,8 +40535,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateTag",
-                "description": "Μερική ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Ετικέτα",
+                "description": "Partially update Tag information. Requires authentication.",
+                "summary": "Partially update a Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -40519,7 +40566,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -40614,8 +40661,8 @@
             },
             "delete": {
                 "operationId": "destroyTag",
-                "description": "Διαγραφή Ετικέτα. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Ετικέτα",
+                "description": "Delete a Tag. Requires authentication.",
+                "summary": "Delete a Tag",
                 "parameters": [
                     {
                         "in": "path",
@@ -40682,8 +40729,8 @@
         "/api/v1/tagged-item": {
             "get": {
                 "operationId": "listTaggedItem",
-                "description": "Ανάκτηση λίστας Αντικείμενα με ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Αντικείμενα με ετικέτες",
+                "description": "Retrieve a list of Tagged Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Tagged Items",
                 "parameters": [
                     {
                         "in": "query",
@@ -40691,7 +40738,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα model τύπου περιεχομένου"
+                        "description": "Filter by content type model name"
                     },
                     {
                         "in": "query",
@@ -40699,7 +40746,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά app label τύπου περιεχομένου"
+                        "description": "Filter by content type app label"
                     },
                     {
                         "in": "query",
@@ -40749,7 +40796,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -40773,7 +40820,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -40799,7 +40846,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -40815,7 +40862,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ID αντικειμένου"
+                        "description": "Filter by object ID"
                     },
                     {
                         "in": "query",
@@ -40824,7 +40871,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -40836,7 +40883,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά πολλαπλά ID αντικειμένων (διαχωρισμένα με κόμμα)",
+                        "description": "Filter by multiple object IDs (comma-separated)",
                         "explode": false,
                         "style": "form"
                     },
@@ -40881,7 +40928,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -40894,7 +40941,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -40908,7 +40955,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -40933,7 +40980,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά συγκεκριμένο ID ετικέτας"
+                        "description": "Filter by specific tag ID"
                     },
                     {
                         "in": "query",
@@ -40954,7 +41001,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά ενεργή κατάσταση ετικέτας"
+                        "description": "Filter by tag active status"
                     },
                     {
                         "in": "query",
@@ -40962,7 +41009,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)"
+                        "description": "Filter by tag label (partial match)"
                     },
                     {
                         "in": "query",
@@ -41089,8 +41136,8 @@
             },
             "post": {
                 "operationId": "createTaggedItem",
-                "description": "Δημιουργία νέου Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Σχετιζόμενο Είδος",
+                "description": "Create a new Tagged Item. Requires authentication.",
+                "summary": "Create a Tagged Item",
                 "parameters": [
                     {
                         "in": "query",
@@ -41104,7 +41151,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -41202,8 +41249,8 @@
         "/api/v1/tagged-item/{id}": {
             "get": {
                 "operationId": "retrieveTaggedItem",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχετιζόμενο Είδος.",
-                "summary": "Ανάκτηση Σχετιζόμενο Είδος",
+                "description": "Get detailed information about a specific Tagged Item.",
+                "summary": "Retrieve a Tagged Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -41233,7 +41280,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -41300,8 +41347,8 @@
             },
             "put": {
                 "operationId": "updateTaggedItem",
-                "description": "Ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Σχετιζόμενο Είδος",
+                "description": "Update Tagged Item information. Requires authentication.",
+                "summary": "Update a Tagged Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -41331,7 +41378,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -41427,8 +41474,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateTaggedItem",
-                "description": "Μερική ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Σχετιζόμενο Είδος",
+                "description": "Partially update Tagged Item information. Requires authentication.",
+                "summary": "Partially update a Tagged Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -41458,7 +41505,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -41553,8 +41600,8 @@
             },
             "delete": {
                 "operationId": "destroyTaggedItem",
-                "description": "Διαγραφή Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Σχετιζόμενο Είδος",
+                "description": "Delete a Tagged Item. Requires authentication.",
+                "summary": "Delete a Tagged Item",
                 "parameters": [
                     {
                         "in": "path",
@@ -41657,8 +41704,8 @@
         "/api/v1/user/account": {
             "get": {
                 "operationId": "listUserAccount",
-                "description": "Ανάκτηση λίστας Λογαριασμοί Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Λογαριασμοί Χρηστών",
+                "description": "Retrieve a list of User Accounts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List User Accounts",
                 "parameters": [
                     {
                         "in": "query",
@@ -41666,7 +41713,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -41680,7 +41727,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -41723,7 +41770,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -41736,7 +41783,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -41750,7 +41797,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -41835,8 +41882,8 @@
             },
             "post": {
                 "operationId": "createUserAccount",
-                "description": "Δημιουργία νέου Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Λογαριασμός Χρήστη",
+                "description": "Create a new User Account. Requires authentication.",
+                "summary": "Create a User Account",
                 "parameters": [
                     {
                         "in": "query",
@@ -41850,7 +41897,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -41948,8 +41995,8 @@
         "/api/v1/user/account/{id}": {
             "get": {
                 "operationId": "retrieveUserAccount",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Λογαριασμός Χρήστη.",
-                "summary": "Ανάκτηση Λογαριασμός Χρήστη",
+                "description": "Get detailed information about a specific User Account.",
+                "summary": "Retrieve a User Account",
                 "parameters": [
                     {
                         "in": "path",
@@ -41979,7 +42026,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -42045,8 +42092,8 @@
             },
             "put": {
                 "operationId": "updateUserAccount",
-                "description": "Ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Λογαριασμός Χρήστη",
+                "description": "Update User Account information. Requires authentication.",
+                "summary": "Update a User Account",
                 "parameters": [
                     {
                         "in": "path",
@@ -42076,7 +42123,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -42172,8 +42219,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateUserAccount",
-                "description": "Μερική ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Λογαριασμός Χρήστη",
+                "description": "Partially update User Account information. Requires authentication.",
+                "summary": "Partially update a User Account",
                 "parameters": [
                     {
                         "in": "path",
@@ -42203,7 +42250,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -42300,8 +42347,8 @@
         "/api/v1/user/account/{id}/addresses": {
             "get": {
                 "operationId": "getUserAccountAddresses",
-                "description": "Λήψη όλων των διευθύνσεων για συγκεκριμένο χρήστη.",
-                "summary": "Λήψη διευθύνσεων χρήστη",
+                "description": "Get all addresses for a specific user.",
+                "summary": "Get user's addresses",
                 "parameters": [
                     {
                         "in": "path",
@@ -42448,8 +42495,8 @@
         "/api/v1/user/account/{id}/blog_post_comments": {
             "get": {
                 "operationId": "getUserAccountBlogPostComments",
-                "description": "Λήψη όλων των σχολίων σε άρθρα που έχει γράψει συγκεκριμένος χρήστης.",
-                "summary": "Λήψη σχολίων blog χρήστη",
+                "description": "Get all blog post comments written by a specific user.",
+                "summary": "Get user's blog comments",
                 "parameters": [
                     {
                         "in": "path",
@@ -42596,8 +42643,8 @@
         "/api/v1/user/account/{id}/change_username": {
             "post": {
                 "operationId": "changeUserAccountUsername",
-                "description": "Αλλαγή του ονόματος χρήστη για συγκεκριμένο χρήστη.",
-                "summary": "Αλλαγή ονόματος χρήστη",
+                "description": "Change the username for a specific user.",
+                "summary": "Change username",
                 "parameters": [
                     {
                         "in": "path",
@@ -42711,8 +42758,8 @@
         "/api/v1/user/account/{id}/data_exports": {
             "get": {
                 "operationId": "listUserAccountDataExports",
-                "description": "Λίστα πρόσφατων αιτημάτων εξαγωγής δεδομένων για αυτόν τον χρήστη, ώστε η διεπαφή να εμφανίζει την πρόοδο και τον τελευταίο σύνδεσμο λήψης.",
-                "summary": "Λίστα εξαγωγών δεδομένων GDPR",
+                "description": "List recent data-export requests for this user so the UI can show progress and the last download link.",
+                "summary": "List GDPR data exports",
                 "parameters": [
                     {
                         "in": "path",
@@ -42859,8 +42906,8 @@
         "/api/v1/user/account/{id}/delete_account": {
             "post": {
                 "operationId": "deleteUserAccountGdpr",
-                "description": "Ανωνυμοποιεί τις παραγγελίες του χρήστη (διατηρούνται για φορολογικούς/λογιστικούς λόγους) και διαγράφει οριστικά κάθε άλλη συνδεδεμένη εγγραφή. Μη αναστρέψιμο. Ο καλών πρέπει να έχει επανα-ταυτοποιηθεί μέσω allauth εντός του χρονικού παραθύρου που ορίζεται από το ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.",
-                "summary": "Διαγραφή λογαριασμού (δικαίωμα διαγραφής GDPR)",
+                "description": "Anonymises the user's orders (kept for tax/accounting) and hard-deletes every other linked record. Irreversible. Caller must have re-authenticated via allauth within the window configured by ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.",
+                "summary": "Delete account (GDPR right-to-erasure)",
                 "parameters": [
                     {
                         "in": "path",
@@ -42974,8 +43021,8 @@
         "/api/v1/user/account/{id}/favourite_products": {
             "get": {
                 "operationId": "getUserAccountFavouriteProducts",
-                "description": "Λήψη όλων των αγαπημένων προϊόντων για συγκεκριμένο χρήστη.",
-                "summary": "Λήψη αγαπημένων προϊόντων χρήστη",
+                "description": "Get all favourite products for a specific user.",
+                "summary": "Get user's favourite products",
                 "parameters": [
                     {
                         "in": "path",
@@ -43122,8 +43169,8 @@
         "/api/v1/user/account/{id}/liked_blog_posts": {
             "get": {
                 "operationId": "getUserAccountLikedBlogPosts",
-                "description": "Λήψη όλων των άρθρων που έχει επισημάνει συγκεκριμένος χρήστης.",
-                "summary": "Λήψη άρθρων με επισήμανση χρήστη",
+                "description": "Get all blog posts liked by a specific user.",
+                "summary": "Get user's liked blog posts",
                 "parameters": [
                     {
                         "in": "path",
@@ -43270,8 +43317,8 @@
         "/api/v1/user/account/{id}/notifications": {
             "get": {
                 "operationId": "getUserAccountNotifications",
-                "description": "Λήψη όλων των ειδοποιήσεων για συγκεκριμένο χρήστη.",
-                "summary": "Λήψη ειδοποιήσεων χρήστη",
+                "description": "Get all notifications for a specific user.",
+                "summary": "Get user's notifications",
                 "parameters": [
                     {
                         "in": "path",
@@ -43361,7 +43408,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ειδοποιήσεων κατά κατάσταση ορατότητας."
+                        "description": "Filter notifications by seen/unseen state."
                     }
                 ],
                 "tags": [
@@ -43439,8 +43486,8 @@
         "/api/v1/user/account/{id}/orders": {
             "get": {
                 "operationId": "getUserAccountOrders",
-                "description": "Λήψη όλων των παραγγελιών για συγκεκριμένο χρήστη.",
-                "summary": "Λήψη παραγγελιών χρήστη",
+                "description": "Get all orders for a specific user.",
+                "summary": "Get user's orders",
                 "parameters": [
                     {
                         "in": "path",
@@ -43587,8 +43634,8 @@
         "/api/v1/user/account/{id}/product_reviews": {
             "get": {
                 "operationId": "getUserAccountProductReviews",
-                "description": "Λήψη όλων των αξιολογήσεων προϊόντων που έχει γράψει συγκεκριμένος χρήστης.",
-                "summary": "Λήψη κριτικών προϊόντος χρήστη",
+                "description": "Get all product reviews written by a specific user.",
+                "summary": "Get user's product reviews",
                 "parameters": [
                     {
                         "in": "path",
@@ -43735,8 +43782,8 @@
         "/api/v1/user/account/{id}/request_data_export": {
             "post": {
                 "operationId": "requestUserAccountDataExport",
-                "description": "Ουρά εργασίας που συγκεντρώνει τα προσωπικά δεδομένα του χρήστη και αποστέλλει με email έναν εφάπαξ σύνδεσμο λήψης. Επιστρέφει τη νέα εγγραφή UserDataExport.",
-                "summary": "Αίτημα εξαγωγής δεδομένων GDPR",
+                "description": "Queue a job that compiles the user's personal data and emails a one-off download link. Returns the new UserDataExport record.",
+                "summary": "Request GDPR data export",
                 "parameters": [
                     {
                         "in": "path",
@@ -43830,8 +43877,8 @@
         "/api/v1/user/address": {
             "get": {
                 "operationId": "listUserAddress",
-                "description": "Ανάκτηση λίστας Διευθύνσεις Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Διευθύνσεις Χρηστών",
+                "description": "Retrieve a list of User Addresses with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List User Addresses",
                 "parameters": [
                     {
                         "in": "query",
@@ -43839,7 +43886,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα πόλης (μερική αντιστοίχιση)"
+                        "description": "Filter by city name (partial match)"
                     },
                     {
                         "in": "query",
@@ -43854,7 +43901,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά alpha_2 κωδικό χώρας"
+                        "description": "Filter by country alpha_2 code"
                     },
                     {
                         "in": "query",
@@ -43862,7 +43909,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό χώρας (π.χ. 'US', 'CA')"
+                        "description": "Filter by country code (e.g., 'US', 'CA')"
                     },
                     {
                         "in": "query",
@@ -43870,7 +43917,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)"
+                        "description": "Filter by country name (partial match)"
                     },
                     {
                         "in": "query",
@@ -43920,7 +43967,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -43928,7 +43975,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα (μερική αντιστοίχιση)"
+                        "description": "Filter by first name (partial match)"
                     },
                     {
                         "in": "query",
@@ -43942,7 +43989,6 @@
                         "name": "floor",
                         "schema": {
                             "type": "string",
-                            "title": "Όροφος",
                             "enum": [
                                 "",
                                 "BASEMENT",
@@ -43955,7 +44001,7 @@
                                 "THIRD_FLOOR"
                             ]
                         },
-                        "description": "Φίλτρο ανά όροφο"
+                        "description": "Filter by floor"
                     },
                     {
                         "in": "query",
@@ -43963,7 +44009,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά πλήρες όνομα (όνομα + επώνυμο)"
+                        "description": "Filter by full name (first + last name)"
                     },
                     {
                         "in": "query",
@@ -43984,7 +44030,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο διευθύνσεων με σημειώσεις"
+                        "description": "Filter addresses that have notes"
                     },
                     {
                         "in": "query",
@@ -44008,7 +44054,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -44041,7 +44087,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κύρια διεύθυνση"
+                        "description": "Filter by main address status"
                     },
                     {
                         "in": "query",
@@ -44055,7 +44101,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -44063,7 +44109,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά επώνυμο (μερική αντιστοίχιση)"
+                        "description": "Filter by last name (partial match)"
                     },
                     {
                         "in": "query",
@@ -44078,7 +44124,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά τύπο τοποθεσίας (ακριβής αντιστοίχιση, χωρίς διάκριση πεζών/κεφαλαίων)"
+                        "description": "Filter by location type (exact match, case insensitive)"
                     },
                     {
                         "in": "query",
@@ -44136,7 +44182,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -44149,7 +44195,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -44163,7 +44209,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -44171,7 +44217,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό τηλεφώνου (μερική αντιστοίχιση)"
+                        "description": "Filter by phone number (partial match)"
                     },
                     {
                         "in": "query",
@@ -44186,7 +44232,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αλφαριθμητικό κωδικό περιφέρειας"
+                        "description": "Filter by region alpha code"
                     },
                     {
                         "in": "query",
@@ -44194,7 +44240,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά κωδικό περιφέρειας"
+                        "description": "Filter by region code"
                     },
                     {
                         "in": "query",
@@ -44202,7 +44248,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)"
+                        "description": "Filter by region name (partial match)"
                     },
                     {
                         "name": "search",
@@ -44219,7 +44265,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα οδού (μερική αντιστοίχιση)"
+                        "description": "Filter by street name (partial match)"
                     },
                     {
                         "in": "query",
@@ -44234,7 +44280,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά αριθμό"
+                        "description": "Filter by street number"
                     },
                     {
                         "in": "query",
@@ -44313,7 +44359,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ταχυδρομικό κώδικα (μερική αντιστοίχιση)"
+                        "description": "Filter by zipcode (partial match)"
                     },
                     {
                         "in": "query",
@@ -44328,7 +44374,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβή ταχυδρομικό κώδικα"
+                        "description": "Filter by exact zipcode"
                     }
                 ],
                 "tags": [
@@ -44404,8 +44450,8 @@
             },
             "post": {
                 "operationId": "createUserAddress",
-                "description": "Δημιουργία νέου Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Διεύθυνση Χρήστη",
+                "description": "Create a new User Address. Requires authentication.",
+                "summary": "Create a User Address",
                 "parameters": [
                     {
                         "in": "query",
@@ -44419,7 +44465,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -44517,8 +44563,8 @@
         "/api/v1/user/address/{id}": {
             "get": {
                 "operationId": "retrieveUserAddress",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Διεύθυνση Χρήστη.",
-                "summary": "Ανάκτηση Διεύθυνση Χρήστη",
+                "description": "Get detailed information about a specific User Address.",
+                "summary": "Retrieve a User Address",
                 "parameters": [
                     {
                         "in": "path",
@@ -44548,7 +44594,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -44614,8 +44660,8 @@
             },
             "put": {
                 "operationId": "updateUserAddress",
-                "description": "Ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Διεύθυνση Χρήστη",
+                "description": "Update User Address information. Requires authentication.",
+                "summary": "Update a User Address",
                 "parameters": [
                     {
                         "in": "path",
@@ -44645,7 +44691,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -44741,8 +44787,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateUserAddress",
-                "description": "Μερική ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Διεύθυνση Χρήστη",
+                "description": "Partially update User Address information. Requires authentication.",
+                "summary": "Partially update a User Address",
                 "parameters": [
                     {
                         "in": "path",
@@ -44772,7 +44818,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -44867,8 +44913,8 @@
             },
             "delete": {
                 "operationId": "destroyUserAddress",
-                "description": "Διαγραφή Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Διεύθυνση Χρήστη",
+                "description": "Delete a User Address. Requires authentication.",
+                "summary": "Delete a User Address",
                 "parameters": [
                     {
                         "in": "path",
@@ -44935,8 +44981,8 @@
         "/api/v1/user/address/{id}/set_main": {
             "post": {
                 "operationId": "setMainUserAddress",
-                "description": "Ορισμός αυτής της διεύθυνσης ως κύριας διεύθυνσης του χρήστη.",
-                "summary": "Ορισμός διεύθυνσης ως κύριας",
+                "description": "Set this address as the user's main address.",
+                "summary": "Set address as main",
                 "parameters": [
                     {
                         "in": "path",
@@ -45030,8 +45076,8 @@
         "/api/v1/user/data_export/{token}/download": {
             "get": {
                 "operationId": "downloadUserDataExport",
-                "description": "Επιστρέφει το πακέτο JSON που παρήγαγε η εργασία εξαγωγής. Το token έχει ένα μόνο πεδίο εφαρμογής, συνδέεται με μία εγγραφή UserDataExport, και λήγει 7 ημέρες μετά την παραγωγή της εξαγωγής.",
-                "summary": "Λήψη πακέτου εξαγωγής δεδομένων GDPR",
+                "description": "Returns the JSON bundle produced by the export task. The token is single-scope, tied to one UserDataExport row, and expires 7 days after the export was produced.",
+                "summary": "Download a GDPR data export bundle",
                 "parameters": [
                     {
                         "in": "path",
@@ -45064,8 +45110,8 @@
         "/api/v1/user/subscription": {
             "get": {
                 "operationId": "listUserSubscription",
-                "description": "Ανάκτηση λίστας Συνδρομές Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Συνδρομές Χρηστών",
+                "description": "Retrieve a list of User Subscriptions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List User Subscriptions",
                 "parameters": [
                     {
                         "in": "query",
@@ -45115,7 +45161,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -45136,7 +45182,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο εγγραφών με metadata"
+                        "description": "Filter subscriptions that have metadata"
                     },
                     {
                         "in": "query",
@@ -45160,7 +45206,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -45193,7 +45239,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση επιβεβαίωσης"
+                        "description": "Filter by confirmation status"
                     },
                     {
                         "in": "query",
@@ -45207,7 +45253,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "name": "ordering",
@@ -45250,7 +45296,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -45263,7 +45309,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -45277,7 +45323,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "name": "search",
@@ -45293,7 +45339,6 @@
                         "name": "status",
                         "schema": {
                             "type": "string",
-                            "title": "Κατάσταση",
                             "enum": [
                                 "ACTIVE",
                                 "BOUNCED",
@@ -45301,7 +45346,7 @@
                                 "UNSUBSCRIBED"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση συνδρομής\n\n* `ACTIVE` - Ενεργή\n* `PENDING` - Εκκρεμεί Επιβεβαίωση\n* `UNSUBSCRIBED` - Διαγραφή\n* `BOUNCED` - Επιστράφηκε"
+                        "description": "Filter by subscription status\n\n* `ACTIVE` - Active\n* `PENDING` - Pending Confirmation\n* `UNSUBSCRIBED` - Unsubscribed\n* `BOUNCED` - Bounced"
                     },
                     {
                         "in": "query",
@@ -45310,7 +45355,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο εγγραφών που δημιουργήθηκαν μετά από αυτή την ημερομηνία"
+                        "description": "Filter subscriptions created after this date"
                     },
                     {
                         "in": "query",
@@ -45343,7 +45388,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο εγγραφών που δημιουργήθηκαν πριν από αυτή την ημερομηνία"
+                        "description": "Filter subscriptions created before this date"
                     },
                     {
                         "in": "query",
@@ -45359,14 +45404,13 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά θέμα συνδρομής"
+                        "description": "Filter by subscription topic"
                     },
                     {
                         "in": "query",
                         "name": "topicCategory",
                         "schema": {
                             "type": "string",
-                            "title": "Κατηγορία",
                             "enum": [
                                 "ACCOUNT",
                                 "MARKETING",
@@ -45377,7 +45421,7 @@
                                 "SYSTEM"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατηγορία θέματος\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Filter by topic category\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     {
                         "in": "query",
@@ -45385,7 +45429,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιγραφή θέματος (μερική αντιστοίχιση)"
+                        "description": "Filter by topic description (partial match)"
                     },
                     {
                         "in": "query",
@@ -45393,7 +45437,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα θέματος (μερική αντιστοίχιση)"
+                        "description": "Filter by topic name (partial match)"
                     },
                     {
                         "in": "query",
@@ -45401,7 +45445,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug θέματος (μερική αντιστοίχιση)"
+                        "description": "Filter by topic slug (partial match)"
                     },
                     {
                         "in": "query",
@@ -45409,7 +45453,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβές slug θέματος"
+                        "description": "Filter by exact topic slug"
                     },
                     {
                         "in": "query",
@@ -45418,7 +45462,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο εγγραφών με διαγραφή μετά από αυτή την ημερομηνία"
+                        "description": "Filter subscriptions unsubscribed after this date"
                     },
                     {
                         "in": "query",
@@ -45451,7 +45495,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "description": "Φίλτρο εγγραφών με διαγραφή πριν από αυτή την ημερομηνία"
+                        "description": "Filter subscriptions unsubscribed before this date"
                     },
                     {
                         "in": "query",
@@ -45577,8 +45621,8 @@
             },
             "post": {
                 "operationId": "createUserSubscription",
-                "description": "Δημιουργία νέου Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Συνδρομή Χρήστη",
+                "description": "Create a new User Subscription. Requires authentication.",
+                "summary": "Create a User Subscription",
                 "parameters": [
                     {
                         "in": "query",
@@ -45592,7 +45636,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -45690,8 +45734,8 @@
         "/api/v1/user/subscription/{id}": {
             "get": {
                 "operationId": "retrieveUserSubscription",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συνδρομή Χρήστη.",
-                "summary": "Ανάκτηση Συνδρομή Χρήστη",
+                "description": "Get detailed information about a specific User Subscription.",
+                "summary": "Retrieve a User Subscription",
                 "parameters": [
                     {
                         "in": "path",
@@ -45721,7 +45765,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -45787,8 +45831,8 @@
             },
             "put": {
                 "operationId": "updateUserSubscription",
-                "description": "Ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Συνδρομή Χρήστη",
+                "description": "Update User Subscription information. Requires authentication.",
+                "summary": "Update a User Subscription",
                 "parameters": [
                     {
                         "in": "path",
@@ -45818,7 +45862,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -45914,8 +45958,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateUserSubscription",
-                "description": "Μερική ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Συνδρομή Χρήστη",
+                "description": "Partially update User Subscription information. Requires authentication.",
+                "summary": "Partially update a User Subscription",
                 "parameters": [
                     {
                         "in": "path",
@@ -45945,7 +45989,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -46040,8 +46084,8 @@
             },
             "delete": {
                 "operationId": "destroyUserSubscription",
-                "description": "Διαγραφή Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Συνδρομή Χρήστη",
+                "description": "Delete a User Subscription. Requires authentication.",
+                "summary": "Delete a User Subscription",
                 "parameters": [
                     {
                         "in": "path",
@@ -46108,8 +46152,8 @@
         "/api/v1/user/subscription/{id}/confirm": {
             "post": {
                 "operationId": "confirmUserSubscription",
-                "description": "Επιβεβαίωση εκκρεμούς εγγραφής με χρήση του token επιβεβαίωσης.",
-                "summary": "Επιβεβαίωση συνδρομής χρήστη",
+                "description": "Confirm a pending subscription using the confirmation token.",
+                "summary": "Confirm a user subscription",
                 "parameters": [
                     {
                         "in": "path",
@@ -46203,8 +46247,8 @@
         "/api/v1/user/subscription/bulk_update": {
             "post": {
                 "operationId": "bulkUpdateUserSubscriptions",
-                "description": "Εγγραφή ή διαγραφή από πολλαπλά θέματα ταυτόχρονα.",
-                "summary": "Μαζική ενημέρωση συνδρομών χρήστη",
+                "description": "Subscribe or unsubscribe from multiple topics at once.",
+                "summary": "Bulk update user subscriptions",
                 "tags": [
                     "User Subscriptions"
                 ],
@@ -46301,7 +46345,7 @@
             "get": {
                 "operationId": "confirmSubscriptionByToken",
                 "description": "Public endpoint for the confirmation link emailed to new subscribers.\n\nThe confirmation token itself is 64 chars of random entropy (sufficient\nauthorization); no login required. Accepts both GET (user clicks the\nlink in a mail client) and POST (for programmatic confirmation).",
-                "summary": "Επιβεβαίωση εκκρεμούς εγγραφής μέσω token email",
+                "summary": "Confirm a pending subscription via email token",
                 "parameters": [
                     {
                         "in": "path",
@@ -46391,15 +46435,14 @@
         "/api/v1/user/subscription/topic": {
             "get": {
                 "operationId": "listSubscriptionTopic",
-                "description": "Ανάκτηση λίστας Θέματα Συνδρομών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.",
-                "summary": "Λίστα Θέματα Συνδρομών",
+                "description": "Retrieve a list of Subscription Topics with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.",
+                "summary": "List Subscription Topics",
                 "parameters": [
                     {
                         "in": "query",
                         "name": "category",
                         "schema": {
                             "type": "string",
-                            "title": "Κατηγορία",
                             "enum": [
                                 "ACCOUNT",
                                 "MARKETING",
@@ -46410,7 +46453,7 @@
                                 "SYSTEM"
                             ]
                         },
-                        "description": "Φίλτρο ανά κατηγορία θέματος\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Filter by topic category\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     {
                         "in": "query",
@@ -46460,7 +46503,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Δείκτης (cursor) για σελιδοποίηση"
+                        "description": "Cursor for pagination"
                     },
                     {
                         "in": "query",
@@ -46468,7 +46511,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)"
+                        "description": "Filter by description (partial match)"
                     },
                     {
                         "in": "query",
@@ -46489,7 +46532,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο θεμάτων με εγγεγραμμένους"
+                        "description": "Filter topics that have subscribers"
                     },
                     {
                         "in": "query",
@@ -46513,7 +46556,7 @@
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "Τιμές διαχωρισμένες με κόμμα"
+                                    "description": "Comma-separated values"
                                 },
                                 {
                                     "type": "array",
@@ -46546,7 +46589,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά κατάσταση ενεργοποίησης"
+                        "description": "Filter by active status"
                     },
                     {
                         "in": "query",
@@ -46567,7 +46610,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά προεπιλεγμένη κατάσταση εγγραφής"
+                        "description": "Filter by default subscription status"
                     },
                     {
                         "in": "query",
@@ -46581,7 +46624,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     },
                     {
                         "in": "query",
@@ -46589,7 +46632,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά όνομα (μερική αντιστοίχιση)"
+                        "description": "Filter by name (partial match)"
                     },
                     {
                         "name": "ordering",
@@ -46632,7 +46675,7 @@
                                 }
                             ]
                         },
-                        "description": "Αριθμός αποτελεσμάτων ανά σελίδα"
+                        "description": "Number of results to return per page"
                     },
                     {
                         "in": "query",
@@ -46645,7 +46688,7 @@
                             ],
                             "default": "true"
                         },
-                        "description": "Ενεργοποίηση/απενεργοποίηση σελιδοποίησης"
+                        "description": "Enable or disable pagination"
                     },
                     {
                         "in": "query",
@@ -46659,7 +46702,7 @@
                             ],
                             "default": "pageNumber"
                         },
-                        "description": "Τύπος στρατηγικής σελιδοποίησης"
+                        "description": "Pagination strategy type"
                     },
                     {
                         "in": "query",
@@ -46680,7 +46723,7 @@
                                 }
                             ]
                         },
-                        "description": "Φίλτρο ανά απαίτηση επιβεβαίωσης"
+                        "description": "Filter by confirmation requirement"
                     },
                     {
                         "name": "search",
@@ -46697,7 +46740,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά slug (μερική αντιστοίχιση)"
+                        "description": "Filter by slug (partial match)"
                     },
                     {
                         "in": "query",
@@ -46712,7 +46755,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Φίλτρο ανά ακριβές slug"
+                        "description": "Filter by exact slug"
                     },
                     {
                         "in": "query",
@@ -46838,8 +46881,8 @@
             },
             "post": {
                 "operationId": "createSubscriptionTopic",
-                "description": "Δημιουργία νέου Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.",
-                "summary": "Δημιουργία Θέμα Συνδρομής",
+                "description": "Create a new Subscription Topic. Requires authentication.",
+                "summary": "Create a Subscription Topic",
                 "parameters": [
                     {
                         "in": "query",
@@ -46853,7 +46896,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -46951,8 +46994,8 @@
         "/api/v1/user/subscription/topic/{id}": {
             "get": {
                 "operationId": "retrieveSubscriptionTopic",
-                "description": "Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Θέμα Συνδρομής.",
-                "summary": "Ανάκτηση Θέμα Συνδρομής",
+                "description": "Get detailed information about a specific Subscription Topic.",
+                "summary": "Retrieve a Subscription Topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -46982,7 +47025,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -47048,8 +47091,8 @@
             },
             "put": {
                 "operationId": "updateSubscriptionTopic",
-                "description": "Ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.",
-                "summary": "Ενημέρωση Θέμα Συνδρομής",
+                "description": "Update Subscription Topic information. Requires authentication.",
+                "summary": "Update a Subscription Topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47079,7 +47122,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -47175,8 +47218,8 @@
             },
             "patch": {
                 "operationId": "partialUpdateSubscriptionTopic",
-                "description": "Μερική ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.",
-                "summary": "Μερική ενημέρωση Θέμα Συνδρομής",
+                "description": "Partially update Subscription Topic information. Requires authentication.",
+                "summary": "Partially update a Subscription Topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47206,7 +47249,7 @@
                             ],
                             "default": "el"
                         },
-                        "description": "Κωδικός γλώσσας για μεταφράσεις (el, en, de)"
+                        "description": "Language code for translations (el, en, de)"
                     }
                 ],
                 "tags": [
@@ -47301,8 +47344,8 @@
             },
             "delete": {
                 "operationId": "destroySubscriptionTopic",
-                "description": "Διαγραφή Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.",
-                "summary": "Διαγραφή Θέμα Συνδρομής",
+                "description": "Delete a Subscription Topic. Requires authentication.",
+                "summary": "Delete a Subscription Topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47369,8 +47412,8 @@
         "/api/v1/user/subscription/topic/{id}/subscribe": {
             "post": {
                 "operationId": "subscribeToTopic",
-                "description": "Εγγραφή του τρέχοντος χρήστη σε συγκεκριμένο θέμα εγγραφής.",
-                "summary": "Εγγραφή σε θέμα",
+                "description": "Subscribe the current user to a specific subscription topic.",
+                "summary": "Subscribe to a topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47474,8 +47517,8 @@
         "/api/v1/user/subscription/topic/{id}/unsubscribe": {
             "post": {
                 "operationId": "unsubscribeFromTopic",
-                "description": "Διαγραφή του τρέχοντος χρήστη από συγκεκριμένο θέμα εγγραφής.",
-                "summary": "Διαγραφή από θέμα",
+                "description": "Unsubscribe the current user from a specific subscription topic.",
+                "summary": "Unsubscribe from a topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47569,8 +47612,8 @@
         "/api/v1/user/subscription/topic/my_subscriptions": {
             "get": {
                 "operationId": "getMySubscriptionTopics",
-                "description": "Λήψη των θεμάτων εγγραφής στα οποία είναι εγγεγραμμένος και των διαθέσιμων θεμάτων για τον τρέχοντα χρήστη.",
-                "summary": "Λήψη συνδρομών μου",
+                "description": "Get the current user's subscribed and available subscription topics.",
+                "summary": "Get my subscriptions",
                 "tags": [
                     "Subscription Topics"
                 ],
@@ -47661,7 +47704,7 @@
             "get": {
                 "operationId": "unsubscribeFromAllViaLink",
                 "description": "Non-topic unsubscribe: `/unsubscribe/<token>`.\n\nUnsubscribes from ALL active subscriptions — used by emails without a\ntopic binding such as re-engagement and abandoned-cart.",
-                "summary": "Διαγραφή από όλα τα θέματα μέσω συνδέσμου email (GET)",
+                "summary": "Unsubscribe from all topics via email link (GET)",
                 "parameters": [
                     {
                         "in": "path",
@@ -47700,8 +47743,8 @@
             },
             "post": {
                 "operationId": "unsubscribeFromAllOneClick",
-                "description": "Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).",
-                "summary": "Διαγραφή με ένα κλικ από όλα τα θέματα κατά RFC 8058",
+                "description": "Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).",
+                "summary": "RFC 8058 one-click unsubscribe from all topics",
                 "parameters": [
                     {
                         "in": "path",
@@ -47726,7 +47769,7 @@
             "get": {
                 "operationId": "unsubscribeFromTopicViaLink",
                 "description": "Topic-scoped unsubscribe: `/unsubscribe/<token>/<topic_slug>`.\n\nUsed by marketing emails with a specific List-ID (newsletter etc.).",
-                "summary": "Διαγραφή από θέμα μέσω συνδέσμου email (GET)",
+                "summary": "Unsubscribe from a topic via email link (GET)",
                 "parameters": [
                     {
                         "in": "path",
@@ -47773,8 +47816,8 @@
             },
             "post": {
                 "operationId": "unsubscribeFromTopicOneClick",
-                "description": "Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).",
-                "summary": "Διαγραφή με ένα κλικ από θέμα κατά RFC 8058",
+                "description": "Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).",
+                "summary": "RFC 8058 one-click unsubscribe from a topic",
                 "parameters": [
                     {
                         "in": "path",
@@ -47956,7 +47999,7 @@
                     2
                 ],
                 "type": "integer",
-                "description": "* `1` - Προπληρωμένο\n* `2` - Αντικαταβολή"
+                "description": "* `1` - Prepaid\n* `2` - Cash on delivery"
             },
             "AcsPickupList": {
                 "type": "object",
@@ -47968,21 +48011,19 @@
                     "pickupListNo": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Αριθμός λίστας παραλαβής",
-                        "description": "PickupList_No που επιστρέφεται από το ACS_Issue_Pickup_List."
+                        "title": "Pickup list number",
+                        "description": "PickupList_No returned by ACS_Issue_Pickup_List."
                     },
                     "issuedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Εκδόθηκε στις"
+                        "readOnly": true
                     },
                     "issuedBy": {
                         "type": "integer",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Εκδόθηκε από",
-                        "description": "Διαχειριστής που ενεργοποίησε τη χειροκίνητη έκδοση. Null όταν η λίστα εκδόθηκε από την καθημερινή εργασία Celery beat."
+                        "description": "Admin who triggered the manual issue. Null when the daily Celery beat task issued the list."
                     },
                     "issuedByUsername": {
                         "type": "string",
@@ -47992,25 +48033,21 @@
                     "billingCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κωδικός χρέωσης",
-                        "description": "Billing_Code που καταγράφεται τη στιγμή της έκδοσης, ώστε τα ιστορικά manifest να παραμένουν επανεκτυπώσιμα ακόμη κι αν αλλάξει η μεταβλητή περιβάλλοντος."
+                        "description": "Billing_Code captured at issuance time so historical manifests stay reprintable even if the env var changes."
                     },
                     "voucherCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Πλήθος vouchers"
+                        "readOnly": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -48042,8 +48079,8 @@
                         "type": "string",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Αριθμός voucher",
-                        "description": "10ψήφιο voucher ACS (Voucher_No από το ACS_Create_Voucher)."
+                        "title": "Voucher number",
+                        "description": "10-digit ACS voucher (Voucher_No from ACS_Create_Voucher)."
                     },
                     "shipmentState": {
                         "allOf": [
@@ -48051,13 +48088,12 @@
                                 "$ref": "#/components/schemas/ShipmentStateEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Κατάσταση αποστολής"
+                        "readOnly": true
                     },
                     "shipmentStateDisplay": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Ετικέτα σε αναγνώσιμη μορφή για την τιμή shipment_state"
+                        "description": "Human-readable label for the shipment_state choice"
                     },
                     "deliveryKind": {
                         "allOf": [
@@ -48065,19 +48101,17 @@
                                 "$ref": "#/components/schemas/ShippingKind"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τρόπος παράδοσης"
+                        "readOnly": true
                     },
                     "weightGrams": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Βάρος (γραμμάρια)",
-                        "description": "Εσωτερικά γραμμάρια· μετατρέπονται σε κιλά (>= 0,5) κατά την κλήση API σύμφωνα με τις απαιτήσεις βάρους της ACS."
+                        "title": "Weight (grams)",
+                        "description": "Internal grams; converted to kilograms (>= 0.5) at API call time per ACS Weight requirements."
                     },
                     "itemQuantity": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Ποσότητα ειδών"
+                        "readOnly": true
                     },
                     "chargeType": {
                         "allOf": [
@@ -48085,60 +48119,53 @@
                                 "$ref": "#/components/schemas/AcsChargeType"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τύπος χρέωσης"
+                        "readOnly": true
                     },
                     "deliveryProducts": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Προϊόντα παράδοσης",
-                        "description": "Κωδικοί Acs_Delivery_Products διαχωρισμένοι με κόμμα (COD, REC, SAT, RDO …)."
+                        "description": "Comma-separated Acs_Delivery_Products codes (COD, REC, SAT, RDO …)."
                     },
                     "lastEventAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Τελευταίο συμβάν"
+                        "nullable": true
                     },
                     "lastPolledAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Τελευταία ανάκτηση",
-                        "description": "Χρησιμοποιείται από το poll_acs_tracking_batch για κατανομή φορτίου και παράλειψη αποστολών που ελέγχθηκαν τα τελευταία 15 λεπτά."
+                        "description": "Used by poll_acs_tracking_batch to spread load and skip shipments polled within the last 15 minutes."
                     },
                     "deliveryDate": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Ημερομηνία παράδοσης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "stationDestinationExternalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID καταστήματος προορισμού",
-                        "description": "Μη κανονικοποιημένο ACS_SHOP_STATION_ID — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή AcsStation."
+                        "title": "Destination station external ID",
+                        "description": "Denormalised ACS_SHOP_STATION_ID — preserved even if the AcsStation row is deleted."
                     },
                     "stationBranchDestination": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Υποκατάστημα προορισμού",
-                        "description": "Τιμή Acs_Station_Branch_Destination."
+                        "title": "Destination branch",
+                        "description": "Acs_Station_Branch_Destination value."
                     },
                     "station": {
                         "allOf": [
@@ -48148,7 +48175,7 @@
                         ],
                         "nullable": true,
                         "readOnly": true,
-                        "description": "Στοιχεία καταστήματος προορισμού ACS (παραλαβές Smartpoint)."
+                        "description": "Destination ACS station details (Smartpoint pickups)."
                     },
                     "events": {
                         "type": "array",
@@ -48156,20 +48183,19 @@
                             "$ref": "#/components/schemas/AcsTrackingEvent"
                         },
                         "readOnly": true,
-                        "description": "Τελευταία 50 συμβάντα παρακολούθησης ταξινομημένα κατά event_time φθίνουσα."
+                        "description": "Last 50 tracking events ordered by event_time desc."
                     },
                     "labelUrl": {
                         "type": "string",
                         "nullable": true,
-                        "description": "Σχετικό URL για λήψη του PDF voucher μέσω του proxy Django.",
+                        "description": "Relative URL to download the voucher PDF via the Django proxy.",
                         "readOnly": true
                     },
                     "cancelRequestedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Αίτημα ακύρωσης στις"
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -48212,15 +48238,13 @@
                     "externalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID",
-                        "description": "ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το 'ATH')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker."
+                        "description": "ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under 'ATH'); the (external_id, branch_code) pair is the locker's identity."
                     },
                     "branchCode": {
                         "type": "string",
                         "readOnly": true,
                         "default": "",
-                        "title": "Κωδικός υποκαταστήματος",
-                        "description": "ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού."
+                        "description": "ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area."
                     },
                     "shopKind": {
                         "allOf": [
@@ -48229,34 +48253,28 @@
                             }
                         ],
                         "readOnly": true,
-                        "title": "Είδος καταστήματος",
-                        "description": "ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.\n\n* `1` - Κατάστημα\n* `2` - Συνεργαζόμενο κατάστημα (2)\n* `3` - Συνεργαζόμενο κατάστημα (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (χωρίς locker)\n* `8` - Smartpoint locker"
+                        "description": "ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.\n\n* `1` - Shop\n* `2` - Partner shop (2)\n* `3` - Partner shop (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (no locker)\n* `8` - Smartpoint locker"
                     },
                     "name": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Όνομα"
+                        "readOnly": true
                     },
                     "addressLine1": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 1"
+                        "readOnly": true
                     },
                     "city": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Πόλη"
+                        "readOnly": true
                     },
                     "postalCode": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ταχυδρομικός κώδικας"
+                        "readOnly": true
                     },
                     "countryCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κωδικός χώρας",
-                        "description": "ISO 3166-1 alpha-2 κωδικός χώρας."
+                        "description": "ISO 3166-1 alpha-2 country code."
                     },
                     "lat": {
                         "type": "string",
@@ -48274,32 +48292,27 @@
                     },
                     "workingHours": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ωράριο λειτουργίας"
+                        "readOnly": true
                     },
                     "isActive": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργό"
+                        "readOnly": true
                     },
                     "lastSyncedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Τελευταίος συγχρονισμός"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -48339,15 +48352,13 @@
                     "externalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID",
-                        "description": "ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το 'ATH')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker."
+                        "description": "ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under 'ATH'); the (external_id, branch_code) pair is the locker's identity."
                     },
                     "branchCode": {
                         "type": "string",
                         "readOnly": true,
                         "default": "",
-                        "title": "Κωδικός υποκαταστήματος",
-                        "description": "ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού."
+                        "description": "ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area."
                     },
                     "shopKind": {
                         "allOf": [
@@ -48356,34 +48367,28 @@
                             }
                         ],
                         "readOnly": true,
-                        "title": "Είδος καταστήματος",
-                        "description": "ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.\n\n* `1` - Κατάστημα\n* `2` - Συνεργαζόμενο κατάστημα (2)\n* `3` - Συνεργαζόμενο κατάστημα (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (χωρίς locker)\n* `8` - Smartpoint locker"
+                        "description": "ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.\n\n* `1` - Shop\n* `2` - Partner shop (2)\n* `3` - Partner shop (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (no locker)\n* `8` - Smartpoint locker"
                     },
                     "name": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Όνομα"
+                        "readOnly": true
                     },
                     "addressLine1": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 1"
+                        "readOnly": true
                     },
                     "city": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Πόλη"
+                        "readOnly": true
                     },
                     "postalCode": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ταχυδρομικός κώδικας"
+                        "readOnly": true
                     },
                     "countryCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κωδικός χώρας",
-                        "description": "ISO 3166-1 alpha-2 κωδικός χώρας."
+                        "description": "ISO 3166-1 alpha-2 country code."
                     },
                     "lat": {
                         "type": "string",
@@ -48401,42 +48406,35 @@
                     },
                     "workingHours": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ωράριο λειτουργίας"
+                        "readOnly": true
                     },
                     "isActive": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργό"
+                        "readOnly": true
                     },
                     "lastSyncedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Τελευταίος συγχρονισμός"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "addressLine2": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 2"
+                        "readOnly": true
                     },
                     "region": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Περιοχή"
+                        "readOnly": true
                     },
                     "phone": {
                         "type": "string",
@@ -48479,33 +48477,28 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "title": "Ώρα συμβάντος",
-                        "description": "Checkpoint_Date_Time από το ACS_TrackingDetails."
+                        "description": "Checkpoint_Date_Time from ACS_TrackingDetails."
                     },
                     "checkpointAction": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Ενέργεια σημείου ελέγχου",
-                        "description": "Checkpoint_Action_Description — κείμενο στα ελληνικά σε αναγνώσιμη μορφή που περιγράφει το συμβάν."
+                        "description": "Checkpoint_Action_Description — human-readable Greek text describing the event."
                     },
                     "checkpointLocation": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Σημείο ελέγχου",
                         "description": "Checkpoint_Location_Description."
                     },
                     "notes": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Σημειώσεις",
-                        "description": "Πεδίο σχολίων ACS."
+                        "description": "ACS Comments field."
                     },
                     "receivedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "title": "Παραλήφθηκε στις",
-                        "description": "Πραγματικός χρόνος κατά τον οποίο η εργασία παρακολούθησης παρατήρησε αυτό το συμβάν."
+                        "description": "Wall-clock time when the polling task observed this event."
                     }
                 },
                 "required": [
@@ -48654,14 +48647,12 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "valuesCount": {
                         "type": "integer",
@@ -48674,14 +48665,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -48746,14 +48735,12 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "usageCount": {
                         "type": "integer",
@@ -48762,14 +48749,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -48839,20 +48824,18 @@
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "numberOfPosts": {
                         "type": "integer",
@@ -48939,20 +48922,18 @@
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "numberOfPosts": {
                         "type": "integer",
@@ -49038,7 +49019,6 @@
                         "type": "integer"
                     },
                     "website": {
-                        "title": "Ιστότοπος",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -49119,8 +49099,7 @@
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "postCount": {
                         "type": "integer",
@@ -49139,14 +49118,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -49224,8 +49201,7 @@
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "postCount": {
                         "type": "integer",
@@ -49244,14 +49220,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "children": {
                         "type": "array",
@@ -49319,11 +49293,11 @@
                 "properties": {
                     "id": {
                         "type": "integer",
-                        "description": "ID κατηγορίας"
+                        "description": "Category ID"
                     },
                     "sortOrder": {
                         "type": "integer",
-                        "description": "Νέα τιμή σειράς ταξινόμησης"
+                        "description": "New sort order value"
                     }
                 },
                 "required": [
@@ -49339,7 +49313,7 @@
                         "items": {
                             "$ref": "#/components/schemas/BlogCategoryReorderItemRequest"
                         },
-                        "description": "Λίστα κατηγοριών με νέες σειρές ταξινόμησης"
+                        "description": "List of categories with new sort orders"
                     }
                 },
                 "required": [
@@ -49351,11 +49325,11 @@
                 "properties": {
                     "updatedCount": {
                         "type": "integer",
-                        "description": "Αριθμός ενημερωμένων κατηγοριών"
+                        "description": "Number of categories updated"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Μήνυμα επιτυχίας"
+                        "description": "Success message"
                     }
                 },
                 "required": [
@@ -49476,12 +49450,12 @@
                         "type": "string",
                         "nullable": true,
                         "readOnly": true,
-                        "description": "Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου"
+                        "description": "First 150 characters of the comment content"
                     },
                     "isReply": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο"
+                        "description": "Whether this comment is a reply to another comment"
                     },
                     "parent": {
                         "type": "integer",
@@ -49491,17 +49465,16 @@
                     "hasReplies": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις"
+                        "description": "Whether this comment has approved replies"
                     },
                     "approved": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Εγκεκριμένο"
+                        "readOnly": true
                     },
                     "isEdited": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο έχει επεξεργαστεί"
+                        "description": "Whether this comment has been edited"
                     },
                     "likesCount": {
                         "type": "integer",
@@ -49514,19 +49487,17 @@
                     "userHasLiked": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο"
+                        "description": "Whether the current user has liked this comment"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -49601,12 +49572,12 @@
                         "type": "string",
                         "nullable": true,
                         "readOnly": true,
-                        "description": "Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου"
+                        "description": "First 150 characters of the comment content"
                     },
                     "isReply": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο"
+                        "description": "Whether this comment is a reply to another comment"
                     },
                     "parent": {
                         "type": "integer",
@@ -49616,17 +49587,16 @@
                     "hasReplies": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις"
+                        "description": "Whether this comment has approved replies"
                     },
                     "approved": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Εγκεκριμένο"
+                        "readOnly": true
                     },
                     "isEdited": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν αυτό το σχόλιο έχει επεξεργαστεί"
+                        "description": "Whether this comment has been edited"
                     },
                     "likesCount": {
                         "type": "integer",
@@ -49639,19 +49609,17 @@
                     "userHasLiked": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο"
+                        "description": "Whether the current user has liked this comment"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -49665,7 +49633,7 @@
                             }
                         ],
                         "readOnly": true,
-                        "description": "Βασικές πληροφορίες για το άρθρο"
+                        "description": "Basic information about the blog post"
                     },
                     "parentComment": {
                         "type": "object",
@@ -49692,7 +49660,7 @@
                             "createdAt"
                         ],
                         "readOnly": true,
-                        "description": "Γονικό σχόλιο, αν πρόκειται για απάντηση"
+                        "description": "Parent comment if this is a reply"
                     },
                     "childrenComments": {
                         "type": "array",
@@ -49700,7 +49668,7 @@
                             "$ref": "#/components/schemas/BlogComment"
                         },
                         "readOnly": true,
-                        "description": "Άμεσα εγκεκριμένα θυγατρικά σχόλια (απαντήσεις)"
+                        "description": "Direct approved child comments (replies)"
                     },
                     "ancestorsPath": {
                         "type": "array",
@@ -49724,7 +49692,7 @@
                             ]
                         },
                         "readOnly": true,
-                        "description": "Διαδρομή από το ριζικό σχόλιο έως αυτό"
+                        "description": "Path from root comment to this comment"
                     },
                     "treePosition": {
                         "type": "object",
@@ -49749,7 +49717,7 @@
                             "siblingsCount"
                         ],
                         "readOnly": true,
-                        "description": "Πληροφορίες θέσης στο δέντρο σχολίων"
+                        "description": "Position information in the comment tree"
                     }
                 },
                 "required": [
@@ -49783,7 +49751,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID σχολίων για έλεγχο κατάστασης επισήμανσης"
+                        "description": "List of comment IDs to check like status for"
                     }
                 },
                 "required": [
@@ -49798,7 +49766,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID σχολίων που έχει επισημάνει ο τρέχων χρήστης"
+                        "description": "List of comment IDs that are liked by the current user"
                     }
                 },
                 "required": [
@@ -49935,13 +49903,11 @@
                         }
                     },
                     "featured": {
-                        "type": "boolean",
-                        "title": "Προβεβλημένο"
+                        "type": "boolean"
                     },
                     "viewCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Προβολές"
+                        "readOnly": true
                     },
                     "likesCount": {
                         "type": "integer",
@@ -49959,27 +49925,23 @@
                         "readOnly": true
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "publishedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Δημοσιεύθηκε στις"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -50111,13 +50073,11 @@
                         "readOnly": true
                     },
                     "featured": {
-                        "type": "boolean",
-                        "title": "Προβεβλημένο"
+                        "type": "boolean"
                     },
                     "viewCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Προβολές"
+                        "readOnly": true
                     },
                     "likesCount": {
                         "type": "integer",
@@ -50135,27 +50095,23 @@
                         "readOnly": true
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "publishedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Δημοσιεύθηκε στις"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -50175,17 +50131,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 },
@@ -50219,7 +50172,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID άρθρων για έλεγχο επισημάνσεων"
+                        "description": "List of post IDs to check for likes"
                     }
                 },
                 "required": [
@@ -50234,7 +50187,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID άρθρων με επισήμανση"
+                        "description": "List of liked post IDs"
                     }
                 },
                 "required": [
@@ -50243,7 +50196,18 @@
             },
             "BlogPostMeiliSearchResponse": {
                 "type": "object",
+                "description": "Common disclosure fields every search response carries.\n\n``query_id`` attributes later clicks to this query (see the\n``search/click`` endpoint); ``relaxed_query`` reports the trimmed\nquery the zero-result fallback actually matched, so clients can\ndisclose \"showing results for …\" instead of silently swapping.",
                 "properties": {
+                    "queryId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier for this search, used to attribute clicks"
+                    },
+                    "relaxedQuery": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The relaxed query used by the zero-result fallback, or null when results matched the original query"
+                    },
                     "limit": {
                         "type": "integer"
                     },
@@ -50264,6 +50228,8 @@
                     "estimatedTotalHits",
                     "limit",
                     "offset",
+                    "queryId",
+                    "relaxedQuery",
                     "results"
                 ]
             },
@@ -50390,26 +50356,21 @@
                         "type": "integer"
                     },
                     "featured": {
-                        "type": "boolean",
-                        "title": "Προβεβλημένο"
+                        "type": "boolean"
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 },
@@ -50458,31 +50419,27 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "postsCount": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα"
+                        "description": "Number of blog posts using this tag"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -50538,31 +50495,27 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "postsCount": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα"
+                        "description": "Number of blog posts using this tag"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -50614,8 +50567,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -50628,15 +50580,15 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Πλήρες όνομα πελάτη"
+                        "description": "Customer full name"
                     },
                     "email": {
                         "type": "string",
-                        "description": "Email πελάτη"
+                        "description": "Customer email address"
                     },
                     "phoneNumber": {
                         "type": "string",
-                        "description": "Τηλέφωνο πελάτη"
+                        "description": "Customer phone number"
                     }
                 }
             },
@@ -50646,11 +50598,11 @@
                 "properties": {
                     "displayName": {
                         "type": "string",
-                        "description": "Όνομα locker ή hub σε αναγνώσιμη μορφή"
+                        "description": "Human-readable locker or hub name"
                     },
                     "postalCode": {
                         "type": "string",
-                        "description": "Ταχυδρομικός κώδικας της τοποθεσίας του συμβάντος"
+                        "description": "Postal code of the event location"
                     }
                 }
             },
@@ -50665,7 +50617,6 @@
                     "externalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID",
                         "description": "BoxNow APM identifier (string)"
                     },
                     "type": {
@@ -50674,15 +50625,13 @@
                                 "$ref": "#/components/schemas/TypeEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τύπος"
+                        "readOnly": true
                     },
                     "imageUrl": {
                         "type": "string",
                         "format": "uri",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "URL εικόνας"
+                        "nullable": true
                     },
                     "lat": {
                         "type": "number",
@@ -50692,7 +50641,7 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Γεωγραφικό πλάτος"
+                        "title": "Latitude"
                     },
                     "lng": {
                         "type": "number",
@@ -50702,38 +50651,32 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Γεωγραφικό μήκος"
+                        "title": "Longitude"
                     },
                     "title": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Τίτλος"
+                        "readOnly": true
                     },
                     "name": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Όνομα"
+                        "readOnly": true
                     },
                     "addressLine1": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 1"
+                        "readOnly": true
                     },
                     "addressLine2": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 2"
+                        "readOnly": true
                     },
                     "postalCode": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ταχ. Κώδικας"
+                        "readOnly": true
                     },
                     "countryCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κωδικός χώρας",
-                        "description": "ISO 3166-1 alpha-2 κωδικός χώρας"
+                        "description": "ISO 3166-1 alpha-2 country code"
                     },
                     "note": {
                         "type": "string",
@@ -50742,28 +50685,24 @@
                     },
                     "isActive": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργό"
+                        "readOnly": true
                     },
                     "lastSyncedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Τελευταίος συγχρονισμός",
-                        "description": "Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow"
+                        "description": "Timestamp of the most recent sync from BoxNow API"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -50803,7 +50742,6 @@
                     "externalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID",
                         "description": "BoxNow APM identifier (string)"
                     },
                     "type": {
@@ -50812,15 +50750,13 @@
                                 "$ref": "#/components/schemas/TypeEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τύπος"
+                        "readOnly": true
                     },
                     "imageUrl": {
                         "type": "string",
                         "format": "uri",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "URL εικόνας"
+                        "nullable": true
                     },
                     "lat": {
                         "type": "number",
@@ -50830,7 +50766,7 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Γεωγραφικό πλάτος"
+                        "title": "Latitude"
                     },
                     "lng": {
                         "type": "number",
@@ -50840,38 +50776,32 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Γεωγραφικό μήκος"
+                        "title": "Longitude"
                     },
                     "title": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Τίτλος"
+                        "readOnly": true
                     },
                     "name": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Όνομα"
+                        "readOnly": true
                     },
                     "addressLine1": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 1"
+                        "readOnly": true
                     },
                     "addressLine2": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Διεύθυνση γραμμή 2"
+                        "readOnly": true
                     },
                     "postalCode": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Ταχ. Κώδικας"
+                        "readOnly": true
                     },
                     "countryCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κωδικός χώρας",
-                        "description": "ISO 3166-1 alpha-2 κωδικός χώρας"
+                        "description": "ISO 3166-1 alpha-2 country code"
                     },
                     "note": {
                         "type": "string",
@@ -50880,28 +50810,24 @@
                     },
                     "isActive": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργό"
+                        "readOnly": true
                     },
                     "lastSyncedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Τελευταίος συγχρονισμός",
-                        "description": "Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow"
+                        "description": "Timestamp of the most recent sync from BoxNow API"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -50937,26 +50863,26 @@
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Όνομα πόλης για αναζήτηση πλησιέστερου locker",
+                        "description": "City name for nearest-locker lookup",
                         "maxLength": 128
                     },
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Οδός και αριθμός",
+                        "description": "Street name and number",
                         "maxLength": 255
                     },
                     "postalCode": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Ταχυδρομικός κώδικας",
+                        "description": "Postal / ZIP code",
                         "maxLength": 16
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
                         "default": "el-GR",
-                        "description": "Ετικέτα γλώσσας IETF / κωδικός περιφέρειας (προεπιλογή: el-GR)",
+                        "description": "IETF language tag / region code (default: el-GR)",
                         "maxLength": 8
                     },
                     "compartmentSize": {
@@ -50964,7 +50890,7 @@
                         "maximum": 3,
                         "minimum": 1,
                         "default": 1,
-                        "description": "Απαιτούμενο μέγεθος θυρίδας: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο"
+                        "description": "Required compartment size: 1=Small, 2=Medium, 3=Large"
                     }
                 },
                 "required": [
@@ -50980,73 +50906,73 @@
                     "id": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Αναγνωριστικό APM BoxNow"
+                        "description": "BoxNow APM identifier"
                     },
                     "type": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Τύπος locker (π.χ. apm, warehouse)"
+                        "description": "Locker type (e.g. apm, warehouse)"
                     },
                     "image": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "URL εικόνας locker"
+                        "description": "URL of locker image"
                     },
                     "lat": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Γεωγραφικό πλάτος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)"
+                        "description": "Latitude (string as returned by BoxNow)"
                     },
                     "lng": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Γεωγραφικό μήκος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)"
+                        "description": "Longitude (string as returned by BoxNow)"
                     },
                     "title": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Σύντομος τίτλος εμφάνισης"
+                        "description": "Short display title"
                     },
                     "name": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Πλήρες όνομα locker"
+                        "description": "Full locker name"
                     },
                     "postalCode": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Ταχ. κώδικας του locker"
+                        "description": "Postal code of the locker"
                     },
                     "country": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "ISO 3166-1 alpha-2 κωδικός χώρας"
+                        "description": "ISO 3166-1 alpha-2 country code"
                     },
                     "note": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Λειτουργική σημείωση από BoxNow"
+                        "description": "Operational note from BoxNow"
                     },
                     "addressLine1": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Κύρια γραμμή διεύθυνσης"
+                        "description": "Primary address line"
                     },
                     "addressLine2": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Δευτερεύουσα γραμμή διεύθυνσης"
+                        "description": "Secondary address line"
                     },
                     "region": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Ετικέτα περιφέρειας IETF που επιστρέφεται από το BoxNow"
+                        "description": "IETF region tag returned by BoxNow"
                     },
                     "distance": {
                         "type": "number",
                         "format": "double",
                         "readOnly": true,
-                        "description": "Απόσταση από τη δεδομένη διεύθυνση σε χιλιόμετρα"
+                        "description": "Distance from the supplied address in kilometres"
                     }
                 },
                 "required": [
@@ -51077,8 +51003,7 @@
                     "webhookMessageId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "ID μηνύματος webhook",
-                        "description": "Πεδίο 'id' του CloudEvents — κλειδί ιδεμποτεντίας"
+                        "description": "CloudEvents 'id' field — idempotency key"
                     },
                     "eventType": {
                         "allOf": [
@@ -51087,56 +51012,48 @@
                             }
                         ],
                         "readOnly": true,
-                        "title": "Τύπος συμβάντος",
-                        "description": "Συμβάν BoxNow αντιστοιχισμένο από το πεδίο 'event' του webhook\n\n* `pending_creation` - Εκκρεμής δημιουργία\n* `new` - Νέο\n* `in_depot` - Σε αποθήκη\n* `final_destination` - Στο locker\n* `delivered` - Παραδόθηκε\n* `returned` - Επιστράφηκε\n* `expired` - Έληξε\n* `canceled` - Ακυρώθηκε\n* `accepted_for_return` - Αποδεκτό για επιστροφή\n* `accepted_to_locker` - Αποδεκτό σε locker\n* `missing` - Λείπει\n* `lost` - Χάθηκε"
+                        "description": "BoxNow event mapped from the webhook 'event' field\n\n* `pending_creation` - Pending creation\n* `new` - New\n* `in_depot` - In depot\n* `final_destination` - At locker\n* `delivered` - Delivered\n* `returned` - Returned\n* `expired` - Expired\n* `canceled` - Canceled\n* `accepted_for_return` - Accepted for return\n* `accepted_to_locker` - Accepted to locker\n* `missing` - Missing\n* `lost` - Lost"
                     },
                     "eventTypeDisplay": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Ετικέτα σε αναγνώσιμη μορφή για την τιμή event_type"
+                        "description": "Human-readable label for the event_type choice"
                     },
                     "parcelState": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Κατάσταση Δέματος",
-                        "description": "Ακατέργαστη τιμή 'data.parcelState' από το payload του webhook BoxNow"
+                        "description": "Raw 'data.parcelState' value from BoxNow webhook payload"
                     },
                     "eventTime": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "title": "Ώρα συμβάντος",
-                        "description": "Χρονοσήμανση από το 'data.time' στο payload του webhook"
+                        "description": "Timestamp from 'data.time' in the webhook payload"
                     },
                     "displayName": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εμφανιζόμενο όνομα",
                         "description": "data.eventLocation.displayName"
                     },
                     "postalCode": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Ταχ. Κώδικας",
                         "description": "data.eventLocation.postalCode"
                     },
                     "additionalInformation": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Πρόσθετες Πληροφορίες"
+                        "readOnly": true
                     },
                     "receivedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "title": "Παραλήφθηκε στις",
-                        "description": "Χρονοσήμανση λήψης του webhook από το GrooveShop (διαφορετική από το event_time)"
+                        "description": "Timestamp when GrooveShop received the webhook (separate from event_time)"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -51169,7 +51086,7 @@
                     "lost"
                 ],
                 "type": "string",
-                "description": "* `pending_creation` - Εκκρεμής δημιουργία\n* `new` - Νέο\n* `in_depot` - Σε αποθήκη\n* `final_destination` - Στο locker\n* `delivered` - Παραδόθηκε\n* `returned` - Επιστράφηκε\n* `expired` - Έληξε\n* `canceled` - Ακυρώθηκε\n* `accepted_for_return` - Αποδεκτό για επιστροφή\n* `accepted_to_locker` - Αποδεκτό σε locker\n* `missing` - Λείπει\n* `lost` - Χάθηκε"
+                "description": "* `pending_creation` - Pending creation\n* `new` - New\n* `in_depot` - In depot\n* `final_destination` - At locker\n* `delivered` - Delivered\n* `returned` - Returned\n* `expired` - Expired\n* `canceled` - Canceled\n* `accepted_for_return` - Accepted for return\n* `accepted_to_locker` - Accepted to locker\n* `missing` - Missing\n* `lost` - Lost"
             },
             "BoxNowShipmentDetail": {
                 "type": "object",
@@ -51188,21 +51105,18 @@
                         "type": "string",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "Αναγνωριστικό αιτήματος παράδοσης",
-                        "description": "ID αιτήματος παράδοσης BoxNow που επιστρέφεται από το POST /api/v1/delivery-requests"
+                        "description": "BoxNow delivery-request ID returned from POST /api/v1/delivery-requests"
                     },
                     "parcelId": {
                         "type": "string",
                         "readOnly": true,
                         "nullable": true,
-                        "title": "ID δέματος",
-                        "description": "10ψήφιος αριθμός BoxNow voucher"
+                        "description": "10-digit BoxNow voucher number"
                     },
                     "lockerExternalId": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Εξωτερικό ID locker",
-                        "description": "Μη κανονικοποιημένο ID APM BoxNow — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή BoxNowLocker"
+                        "description": "Denormalised BoxNow APM ID — preserved even if the BoxNowLocker row is deleted"
                     },
                     "parcelState": {
                         "allOf": [
@@ -51210,13 +51124,12 @@
                                 "$ref": "#/components/schemas/BoxNowParcelState"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Κατάσταση Δέματος"
+                        "readOnly": true
                     },
                     "parcelStateDisplay": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Ετικέτα σε αναγνώσιμη μορφή για την τιμή parcel_state"
+                        "description": "Human-readable label for the parcel_state choice"
                     },
                     "compartmentSize": {
                         "allOf": [
@@ -51224,8 +51137,7 @@
                                 "$ref": "#/components/schemas/CompartmentSizeEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Μέγεθος θυρίδας"
+                        "readOnly": true
                     },
                     "paymentMode": {
                         "allOf": [
@@ -51233,27 +51145,23 @@
                                 "$ref": "#/components/schemas/PaymentModeEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τρόπος πληρωμής"
+                        "readOnly": true
                     },
                     "lastEventAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Τελευταίο συμβάν"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "locker": {
                         "allOf": [
@@ -51263,7 +51171,7 @@
                         ],
                         "nullable": true,
                         "readOnly": true,
-                        "description": "Ενσωματωμένα στοιχεία locker BoxNow"
+                        "description": "Nested BoxNow locker details"
                     },
                     "events": {
                         "type": "array",
@@ -51271,18 +51179,18 @@
                             "$ref": "#/components/schemas/BoxNowParcelEvent"
                         },
                         "readOnly": true,
-                        "description": "Τελευταία 20 συμβάντα δέματος ταξινομημένα κατά event_time φθίνουσα"
+                        "description": "Last 20 parcel events ordered by event_time desc"
                     },
                     "labelUrl": {
                         "type": "string",
                         "nullable": true,
-                        "description": "Σχετικό URL για λήψη του PDF ετικέτας δέματος μέσω του endpoint proxy Django",
+                        "description": "Relative URL to download the parcel label PDF via the Django proxy endpoint",
                         "readOnly": true
                     },
                     "weightGrams": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Βάρος (γραμμάρια)"
+                        "title": "Weight (grams)"
                     },
                     "amountToBeCollected": {
                         "type": "number",
@@ -51292,20 +51200,17 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Ποσό προς Είσπραξη",
-                        "description": "Ποσό που εισπράττεται κατά την παράδοση (PoG / COD). Πάντα 0 στη Φάση 1."
+                        "description": "Amount collected at delivery (PoG / COD). Always 0 in Phase 1."
                     },
                     "allowReturn": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Επιτρέπεται επιστροφή"
+                        "readOnly": true
                     },
                     "cancelRequestedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Ημερομηνία αιτήματος ακύρωσης"
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -51337,30 +51242,30 @@
                     "parcelId": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "10ψήφιος αριθμός voucher/δέματος BoxNow"
+                        "description": "10-digit BoxNow voucher/parcel number"
                     },
                     "parcelState": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Λεξιλόγιο κατάστασης δέματος BoxNow (data.parcelState)"
+                        "description": "BoxNow parcel state vocabulary (data.parcelState)"
                     },
                     "parcelReferenceNumber": {
                         "type": "string",
-                        "description": "Προαιρετικός αριθμός αναφοράς εμπόρου"
+                        "description": "Optional merchant reference number"
                     },
                     "parcelName": {
                         "type": "string",
-                        "description": "Προαιρετικό όνομα δέματος"
+                        "description": "Optional descriptive parcel name"
                     },
                     "orderNumber": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Αριθμός παραγγελίας εμπόρου που αποστέλλεται κατά τη δημιουργία αιτήματος παράδοσης"
+                        "description": "Merchant order number sent during delivery-request creation"
                     },
                     "event": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Συμβολοσειρά τύπου συμβάντος BoxNow (π.χ. 'in-depot', 'final-destination', 'delivered')"
+                        "description": "BoxNow event type string (e.g. 'in-depot', 'final-destination', 'delivered')"
                     },
                     "eventLocation": {
                         "allOf": [
@@ -51368,7 +51273,7 @@
                                 "$ref": "#/components/schemas/BoxNowEventLocationRequest"
                             }
                         ],
-                        "description": "Πλαίσιο τοποθεσίας συμβάντος"
+                        "description": "Location context for this event"
                     },
                     "customer": {
                         "allOf": [
@@ -51376,16 +51281,16 @@
                                 "$ref": "#/components/schemas/BoxNowCustomerRequest"
                             }
                         ],
-                        "description": "Στοιχεία πελάτη που σχετίζονται με το δέμα"
+                        "description": "Customer details associated with the parcel"
                     },
                     "additionalInformation": {
                         "type": "string",
-                        "description": "Ελεύθερο κείμενο με επιπλέον πληροφορίες από το BoxNow"
+                        "description": "Free-text additional information from BoxNow"
                     },
                     "time": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Χρονοσήμανση όταν συνέβη το συμβάν στο BoxNow"
+                        "description": "Timestamp when the event occurred at BoxNow"
                     }
                 },
                 "required": [
@@ -51403,43 +51308,43 @@
                     "specversion": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Έκδοση προδιαγραφής CloudEvents (αναμενόμενη: '1.0')"
+                        "description": "CloudEvents specification version (expected: '1.0')"
                     },
                     "type": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Τύπος συμβάντος (αναμενόμενος: 'gr.boxnow.parcel_event_change')"
+                        "description": "Event type (expected: 'gr.boxnow.parcel_event_change')"
                     },
                     "source": {
                         "type": "string",
                         "format": "uri",
                         "minLength": 1,
-                        "description": "URL προέλευσης πηγής συμβάντος"
+                        "description": "Origin URL of the event source"
                     },
                     "subject": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Θέμα του συμβάντος (συνήθως το ID δέματος)"
+                        "description": "Subject of the event (typically the parcel ID)"
                     },
                     "id": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Μοναδικό ID CloudEvents· χρησιμοποιείται ως κλειδί ιδεμποτεντίας (αποθηκεύεται ως webhook_message_id)"
+                        "description": "Unique CloudEvents ID; used as idempotency key (stored as webhook_message_id)"
                     },
                     "time": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Χρονοσήμανση δημιουργίας του φακέλου"
+                        "description": "Timestamp the envelope was generated"
                     },
                     "datacontenttype": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Τύπος MIME του πεδίου data (αναμενόμενος: 'application/json')"
+                        "description": "MIME type of the data field (expected: 'application/json')"
                     },
                     "datasignature": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Δεκαεξαδικό digest HMAC-SHA256 του ακατέργαστου JSON αντικειμένου 'data'· χρησιμοποιείται για επαλήθευση υπογραφής"
+                        "description": "HMAC-SHA256 hex digest of the raw 'data' JSON object; used for signature verification"
                     },
                     "data": {
                         "allOf": [
@@ -51447,7 +51352,7 @@
                                 "$ref": "#/components/schemas/BoxNowWebhookDataRequest"
                             }
                         ],
-                        "description": "Payload συμβάντος δέματος"
+                        "description": "Parcel event payload"
                     }
                 },
                 "required": [
@@ -51487,7 +51392,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID θεμάτων για εγγραφή/διαγραφή"
+                        "description": "List of topic IDs to subscribe/unsubscribe"
                     },
                     "action": {
                         "allOf": [
@@ -51495,7 +51400,7 @@
                                 "$ref": "#/components/schemas/ActionEnum"
                             }
                         ],
-                        "description": "Ενέργεια προς εκτέλεση σε θέματα\n\n* `subscribe` - subscribe\n* `unsubscribe` - unsubscribe"
+                        "description": "Action to perform on the topics\n\n* `subscribe` - subscribe\n* `unsubscribe` - unsubscribe"
                     }
                 },
                 "required": [
@@ -51622,30 +51527,27 @@
                     "totalWeightGrams": {
                         "type": "integer",
                         "readOnly": true,
-                        "description": "Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher."
+                        "description": "Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge."
                     },
                     "currency": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού"
+                        "description": "ISO 4217 currency code for all monetary values in this cart"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "lastActivity": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Τελευταία δραστηριότητα"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -51671,7 +51573,7 @@
                     "payWayId": {
                         "type": "integer",
                         "minimum": 1,
-                        "description": "ID της επιλεγμένης μεθόδου πληρωμής (πρέπει να είναι online Stripe)."
+                        "description": "ID of the selected PayWay (must be online Stripe)."
                     },
                     "shippingKind": {
                         "allOf": [
@@ -51679,21 +51581,21 @@
                                 "$ref": "#/components/schemas/CartCreatePaymentIntentRequestShippingKindEnum"
                             }
                         ],
-                        "description": "Τύπος εκπλήρωσης για τον μεταφορέα (home_delivery ή pickup_point). Απαιτείται ώστε να τηρούνται οι επιμέρους σημαίες λειτουργίας (π.χ. ACS_SMARTPOINT_ENABLED) και ο έλεγχος PICKUP_POINT του BoxNow.\n\n* `home_delivery` - home_delivery\n* `pickup_point` - pickup_point"
+                        "description": "Fulfilment kind for the carrier (home_delivery or pickup_point). Required so the per-kind feature flags (e.g. ACS_SMARTPOINT_ENABLED) and BoxNow's PICKUP_POINT gate are honoured.\n\n* `home_delivery` - home_delivery\n* `pickup_point` - pickup_point"
                     },
                     "shippingProviderCode": {
                         "type": "string",
-                        "description": "Κωδικός μεταφορέα που αντιστοιχεί σε καταχωρημένο προσαρμογέα αποστολής (π.χ. 'acs', 'boxnow'). Απαιτείται για ``pickup_point``· παραλείψτε/αφήστε κενό για ``home_delivery`` (το backend χρησιμοποιεί τη γενική πάγια χρέωση, αντίστοιχη με αυτή που θα υπολογίσει η επαλήθευση δημιουργίας παραγγελίας για το ίδιο αίτημα).",
+                        "description": "Carrier code matching a registered shipping adapter (e.g. 'acs', 'boxnow'). Required for ``pickup_point``; omit/empty for ``home_delivery`` (the backend uses the generic flat rate, matching what the order-create verification will compute for the same body).",
                         "maxLength": 32
                     },
                     "countryId": {
                         "type": "string",
-                        "description": "Προαιρετικός κωδικός χώρας ISO 3166-1 alpha-2 — καθορίζει τον συντελεστή αποστολής σε επίπεδο χώρας. Πρέπει να ταιριάζει με αυτόν που θα φέρει το αίτημα δημιουργίας παραγγελίας.",
+                        "description": "Optional ISO 3166-1 alpha-2 country code — drives the country-level shipping multiplier. Match what the order-create body will carry.",
                         "maxLength": 2
                     },
                     "regionId": {
                         "type": "string",
-                        "description": "Προαιρετικός κωδικός περιφέρειας — καθορίζει την προσαρμογή αποστολής σε επίπεδο περιφέρειας.",
+                        "description": "Optional region code — drives the region-level shipping adjustment.",
                         "maxLength": 16
                     }
                 },
@@ -51783,30 +51685,27 @@
                     "totalWeightGrams": {
                         "type": "integer",
                         "readOnly": true,
-                        "description": "Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher."
+                        "description": "Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge."
                     },
                     "currency": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού"
+                        "description": "ISO 4217 currency code for all monetary values in this cart"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "lastActivity": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Τελευταία δραστηριότητα"
+                        "readOnly": true
                     },
                     "recommendations": {
                         "type": "array",
@@ -51814,7 +51713,7 @@
                             "$ref": "#/components/schemas/Product"
                         },
                         "readOnly": true,
-                        "description": "Προτάσεις προϊόντων βάσει περιεχομένου καλαθιού"
+                        "description": "Product recommendations based on cart contents"
                     }
                 },
                 "required": [
@@ -51856,8 +51755,7 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Ποσότητα"
+                        "minimum": 0
                     },
                     "weightInfo": {
                         "type": "object",
@@ -51878,7 +51776,7 @@
                             "weightUnit"
                         ],
                         "readOnly": true,
-                        "description": "Πληροφορίες βάρους για υπολογισμούς αποστολής"
+                        "description": "Weight information for shipping calculations"
                     },
                     "price": {
                         "type": "number",
@@ -51952,14 +51850,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -51995,8 +51891,7 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Ποσότητα"
+                        "minimum": 0
                     }
                 },
                 "required": [
@@ -52025,8 +51920,7 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Ποσότητα"
+                        "minimum": 0
                     },
                     "weightInfo": {
                         "type": "object",
@@ -52047,7 +51941,7 @@
                             "weightUnit"
                         ],
                         "readOnly": true,
-                        "description": "Πληροφορίες βάρους για υπολογισμούς αποστολής"
+                        "description": "Weight information for shipping calculations"
                     },
                     "price": {
                         "type": "number",
@@ -52121,14 +52015,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -52141,7 +52033,7 @@
                             "$ref": "#/components/schemas/Product"
                         },
                         "readOnly": true,
-                        "description": "Σχετικά προϊόντα που ίσως ενδιαφέρουν τον πελάτη"
+                        "description": "Related products that might interest the customer"
                     }
                 },
                 "required": [
@@ -52170,8 +52062,7 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Ποσότητα"
+                        "minimum": 0
                     }
                 }
             },
@@ -52181,11 +52072,11 @@
                 "properties": {
                     "clientSecret": {
                         "type": "string",
-                        "description": "Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend"
+                        "description": "Stripe PaymentIntent client secret for frontend confirmation"
                     },
                     "paymentIntentId": {
                         "type": "string",
-                        "description": "ID του Stripe PaymentIntent προς αποθήκευση στην παραγγελία"
+                        "description": "Stripe PaymentIntent ID to be stored on the order"
                     },
                     "amount": {
                         "type": "number",
@@ -52194,11 +52085,11 @@
                         "minimum": -10000000000,
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
-                        "description": "Συνολικό ποσό χρέωσης (καλάθι + αποστολή + έξοδα πληρωμής)"
+                        "description": "Total charge amount (cart + shipping + payment fee)"
                     },
                     "currency": {
                         "type": "string",
-                        "description": "Κωδικός νομίσματος ISO 4217 (π.χ. EUR)",
+                        "description": "ISO 4217 currency code (e.g. EUR)",
                         "maxLength": 3
                     }
                 },
@@ -52241,19 +52132,19 @@
                     },
                     "status": {
                         "type": "string",
-                        "description": "Κατάσταση πληρωμής"
+                        "description": "Payment status"
                     },
                     "amount": {
                         "type": "string",
-                        "description": "Ποσό πληρωμής"
+                        "description": "Payment amount"
                     },
                     "currency": {
                         "type": "string",
-                        "description": "Νόμισμα πληρωμής"
+                        "description": "Payment currency"
                     },
                     "provider": {
                         "type": "string",
-                        "description": "Όνομα παρόχου πληρωμών"
+                        "description": "Payment provider name"
                     }
                 },
                 "required": [
@@ -52303,7 +52194,6 @@
                     },
                     "name": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 100
                     },
                     "email": {
@@ -52312,20 +52202,17 @@
                         "maxLength": 254
                     },
                     "message": {
-                        "type": "string",
-                        "title": "Μήνυμα"
+                        "type": "string"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -52349,7 +52236,6 @@
                     "name": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Όνομα",
                         "maxLength": 100
                     },
                     "email": {
@@ -52360,8 +52246,7 @@
                     },
                     "message": {
                         "type": "string",
-                        "minLength": 1,
-                        "title": "Μήνυμα"
+                        "minLength": 1
                     }
                 },
                 "required": [
@@ -52405,13 +52290,13 @@
                     },
                     "alpha2": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "pattern": "^[A-Z]{2}$",
                         "maxLength": 2
                     },
                     "alpha3": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 3)",
+                        "title": "Country Code Alpha 3",
                         "pattern": "^[A-Z]{3}$",
                         "maxLength": 3
                     },
@@ -52420,32 +52305,28 @@
                         "maximum": 32767,
                         "minimum": 0,
                         "nullable": true,
-                        "title": "Κωδικός ISO χώρας"
+                        "title": "ISO Country Code"
                     },
                     "phoneCode": {
                         "type": "integer",
                         "maximum": 32767,
                         "minimum": 0,
-                        "nullable": true,
-                        "title": "Κωδικός κλήσης"
+                        "nullable": true
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -52503,13 +52384,13 @@
                     },
                     "alpha2": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "pattern": "^[A-Z]{2}$",
                         "maxLength": 2
                     },
                     "alpha3": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 3)",
+                        "title": "Country Code Alpha 3",
                         "pattern": "^[A-Z]{3}$",
                         "maxLength": 3
                     },
@@ -52518,32 +52399,28 @@
                         "maximum": 32767,
                         "minimum": 0,
                         "nullable": true,
-                        "title": "Κωδικός ISO χώρας"
+                        "title": "ISO Country Code"
                     },
                     "phoneCode": {
                         "type": "integer",
                         "maximum": 32767,
                         "minimum": 0,
-                        "nullable": true,
-                        "title": "Κωδικός κλήσης"
+                        "nullable": true
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -52558,7 +52435,7 @@
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "title": "Κωδικός περιφέρειας"
+                            "title": "Region Code"
                         },
                         "readOnly": true
                     }
@@ -52611,14 +52488,14 @@
                     "alpha2": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "pattern": "^[A-Z]{2}$",
                         "maxLength": 2
                     },
                     "alpha3": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 3)",
+                        "title": "Country Code Alpha 3",
                         "pattern": "^[A-Z]{3}$",
                         "maxLength": 3
                     },
@@ -52627,14 +52504,13 @@
                         "maximum": 32767,
                         "minimum": 0,
                         "nullable": true,
-                        "title": "Κωδικός ISO χώρας"
+                        "title": "ISO Country Code"
                     },
                     "phoneCode": {
                         "type": "integer",
                         "maximum": 32767,
                         "minimum": 0,
-                        "nullable": true,
-                        "title": "Κωδικός κλήσης"
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -52718,7 +52594,7 @@
                             "minLength": 1,
                             "maxLength": 500
                         },
-                        "description": "Επιπλέον δεδομένα πληρωμής που απαιτούνται από τον πάροχο πληρωμών"
+                        "description": "Additional payment data required by the payment provider"
                     }
                 }
             },
@@ -52727,38 +52603,38 @@
                 "properties": {
                     "paymentId": {
                         "type": "string",
-                        "description": "ID payment intent από τον πάροχο πληρωμών"
+                        "description": "Payment intent ID from the payment provider"
                     },
                     "status": {
                         "type": "string",
-                        "description": "Κατάσταση πληρωμής"
+                        "description": "Payment status"
                     },
                     "amount": {
                         "type": "string",
-                        "description": "Ποσό πληρωμής"
+                        "description": "Payment amount"
                     },
                     "currency": {
                         "type": "string",
-                        "description": "Νόμισμα πληρωμής"
+                        "description": "Payment currency"
                     },
                     "provider": {
                         "type": "string",
-                        "description": "Όνομα παρόχου πληρωμών"
+                        "description": "Payment provider name"
                     },
                     "clientSecret": {
                         "type": "string",
-                        "description": "Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend"
+                        "description": "Stripe PaymentIntent client secret for frontend confirmation"
                     },
                     "requiresAction": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Αν η πληρωμή απαιτεί επιπλέον ενέργεια (3D Secure κ.λπ.)"
+                        "description": "Whether the payment requires additional action (3D Secure, etc.)"
                     },
                     "nextAction": {
                         "type": "object",
                         "additionalProperties": {},
                         "nullable": true,
-                        "description": "Επόμενη ενέργεια που απαιτείται για την ολοκλήρωση της πληρωμής"
+                        "description": "Next action required for payment completion"
                     }
                 },
                 "required": [
@@ -52802,7 +52678,7 @@
                     "confirmation": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Πρέπει να ισούται ακριβώς με τη συμβολοσειρά \"DELETE\"."
+                        "description": "Must equal the literal string \"DELETE\"."
                     }
                 },
                 "required": [
@@ -52882,6 +52758,16 @@
                 "type": "object",
                 "description": "Serializer for federated search response.",
                 "properties": {
+                    "queryId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier for this search, used to attribute clicks"
+                    },
+                    "relaxedQuery": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The relaxed query used by the zero-result fallback, or null when results matched the original query"
+                    },
                     "limit": {
                         "type": "integer",
                         "description": "Maximum number of results requested"
@@ -52906,6 +52792,8 @@
                     "estimatedTotalHits",
                     "limit",
                     "offset",
+                    "queryId",
+                    "relaxedQuery",
                     "results"
                 ]
             },
@@ -53043,7 +52931,7 @@
                     "SIXTH_FLOOR_PLUS"
                 ],
                 "type": "string",
-                "description": "* `BASEMENT` - Υπόγειο\n* `GROUND_FLOOR` - Ισόγειο\n* `FIRST_FLOOR` - 1ος όροφος\n* `SECOND_FLOOR` - 2ος όροφος\n* `THIRD_FLOOR` - 3ος όροφος\n* `FOURTH_FLOOR` - 4ος όροφος\n* `FIFTH_FLOOR` - 5ος όροφος\n* `SIXTH_FLOOR_PLUS` - 6ος όροφος +"
+                "description": "* `BASEMENT` - Basement\n* `GROUND_FLOOR` - Ground Floor\n* `FIRST_FLOOR` - First Floor\n* `SECOND_FLOOR` - Second Floor\n* `THIRD_FLOOR` - Third Floor\n* `FOURTH_FLOOR` - Fourth Floor\n* `FIFTH_FLOOR` - Fifth Floor\n* `SIXTH_FLOOR_PLUS` - Sixth Floor Plus"
             },
             "FreeShippingInfo": {
                 "type": "object",
@@ -53063,7 +52951,7 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "nullable": true,
-                        "description": "Χαμηλότερο όριο μεταξύ των ενεργών παρόχων — ο κύριος αριθμός 'δωρεάν αποστολή από X €'. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο."
+                        "description": "Lowest threshold across active providers — the headline 'free shipping from X €' number. Null when no active provider advertises a threshold."
                     },
                     "maxThreshold": {
                         "type": "number",
@@ -53073,7 +52961,7 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "nullable": true,
-                        "description": "Υψηλότερο όριο μεταξύ των ενεργών παρόχων — το υποσύνολο στο οποίο κάθε μεταφορέας αποστέλλει δωρεάν. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο."
+                        "description": "Highest threshold across active providers — the subtotal at which every carrier ships free. Null when no active provider advertises a threshold."
                     },
                     "currency": {
                         "type": "string",
@@ -53107,7 +52995,7 @@
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
-                        "description": "Υποσύνολο καλαθιού στο νόμισμα της απόκρισης πάνω από το οποίο αυτός ο συνδυασμός (πάροχος, τύπος) αποστέλλει δωρεάν."
+                        "description": "Cart subtotal in the response's currency above which this (provider, kind) ships free."
                     },
                     "priority": {
                         "type": "integer"
@@ -53154,7 +53042,7 @@
                     "SEASONAL"
                 ],
                 "type": "string",
-                "description": "* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα"
+                "description": "* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image"
             },
             "InvoiceDownloadResponse": {
                 "type": "object",
@@ -53163,15 +53051,13 @@
                     "invoiceNumber": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Αριθμός τιμολογίου",
-                        "description": "Διαδοχικό αναγνωριστικό στη μορφή ``INV-{YEAR}-{NNNNNN}``. Δεν επιτρέπονται κενά βάσει της ελληνικής φορολογικής νομοθεσίας."
+                        "description": "Sequential identifier in the form ``INV-{YEAR}-{NNNNNN}``. Gaps are not allowed by Greek tax law."
                     },
                     "issueDate": {
                         "type": "string",
                         "format": "date",
                         "readOnly": true,
-                        "title": "Ημερομηνία έκδοσης",
-                        "description": "Φορολογική ημερομηνία έκδοσης. Αμετάβλητη μόλις εκδοθεί το τιμολόγιο — χρησιμοποιείται για διαδοχική αρίθμηση και αναφορές."
+                        "description": "Fiscal date of issue. Immutable once the invoice is rendered — used for sequential numbering and reporting."
                     },
                     "downloadUrl": {
                         "type": "string",
@@ -53196,13 +53082,11 @@
                     },
                     "currency": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Νόμισμα"
+                        "readOnly": true
                     },
                     "vatBreakdown": {
                         "readOnly": true,
-                        "title": "Ανάλυση ΦΠΑ",
-                        "description": "Λίστα σε cache από γραμμές ``{rate, subtotal, vat, gross}`` — παγιωμένη τη στιγμή της έκδοσης, ώστε η εκ νέου απόδοση του τιμολογίου να δίνει πάντα τον ίδιο πίνακα ΦΠΑ ακόμη κι αν αλλάξουν οι συντελεστές των προϊόντων."
+                        "description": "Cached list of ``{rate, subtotal, vat, gross}`` rows — frozen at issue time so re-rendering the invoice always yields the same VAT table even if product rates change."
                     }
                 },
                 "required": [
@@ -53223,7 +53107,7 @@
                     "OTHER"
                 ],
                 "type": "string",
-                "description": "* `HOME` - Σπίτι\n* `OFFICE` - Γραφείο\n* `OTHER` - Άλλο"
+                "description": "* `HOME` - Αρχική\n* `OFFICE` - Office\n* `OTHER` - Other"
             },
             "LoyaltySummary": {
                 "type": "object",
@@ -53318,8 +53202,7 @@
                     "requiredLevel": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Απαιτούμενο επίπεδο",
-                        "description": "Ελάχιστο επίπεδο για την επίτευξη αυτού του tier"
+                        "description": "Minimum level to achieve this tier"
                     },
                     "pointsMultiplier": {
                         "type": "number",
@@ -53329,14 +53212,12 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "readOnly": true,
-                        "title": "Πολλαπλασιαστής πόντων",
-                        "description": "Πολλαπλασιαστής που εφαρμόζεται στους πόντους που κερδίζουν οι χρήστες σε αυτό το tier"
+                        "description": "Multiplier applied to earned points for users in this tier"
                     },
                     "icon": {
                         "type": "string",
                         "format": "uri",
-                        "nullable": true,
-                        "title": "Εικονίδιο"
+                        "nullable": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -53406,36 +53287,20 @@
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "kind": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/NotificationKindEnum"
-                            }
-                        ],
-                        "title": "Είδος"
+                        "$ref": "#/components/schemas/NotificationKindEnum"
                     },
                     "category": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/NotificationCategory"
-                            }
-                        ],
-                        "title": "Κατηγορία"
+                        "$ref": "#/components/schemas/NotificationCategory"
                     },
                     "priority": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PriorityEnum"
-                            }
-                        ],
-                        "title": "Προτεραιότητα"
+                        "$ref": "#/components/schemas/PriorityEnum"
                     },
                     "notificationType": {
-                        "title": "Τύπος ειδοποίησης",
-                        "description": "Λεπτομερές αναγνωριστικό συμβάντος. Δείτε ``notification.enum.NotificationTypeEnum`` για τον πλήρη κατάλογο. Αφήνεται κενό για περιστασιακές ανακοινώσεις διαχειριστή.\n\n* `order_created` - Η παραγγελία δημιουργήθηκε\n* `order_processing` - Επεξεργασία παραγγελίας\n* `order_shipped` - Η παραγγελία απεστάλη\n* `order_delivered` - Η παραγγελία παραδόθηκε\n* `order_completed` - Η παραγγελία ολοκληρώθηκε\n* `order_canceled` - Η παραγγελία ακυρώθηκε\n* `order_refunded` - Επιστροφή χρημάτων παραγγελίας\n* `shipment_dispatched` - Αποστολή απεστάλη\n* `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε\n* `payment_failed` - Η πληρωμή απέτυχε\n* `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)\n* `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)\n* `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης\n* `comment_liked` - Επισήμανση σχολίου blog\n* `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker\n* `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε\n* `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση",
+                        "description": "Fine-grained event identifier. See ``notification.enum.NotificationTypeEnum`` for the full catalogue. Left blank for ad-hoc admin broadcasts.\n\n* `order_created` - Order created\n* `order_processing` - Order processing\n* `order_shipped` - Order shipped\n* `order_delivered` - Order delivered\n* `order_completed` - Order completed\n* `order_canceled` - Order canceled\n* `order_refunded` - Order refunded\n* `shipment_dispatched` - Shipment dispatched\n* `payment_confirmed` - Payment confirmed\n* `payment_failed` - Payment failed\n* `price_drop_favourite` - Price drop (favourited product)\n* `restock_favourite` - Back in stock (favourited product)\n* `loyalty_tier_up` - Loyalty tier promotion\n* `comment_liked` - Blog comment liked\n* `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker\n* `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered\n* `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/NotificationTypeEnum"
@@ -53448,20 +53313,17 @@
                     "expiryDate": {
                         "type": "string",
                         "format": "date-time",
-                        "nullable": true,
-                        "title": "Ημερομηνία Λήξης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -53496,14 +53358,14 @@
                     "RECOMMENDATION"
                 ],
                 "type": "string",
-                "description": "* `ORDER` - Παραγγελία\n* `PAYMENT` - Πληρωμή\n* `SHIPPING` - Μεταφορικά\n* `CART` - Καλάθι\n* `PRODUCT` - Προϊόν\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SECURITY` - Ασφάλεια\n* `PROMOTION` - Προσφορά\n* `SYSTEM` - Σύστημα\n* `REVIEW` - Εξέταση\n* `WISHLIST` - Λίστα επιθυμιών\n* `SUPPORT` - Υποστήριξη\n* `NEWSLETTER` - Newsletter\n* `RECOMMENDATION` - Σύσταση"
+                "description": "* `ORDER` - Ταξινόμηση\n* `PAYMENT` - Payment\n* `SHIPPING` - Shipping\n* `CART` - Cart\n* `PRODUCT` - Product\n* `ACCOUNT` - Account\n* `SECURITY` - Security\n* `PROMOTION` - Promotion\n* `SYSTEM` - System\n* `REVIEW` - Review\n* `WISHLIST` - Wishlist\n* `SUPPORT` - Support\n* `NEWSLETTER` - Newsletter\n* `RECOMMENDATION` - Recommendation"
             },
             "NotificationCountResponse": {
                 "type": "object",
                 "properties": {
                     "count": {
                         "type": "integer",
-                        "description": "Αριθμός μη ορατών ειδοποιήσεων"
+                        "description": "Number of unseen notifications"
                     }
                 },
                 "required": [
@@ -53533,14 +53395,14 @@
                     "DANGER"
                 ],
                 "type": "string",
-                "description": "* `ERROR` - Σφάλμα\n* `SUCCESS` - Επιτυχία\n* `INFO` - Πληροφορία\n* `WARNING` - Προειδοποίηση\n* `DANGER` - Κίνδυνος"
+                "description": "* `ERROR` - Σφάλμα\n* `SUCCESS` - Success\n* `INFO` - Info\n* `WARNING` - Warning\n* `DANGER` - Danger"
             },
             "NotificationSuccessResponse": {
                 "type": "object",
                 "properties": {
                     "success": {
                         "type": "boolean",
-                        "description": "Αν η λειτουργία ήταν επιτυχής"
+                        "description": "Whether the operation was successful"
                     }
                 }
             },
@@ -53565,7 +53427,7 @@
                     "ACS_OUT_FOR_DELIVERY"
                 ],
                 "type": "string",
-                "description": "* `order_created` - Η παραγγελία δημιουργήθηκε\n* `order_processing` - Επεξεργασία παραγγελίας\n* `order_shipped` - Η παραγγελία απεστάλη\n* `order_delivered` - Η παραγγελία παραδόθηκε\n* `order_completed` - Η παραγγελία ολοκληρώθηκε\n* `order_canceled` - Η παραγγελία ακυρώθηκε\n* `order_refunded` - Επιστροφή χρημάτων παραγγελίας\n* `shipment_dispatched` - Αποστολή απεστάλη\n* `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε\n* `payment_failed` - Η πληρωμή απέτυχε\n* `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)\n* `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)\n* `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης\n* `comment_liked` - Επισήμανση σχολίου blog\n* `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker\n* `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε\n* `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση"
+                "description": "* `order_created` - Order created\n* `order_processing` - Order processing\n* `order_shipped` - Order shipped\n* `order_delivered` - Order delivered\n* `order_completed` - Order completed\n* `order_canceled` - Order canceled\n* `order_refunded` - Order refunded\n* `shipment_dispatched` - Shipment dispatched\n* `payment_confirmed` - Payment confirmed\n* `payment_failed` - Payment failed\n* `price_drop_favourite` - Price drop (favourited product)\n* `restock_favourite` - Back in stock (favourited product)\n* `loyalty_tier_up` - Loyalty tier promotion\n* `comment_liked` - Blog comment liked\n* `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker\n* `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered\n* `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery"
             },
             "NotificationUser": {
                 "type": "object",
@@ -53583,26 +53445,22 @@
                         "readOnly": true
                     },
                     "seen": {
-                        "type": "boolean",
-                        "title": "Ορατό"
+                        "type": "boolean"
                     },
                     "seenAt": {
                         "type": "string",
                         "format": "date-time",
-                        "nullable": true,
-                        "title": "Ορατό στις"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -53627,7 +53485,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID χρηστών ειδοποίησης προς σήμανση ως ορατά/μη ορατά"
+                        "description": "List of notification user IDs to mark as seen/unseen"
                     }
                 },
                 "required": [
@@ -53658,26 +53516,22 @@
                         "readOnly": true
                     },
                     "seen": {
-                        "type": "boolean",
-                        "title": "Ορατό"
+                        "type": "boolean"
                     },
                     "seenAt": {
                         "type": "string",
                         "format": "date-time",
-                        "nullable": true,
-                        "title": "Ορατό στις"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -53698,8 +53552,7 @@
                 "type": "object",
                 "properties": {
                     "seen": {
-                        "type": "boolean",
-                        "title": "Ορατό"
+                        "type": "boolean"
                     }
                 }
             },
@@ -53716,16 +53569,15 @@
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -53736,7 +53588,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -53748,12 +53599,10 @@
                     },
                     "street": {
                         "type": "string",
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "payWay": {
@@ -53761,12 +53610,7 @@
                         "nullable": true
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/OrderStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/OrderStatus"
                     },
                     "statusDisplay": {
                         "type": "string",
@@ -53776,17 +53620,14 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Κατάσταση ενημερώθηκε στις"
+                        "nullable": true
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "email": {
@@ -53796,25 +53637,21 @@
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Τ.Κ.",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "phone": {
                         "type": "string"
                     },
                     "customerNotes": {
-                        "type": "string",
-                        "title": "Σημειώσεις Πελάτη"
+                        "type": "string"
                     },
                     "paidAmount": {
                         "type": "number",
@@ -53850,24 +53687,17 @@
                         "readOnly": true
                     },
                     "documentType": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/OrderDocumentType"
-                            }
-                        ],
-                        "title": "Τύπος Εγγράφου"
+                        "$ref": "#/components/schemas/OrderDocumentType"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -53899,11 +53729,9 @@
                     "paymentId": {
                         "type": "string",
                         "nullable": true,
-                        "title": "ID πληρωμής",
                         "maxLength": 255
                     },
                     "paymentStatus": {
-                        "title": "Κατάσταση πληρωμής",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/PaymentStatusEnum"
@@ -53920,7 +53748,6 @@
                     },
                     "paymentMethod": {
                         "type": "string",
-                        "title": "Μέθοδος πληρωμής",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
@@ -53974,7 +53801,7 @@
                     "INVOICE"
                 ],
                 "type": "string",
-                "description": "* `RECEIPT` - Απόδειξη\n* `INVOICE` - Τιμολόγιο"
+                "description": "* `RECEIPT` - Receipt\n* `INVOICE` - Invoice"
             },
             "OrderCreateFromCartRequest": {
                 "type": "object",
@@ -53982,92 +53809,92 @@
                 "properties": {
                     "payWayId": {
                         "type": "integer",
-                        "description": "ID μεθόδου πληρωμής"
+                        "description": "Payment method ID"
                     },
                     "paymentIntentId": {
                         "type": "string",
                         "nullable": true,
-                        "description": "ID payment intent από τον πάροχο πληρωμών (υποχρεωτικό για online πληρωμές)"
+                        "description": "Payment intent ID from payment provider (required for online payments)"
                     },
                     "firstName": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Όνομα πελάτη",
+                        "description": "Customer first name",
                         "maxLength": 150
                     },
                     "lastName": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Επώνυμο πελάτη",
+                        "description": "Customer last name",
                         "maxLength": 150
                     },
                     "email": {
                         "type": "string",
                         "format": "email",
                         "minLength": 1,
-                        "description": "Email πελάτη"
+                        "description": "Customer email address"
                     },
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Όνομα οδού",
+                        "description": "Street name",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
-                        "description": "Αριθμός οδού",
+                        "description": "Street number",
                         "maxLength": 50
                     },
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Όνομα πόλης",
+                        "description": "City name",
                         "maxLength": 100
                     },
                     "zipcode": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Ταχυδρομικός κώδικας",
+                        "description": "Postal/ZIP code",
                         "maxLength": 20
                     },
                     "countryId": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Κωδικός χώρας alpha-2 (π.χ. 'GR', 'US')"
+                        "description": "Country alpha-2 code (e.g., 'GR', 'US')"
                     },
                     "regionId": {
                         "type": "string",
                         "nullable": true,
-                        "description": "Αλφαριθμητικός κωδικός περιφέρειας"
+                        "description": "Region alpha code"
                     },
                     "phone": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Τηλέφωνο πελάτη"
+                        "description": "Customer phone number"
                     },
                     "customerNotes": {
                         "type": "string",
-                        "description": "Σημειώσεις πελάτη ή ειδικές οδηγίες",
+                        "description": "Customer notes or special instructions",
                         "maxLength": 500
                     },
                     "floor": {
                         "type": "string",
-                        "description": "Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)",
+                        "description": "Floor number or label (e.g. FIRST_FLOOR)",
                         "maxLength": 50
                     },
                     "locationType": {
                         "type": "string",
-                        "description": "Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)",
+                        "description": "Location type, e.g. HOME or OFFICE (optional)",
                         "maxLength": 100
                     },
                     "billingVatId": {
                         "type": "string",
-                        "description": "ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.",
+                        "description": "Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.",
                         "maxLength": 12
                     },
                     "billingCountry": {
                         "type": "string",
-                        "description": "Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.",
+                        "description": "ISO 3166-1 alpha-2 country code for the buyer's tax identity. Defaults to the order country when blank.",
                         "maxLength": 2
                     },
                     "documentType": {
@@ -54077,17 +53904,17 @@
                             }
                         ],
                         "default": "RECEIPT",
-                        "description": "RECEIPT (Α.Λ.Π., Tier A — λιανική) ή INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Η επιλογή INVOICE απαιτεί έγκυρο ``billing_vat_id``.\n\n* `RECEIPT` - Απόδειξη\n* `INVOICE` - Τιμολόγιο"
+                        "description": "RECEIPT (Α.Λ.Π., Tier A — retail) or INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Selecting INVOICE requires a valid ``billing_vat_id``.\n\n* `RECEIPT` - Receipt\n* `INVOICE` - Invoice"
                     },
                     "loyaltyPointsToRedeem": {
                         "type": "integer",
                         "minimum": 0,
                         "nullable": true,
-                        "description": "Αριθμός πόντων πιστότητας προς εξαργύρωση για έκπτωση σε αυτή την παραγγελία"
+                        "description": "Number of loyalty points to redeem for discount on this order"
                     },
                     "boxnowLockerId": {
                         "type": "string",
-                        "description": "ID locker APM BoxNow από το widget",
+                        "description": "BoxNow APM locker ID from the widget",
                         "maxLength": 64
                     },
                     "boxnowCompartmentSize": {
@@ -54095,10 +53922,10 @@
                         "maximum": 3,
                         "minimum": 1,
                         "default": 1,
-                        "description": "Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο"
+                        "description": "BoxNow compartment size: 1=Small, 2=Medium, 3=Large"
                     },
                     "shippingProviderCode": {
-                        "description": "Κωδικός μεταφορέα από /api/v1/shipping/options (π.χ. 'acs').",
+                        "description": "Carrier code from /api/v1/shipping/options (e.g. 'acs').",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -54117,16 +53944,16 @@
                                 "$ref": "#/components/schemas/ShippingKind"
                             }
                         ],
-                        "description": "Γενικός τύπος εκπλήρωσης, ανεξάρτητος από τον πάροχο.\n\n* `home_delivery` - Κατ' οίκον παράδοση\n* `pickup_point` - Σημείο παραλαβής / locker"
+                        "description": "Generic fulfilment kind, independent of provider.\n\n* `home_delivery` - Home delivery\n* `pickup_point` - Pickup point / locker"
                     },
                     "acsStationExternalId": {
                         "type": "string",
-                        "description": "Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).",
+                        "description": "ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).",
                         "maxLength": 32
                     },
                     "acsStationBranch": {
                         "type": "string",
-                        "description": "Τιμή ACS_Station_Branch_Destination.",
+                        "description": "ACS_Station_Branch_Destination value.",
                         "maxLength": 32
                     },
                     "acsChargeType": {
@@ -54135,20 +53962,20 @@
                                 "$ref": "#/components/schemas/AcsChargeType"
                             }
                         ],
-                        "description": "Προαιρετική παράκαμψη του ACS Charge_Type ανά παραγγελία. Αφήστε το κενό για χρήση της προεπιλογής σε επίπεδο μεταφορέα (COD σε σύμβαση μόνο-COD). Ο ορισμός εδώ έχει νόημα μόνο αν η εμπορική σύμβαση με την ACS επιτρέπει την επιλεγμένη τιμή — μη έγκυροι συνδυασμοί απορρίπτονται από το ACS_Create_Voucher.\n\n* `1` - Προπληρωμένο\n* `2` - Αντικαταβολή"
+                        "description": "Optional per-order ACS Charge_Type override. Leave unset to use the carrier-level default (COD on a COD-only contract). Setting this here only makes sense if the ACS commercial contract permits the chosen value — invalid combinations are rejected by ACS_Create_Voucher.\n\n* `1` - Prepaid\n* `2` - Cash on delivery"
                     },
                     "acsItemQuantity": {
                         "type": "integer",
                         "maximum": 20,
                         "minimum": 1,
-                        "description": "Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers."
+                        "description": "Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers."
                     },
                     "meta": {
                         "type": "object",
                         "additionalProperties": {},
                         "writeOnly": true,
                         "nullable": true,
-                        "description": "Πλαίσιο Meta Pixel: κλειδιά ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict με {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict με boolean ``ads``). Κενό dict / null όταν ο πελάτης αρνήθηκε τα cookies μάρκετινγκ· ο αποστολέας CAPI τότε παραλείπει την αποστολή."
+                        "description": "Meta Pixel context: keys ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict of {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict with ``ads`` boolean). Empty dict / null when the customer declined marketing cookies; the CAPI dispatcher then skips the send."
                     }
                 },
                 "required": [
@@ -54176,16 +54003,15 @@
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -54196,7 +54022,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -54208,12 +54033,10 @@
                     },
                     "street": {
                         "type": "string",
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "payWay": {
@@ -54221,12 +54044,7 @@
                         "nullable": true
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/OrderStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/OrderStatus"
                     },
                     "statusDisplay": {
                         "type": "string",
@@ -54236,17 +54054,14 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Κατάσταση ενημερώθηκε στις"
+                        "nullable": true
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "email": {
@@ -54256,17 +54071,14 @@
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Τ.Κ.",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "phone": {
@@ -54274,8 +54086,7 @@
                         "readOnly": true
                     },
                     "customerNotes": {
-                        "type": "string",
-                        "title": "Σημειώσεις Πελάτη"
+                        "type": "string"
                     },
                     "paidAmount": {
                         "type": "number",
@@ -54311,24 +54122,17 @@
                         "readOnly": true
                     },
                     "documentType": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/OrderDocumentType"
-                            }
-                        ],
-                        "title": "Τύπος Εγγράφου"
+                        "$ref": "#/components/schemas/OrderDocumentType"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -54360,11 +54164,9 @@
                     "paymentId": {
                         "type": "string",
                         "nullable": true,
-                        "title": "ID πληρωμής",
                         "maxLength": 255
                     },
                     "paymentStatus": {
-                        "title": "Κατάσταση πληρωμής",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/PaymentStatusEnum"
@@ -54381,7 +54183,6 @@
                     },
                     "paymentMethod": {
                         "type": "string",
-                        "title": "Μέθοδος πληρωμής",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
@@ -54560,12 +54361,10 @@
                     },
                     "trackingNumber": {
                         "type": "string",
-                        "title": "Αριθμός Παρακολούθησης",
                         "maxLength": 255
                     },
                     "shippingCarrier": {
                         "type": "string",
-                        "title": "Εταιρεία μεταφοράς",
                         "maxLength": 255
                     },
                     "customerFullName": {
@@ -54650,7 +54449,7 @@
                     "CREDIT_NOTE"
                 ],
                 "type": "string",
-                "description": "* `RECEIPT` - Απόδειξη\n* `INVOICE` - Τιμολόγιο\n* `PROFORMA` - Προτιμολόγιο\n* `SHIPPING_LABEL` - Ετικέτα αποστολής\n* `RETURN_LABEL` - Ετικέτα επιστροφής\n* `CREDIT_NOTE` - Πιστωτικό"
+                "description": "* `RECEIPT` - Receipt\n* `INVOICE` - Invoice\n* `PROFORMA` - Proforma Invoice\n* `SHIPPING_LABEL` - Shipping Label\n* `RETURN_LABEL` - Return Label\n* `CREDIT_NOTE` - Credit Note"
             },
             "OrderItem": {
                 "type": "object",
@@ -54682,18 +54481,15 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "title": "Ποσότητα"
+                        "minimum": -2147483648
                     },
                     "isRefunded": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Έχει επιστραφεί"
+                        "readOnly": true
                     },
                     "refundedQuantity": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Επιστραφείσα ποσότητα"
+                        "readOnly": true
                     },
                     "netQuantity": {
                         "type": "integer",
@@ -54711,14 +54507,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -54744,12 +54538,10 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "title": "Ποσότητα"
+                        "minimum": -2147483648
                     },
                     "notes": {
-                        "type": "string",
-                        "title": "Σημειώσεις"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54791,18 +54583,15 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "title": "Ποσότητα"
+                        "minimum": -2147483648
                     },
                     "isRefunded": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Έχει επιστραφεί"
+                        "readOnly": true
                     },
                     "refundedQuantity": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Επιστραφείσα ποσότητα"
+                        "readOnly": true
                     },
                     "netQuantity": {
                         "type": "integer",
@@ -54820,20 +54609,17 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "originalQuantity": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Αρχική ποσότητα"
+                        "nullable": true
                     },
                     "refundedAmount": {
                         "type": "number",
@@ -54856,12 +54642,10 @@
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "notes": {
-                        "type": "string",
-                        "title": "Σημειώσεις"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54888,11 +54672,11 @@
                     "quantity": {
                         "type": "integer",
                         "minimum": 1,
-                        "description": "Ποσότητα προς επιστροφή. Αν δεν δοθεί, επιστρέφονται όλα."
+                        "description": "Quantity to refund. If not provided, refunds all."
                     },
                     "reason": {
                         "type": "string",
-                        "description": "Προαιρετική αιτία επιστροφής",
+                        "description": "Optional reason for the refund",
                         "maxLength": 255
                     }
                 }
@@ -54933,12 +54717,10 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "title": "Ποσότητα"
+                        "minimum": -2147483648
                     },
                     "notes": {
-                        "type": "string",
-                        "title": "Σημειώσεις"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54958,7 +54740,7 @@
                     "REFUNDED"
                 ],
                 "type": "string",
-                "description": "* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων"
+                "description": "* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded"
             },
             "OrderWriteRequest": {
                 "type": "object",
@@ -54966,17 +54748,16 @@
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -54987,7 +54768,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -55000,25 +54780,21 @@
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "email": {
@@ -55030,18 +54806,15 @@
                     "zipcode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Τ.Κ.",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "phone": {
@@ -55049,8 +54822,7 @@
                         "minLength": 1
                     },
                     "customerNotes": {
-                        "type": "string",
-                        "title": "Σημειώσεις Πελάτη"
+                        "type": "string"
                     },
                     "items": {
                         "type": "array",
@@ -56876,7 +56648,6 @@
                         "type": "integer"
                     },
                     "website": {
-                        "title": "Ιστότοπος",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -57063,26 +56834,21 @@
                         "type": "integer"
                     },
                     "featured": {
-                        "type": "boolean",
-                        "title": "Προβεβλημένο"
+                        "type": "boolean"
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 }
@@ -57121,8 +56887,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 }
             },
@@ -57132,8 +56897,7 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Ποσότητα"
+                        "minimum": 0
                     }
                 }
             },
@@ -57173,14 +56937,14 @@
                     "alpha2": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "pattern": "^[A-Z]{2}$",
                         "maxLength": 2
                     },
                     "alpha3": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 3)",
+                        "title": "Country Code Alpha 3",
                         "pattern": "^[A-Z]{3}$",
                         "maxLength": 3
                     },
@@ -57189,14 +56953,13 @@
                         "maximum": 32767,
                         "minimum": 0,
                         "nullable": true,
-                        "title": "Κωδικός ISO χώρας"
+                        "title": "ISO Country Code"
                     },
                     "phoneCode": {
                         "type": "integer",
                         "maximum": 32767,
                         "minimum": 0,
-                        "nullable": true,
-                        "title": "Κωδικός κλήσης"
+                        "nullable": true
                     }
                 }
             },
@@ -57204,8 +56967,7 @@
                 "type": "object",
                 "properties": {
                     "seen": {
-                        "type": "boolean",
-                        "title": "Ορατό"
+                        "type": "boolean"
                     }
                 }
             },
@@ -57221,12 +56983,10 @@
                     "quantity": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": -2147483648,
-                        "title": "Ποσότητα"
+                        "minimum": -2147483648
                     },
                     "notes": {
-                        "type": "string",
-                        "title": "Σημειώσεις"
+                        "type": "string"
                     }
                 }
             },
@@ -57236,17 +56996,16 @@
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -57257,7 +57016,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -57270,25 +57028,21 @@
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "email": {
@@ -57300,18 +57054,15 @@
                     "zipcode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Τ.Κ.",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "phone": {
@@ -57319,8 +57070,7 @@
                         "minLength": 1
                     },
                     "customerNotes": {
-                        "type": "string",
-                        "title": "Σημειώσεις Πελάτη"
+                        "type": "string"
                     },
                     "items": {
                         "type": "array",
@@ -57382,8 +57132,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "cost": {
                         "type": "number",
@@ -57404,29 +57153,25 @@
                     "icon": {
                         "type": "string",
                         "format": "binary",
-                        "nullable": true,
-                        "title": "Εικονίδιο"
+                        "nullable": true
                     },
                     "providerCode": {
                         "type": "string",
-                        "title": "Κωδικός παρόχου",
-                        "description": "Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')",
+                        "description": "Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
                         "type": "boolean",
-                        "title": "Είναι online πληρωμή",
-                        "description": "Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online"
+                        "description": "Whether this payment method is processed online"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)"
+                        "description": "Whether this payment method requires manual confirmation (e.g., bank transfer)"
                     },
                     "configuration": {
                         "nullable": true,
-                        "title": "Διαμόρφωση Παρόχου",
-                        "description": "Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)"
+                        "title": "Provider Configuration",
+                        "description": "Provider-specific configuration (API keys, webhooks, etc.)"
                     }
                 }
             },
@@ -57465,12 +57210,10 @@
                                 "$ref": "#/components/schemas/ImageTypeEnum"
                             }
                         ],
-                        "default": "MAIN",
-                        "title": "Τύπος εικόνας"
+                        "default": "MAIN"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "translations": {
                         "type": "object",
@@ -57561,8 +57304,7 @@
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "parent": {
                         "type": "integer",
@@ -57570,17 +57312,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 }
@@ -57606,8 +57345,7 @@
                         "title": "Εικόνα"
                     },
                     "isMain": {
-                        "type": "boolean",
-                        "title": "Κύριο"
+                        "type": "boolean"
                     },
                     "translations": {
                         "type": "object",
@@ -57653,7 +57391,6 @@
                                 "$ref": "#/components/schemas/RateEnum"
                             }
                         ],
-                        "title": "Συντ.",
                         "minimum": 0,
                         "maximum": 32767
                     },
@@ -57757,8 +57494,7 @@
                     "stock": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Απόθεμα"
+                        "minimum": 0
                     },
                     "weight": {
                         "type": "object",
@@ -57782,27 +57518,22 @@
                         "maximum": 1000000000,
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
-                        "exclusiveMinimum": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "exclusiveMinimum": true
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 }
             },
@@ -57842,13 +57573,13 @@
                     "alpha": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "maxLength": 10
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     }
                 }
             },
@@ -57897,7 +57628,7 @@
                     "slug": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')",
+                        "description": "Unique identifier for the topic (e.g., 'weekly-newsletter')",
                         "maxLength": 50,
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
@@ -57907,23 +57638,21 @@
                                 "$ref": "#/components/schemas/TopicCategory"
                             }
                         ],
-                        "title": "Κατηγορία",
-                        "description": "Κατηγορία του θέματος εγγραφής\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Category of the subscription topic\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     "isActive": {
                         "type": "boolean",
-                        "title": "Ενεργή",
-                        "description": "Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή"
+                        "title": "Active",
+                        "description": "Whether this topic is currently available for subscription"
                     },
                     "isDefault": {
                         "type": "boolean",
-                        "title": "Προεπιλεγμένη συνδρομή",
-                        "description": "Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα"
+                        "title": "Default Subscription",
+                        "description": "Whether new users are automatically subscribed to this topic"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email"
+                        "description": "Whether subscription to this topic requires email confirmation"
                     }
                 }
             },
@@ -57961,8 +57690,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 }
             },
@@ -57972,7 +57700,7 @@
                     "tagId": {
                         "type": "integer",
                         "writeOnly": true,
-                        "description": "ID ετικέτας προς ανάθεση"
+                        "description": "ID of the tag to assign"
                     },
                     "contentType": {
                         "type": "integer"
@@ -57990,47 +57718,40 @@
                     "title": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Τίτλος",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -58041,7 +57762,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -58057,23 +57777,21 @@
                     },
                     "notes": {
                         "type": "string",
-                        "title": "Σημειώσεις",
                         "maxLength": 255
                     },
                     "isMain": {
                         "type": "boolean",
-                        "default": false,
-                        "title": "Κύριο"
+                        "default": false
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας"
+                        "title": "Region Code"
                     }
                 }
             },
@@ -58084,8 +57802,7 @@
                         "type": "integer"
                     },
                     "metadata": {
-                        "title": "Μεταδεδομένα",
-                        "description": "Επιπλέον προτιμήσεις ή δεδομένα εγγραφής"
+                        "description": "Additional subscription preferences or data"
                     }
                 }
             },
@@ -58096,17 +57813,15 @@
                         "type": "string",
                         "format": "email",
                         "minLength": 1,
-                        "title": "Διεύθυνση Email",
+                        "title": "Διεύθυνση ηλεκτρονικού ταχυδρομείου",
                         "maxLength": 254
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "username": {
@@ -58137,45 +57852,41 @@
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "address": {
                         "type": "string",
-                        "title": "Διεύθυνση",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "birthDate": {
                         "type": "string",
                         "format": "date",
-                        "nullable": true,
-                        "title": "Ημ/νία γέννησης"
+                        "nullable": true
                     },
                     "twitter": {
                         "nullable": true,
-                        "title": "Προφίλ Twitter",
+                        "title": "Twitter Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58190,7 +57901,7 @@
                     },
                     "linkedin": {
                         "nullable": true,
-                        "title": "Προφίλ LinkedIn",
+                        "title": "LinkedIn Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58205,7 +57916,7 @@
                     },
                     "facebook": {
                         "nullable": true,
-                        "title": "Προφίλ Facebook",
+                        "title": "Facebook Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58220,7 +57931,7 @@
                     },
                     "instagram": {
                         "nullable": true,
-                        "title": "Προφίλ Instagram",
+                        "title": "Instagram Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58235,7 +57946,6 @@
                     },
                     "website": {
                         "nullable": true,
-                        "title": "Ιστότοπος",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58250,7 +57960,7 @@
                     },
                     "youtube": {
                         "nullable": true,
-                        "title": "Προφίλ Youtube",
+                        "title": "Youtube Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58265,7 +57975,7 @@
                     },
                     "github": {
                         "nullable": true,
-                        "title": "Προφίλ Github",
+                        "title": "Github Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -58279,14 +57989,13 @@
                         ]
                     },
                     "bio": {
-                        "type": "string",
-                        "title": "Βιογραφικό"
+                        "type": "string"
                     },
                     "languageCode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Γλώσσα",
-                        "description": "Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.",
+                        "title": "Language",
+                        "description": "Preferred language for emails and UI messages.",
                         "maxLength": 10
                     }
                 }
@@ -58347,8 +58056,7 @@
                         "readOnly": true
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "cost": {
                         "type": "number",
@@ -58369,14 +58077,12 @@
                     "icon": {
                         "type": "string",
                         "format": "uri",
-                        "nullable": true,
-                        "title": "Εικονίδιο"
+                        "nullable": true
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -58385,14 +58091,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -58405,19 +58109,16 @@
                     },
                     "providerCode": {
                         "type": "string",
-                        "title": "Κωδικός παρόχου",
-                        "description": "Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')",
+                        "description": "Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
                         "type": "boolean",
-                        "title": "Είναι online πληρωμή",
-                        "description": "Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online"
+                        "description": "Whether this payment method is processed online"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)"
+                        "description": "Whether this payment method requires manual confirmation (e.g., bank transfer)"
                     }
                 },
                 "required": [
@@ -58489,8 +58190,7 @@
                         "readOnly": true
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "cost": {
                         "type": "number",
@@ -58511,14 +58211,12 @@
                     "icon": {
                         "type": "string",
                         "format": "uri",
-                        "nullable": true,
-                        "title": "Εικονίδιο"
+                        "nullable": true
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -58527,14 +58225,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -58547,19 +58243,16 @@
                     },
                     "providerCode": {
                         "type": "string",
-                        "title": "Κωδικός παρόχου",
-                        "description": "Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')",
+                        "description": "Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
                         "type": "boolean",
-                        "title": "Είναι online πληρωμή",
-                        "description": "Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online"
+                        "description": "Whether this payment method is processed online"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)"
+                        "description": "Whether this payment method requires manual confirmation (e.g., bank transfer)"
                     },
                     "configuration": {
                         "readOnly": true
@@ -58631,8 +58324,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "cost": {
                         "type": "number",
@@ -58653,29 +58345,25 @@
                     "icon": {
                         "type": "string",
                         "format": "binary",
-                        "nullable": true,
-                        "title": "Εικονίδιο"
+                        "nullable": true
                     },
                     "providerCode": {
                         "type": "string",
-                        "title": "Κωδικός παρόχου",
-                        "description": "Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')",
+                        "description": "Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')",
                         "maxLength": 50
                     },
                     "isOnlinePayment": {
                         "type": "boolean",
-                        "title": "Είναι online πληρωμή",
-                        "description": "Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online"
+                        "description": "Whether this payment method is processed online"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)"
+                        "description": "Whether this payment method requires manual confirmation (e.g., bank transfer)"
                     },
                     "configuration": {
                         "nullable": true,
-                        "title": "Διαμόρφωση Παρόχου",
-                        "description": "Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)"
+                        "title": "Provider Configuration",
+                        "description": "Provider-specific configuration (API keys, webhooks, etc.)"
                     }
                 },
                 "required": [
@@ -58689,7 +58377,7 @@
                     "cod"
                 ],
                 "type": "string",
-                "description": "* `prepaid` - Προπληρωμένο\n* `cod` - Αντικαταβολή"
+                "description": "* `prepaid` - Prepaid\n* `cod` - Cash on delivery"
             },
             "PaymentStatusEnum": {
                 "enum": [
@@ -58702,7 +58390,7 @@
                     "CANCELED"
                 ],
                 "type": "string",
-                "description": "* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε"
+                "description": "* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled"
             },
             "PaymentStatusResponse": {
                 "type": "object",
@@ -58779,8 +58467,7 @@
                     "points": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Πόντοι",
-                        "description": "Θετικό για κέρδος/μπόνους, αρνητικό για εξαργύρωση/λήξη/προσαρμογή"
+                        "description": "Positive for earn/bonus, negative for redeem/expire/adjust"
                     },
                     "transactionType": {
                         "allOf": [
@@ -58788,8 +58475,7 @@
                                 "$ref": "#/components/schemas/TransactionTypeEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "title": "Τύπος συναλλαγής"
+                        "readOnly": true
                     },
                     "referenceOrder": {
                         "type": "integer",
@@ -58798,14 +58484,12 @@
                     },
                     "description": {
                         "type": "string",
-                        "readOnly": true,
-                        "title": "Περιγραφή"
+                        "readOnly": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -58826,7 +58510,7 @@
                     "CRITICAL"
                 ],
                 "type": "string",
-                "description": "* `LOW` - Χαμηλή προτεραιότητα\n* `NORMAL` - Κανονική προτεραιότητα\n* `HIGH` - Υψηλή προτεραιότητα\n* `URGENT` - Επείγουσα προτεραιότητα\n* `CRITICAL` - Κρίσιμη προτεραιότητα"
+                "description": "* `LOW` - Low Priority\n* `NORMAL` - Normal Priority\n* `HIGH` - High Priority\n* `URGENT` - Urgent Priority\n* `CRITICAL` - Critical Priority"
             },
             "Product": {
                 "type": "object",
@@ -58886,7 +58570,7 @@
                         "type": "integer",
                         "readOnly": true,
                         "nullable": true,
-                        "description": "Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα."
+                        "description": "Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront."
                     },
                     "brand": {
                         "type": "integer",
@@ -58911,24 +58595,20 @@
                     },
                     "viewCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Προβολές"
+                        "readOnly": true
                     },
                     "stock": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Απόθεμα"
+                        "minimum": 0
                     },
                     "lowStockThreshold": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Όριο χαμηλού αποθέματος",
-                        "description": "Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν."
+                        "description": "Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product."
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "weight": {
                         "type": "object",
@@ -58948,17 +58628,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     },
                     "discountPercent": {
@@ -58967,8 +58644,7 @@
                         "maximum": 1000000000,
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
-                        "exclusiveMinimum": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "exclusiveMinimum": true
                     },
                     "discountValue": {
                         "type": "number",
@@ -59030,14 +58706,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -59092,12 +58766,7 @@
                         "readOnly": true
                     },
                     "kind": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ProductAlertKindEnum"
-                            }
-                        ],
-                        "title": "Είδος"
+                        "$ref": "#/components/schemas/ProductAlertKindEnum"
                     },
                     "product": {
                         "type": "integer"
@@ -59124,27 +58793,23 @@
                     },
                     "isActive": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργό"
+                        "readOnly": true
                     },
                     "notifiedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Ειδοποιήθηκε στις"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -59165,18 +58830,13 @@
                     "price_drop"
                 ],
                 "type": "string",
-                "description": "* `restock` - Αναπλήρωση\n* `price_drop` - Πτώση τιμής"
+                "description": "* `restock` - Restock\n* `price_drop` - Price drop"
             },
             "ProductAlertRequest": {
                 "type": "object",
                 "properties": {
                     "kind": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ProductAlertKindEnum"
-                            }
-                        ],
-                        "title": "Είδος"
+                        "$ref": "#/components/schemas/ProductAlertKindEnum"
                     },
                     "product": {
                         "type": "integer"
@@ -59231,8 +58891,7 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -59326,8 +58985,7 @@
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "parent": {
                         "type": "integer",
@@ -59344,14 +59002,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -59422,8 +59078,7 @@
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "parent": {
                         "type": "integer",
@@ -59440,14 +59095,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -59467,17 +59120,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 },
@@ -59520,18 +59170,15 @@
                                 "$ref": "#/components/schemas/ImageTypeEnum"
                             }
                         ],
-                        "default": "MAIN",
-                        "title": "Τύπος εικόνας"
+                        "default": "MAIN"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "translations": {
                         "type": "object",
@@ -59582,14 +59229,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -59656,18 +59301,15 @@
                                 "$ref": "#/components/schemas/ImageTypeEnum"
                             }
                         ],
-                        "default": "MAIN",
-                        "title": "Τύπος εικόνας"
+                        "default": "MAIN"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "translations": {
                         "type": "object",
@@ -59718,14 +59360,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -59765,12 +59405,10 @@
                                 "$ref": "#/components/schemas/ImageTypeEnum"
                             }
                         ],
-                        "default": "MAIN",
-                        "title": "Τύπος εικόνας"
+                        "default": "MAIN"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "translations": {
                         "type": "object",
@@ -59866,8 +59504,7 @@
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "parent": {
                         "type": "integer",
@@ -59875,17 +59512,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     }
                 },
@@ -59952,7 +59586,7 @@
                         "type": "integer",
                         "readOnly": true,
                         "nullable": true,
-                        "description": "Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα."
+                        "description": "Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront."
                     },
                     "brand": {
                         "type": "integer",
@@ -59977,24 +59611,20 @@
                     },
                     "viewCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Προβολές"
+                        "readOnly": true
                     },
                     "stock": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Απόθεμα"
+                        "minimum": 0
                     },
                     "lowStockThreshold": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Όριο χαμηλού αποθέματος",
-                        "description": "Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν."
+                        "description": "Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product."
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "weight": {
                         "type": "object",
@@ -60014,17 +59644,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     },
                     "discountPercent": {
@@ -60033,8 +59660,7 @@
                         "maximum": 1000000000,
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
-                        "exclusiveMinimum": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "exclusiveMinimum": true
                     },
                     "discountValue": {
                         "type": "number",
@@ -60096,14 +59722,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -60120,8 +59744,7 @@
                     "priceDropAlertsEnabled": {
                         "type": "boolean",
                         "readOnly": true,
-                        "title": "Ειδοποιήσεις πτώσης τιμής",
-                        "description": "Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU."
+                        "description": "When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU."
                     }
                 },
                 "required": [
@@ -60210,7 +59833,7 @@
                         "type": "integer",
                         "readOnly": true,
                         "nullable": true,
-                        "description": "Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα."
+                        "description": "Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront."
                     },
                     "brand": {
                         "type": "integer",
@@ -60235,24 +59858,20 @@
                     },
                     "viewCount": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Προβολές"
+                        "readOnly": true
                     },
                     "stock": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Απόθεμα"
+                        "minimum": 0
                     },
                     "lowStockThreshold": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Όριο χαμηλού αποθέματος",
-                        "description": "Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν."
+                        "description": "Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product."
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "weight": {
                         "type": "object",
@@ -60272,17 +59891,14 @@
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     },
                     "discountPercent": {
@@ -60291,8 +59907,7 @@
                         "maximum": 1000000000,
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
-                        "exclusiveMinimum": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "exclusiveMinimum": true
                     },
                     "discountValue": {
                         "type": "number",
@@ -60354,14 +59969,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -60378,8 +59991,7 @@
                     "priceDropAlertsEnabled": {
                         "type": "boolean",
                         "readOnly": true,
-                        "title": "Ειδοποιήσεις πτώσης τιμής",
-                        "description": "Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU."
+                        "description": "When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU."
                     }
                 },
                 "required": [
@@ -60436,8 +60048,7 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -60462,7 +60073,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID προϊόντων για έλεγχο αγαπημένων",
+                        "description": "List of product IDs to check for favorites",
                         "maxItems": 100
                     }
                 },
@@ -60520,8 +60131,7 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -60535,8 +60145,7 @@
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -60613,14 +60222,12 @@
                         "readOnly": true
                     },
                     "isMain": {
-                        "type": "boolean",
-                        "title": "Κύριο"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "translations": {
                         "type": "object",
@@ -60658,8 +60265,7 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -60716,14 +60322,12 @@
                         "readOnly": true
                     },
                     "isMain": {
-                        "type": "boolean",
-                        "title": "Κύριο"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "translations": {
                         "type": "object",
@@ -60761,8 +60365,7 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "imageDimensions": {
                         "type": "object",
@@ -60804,8 +60407,7 @@
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -60839,8 +60441,7 @@
                         "title": "Εικόνα"
                     },
                     "isMain": {
-                        "type": "boolean",
-                        "title": "Κύριο"
+                        "type": "boolean"
                     },
                     "translations": {
                         "type": "object",
@@ -60880,7 +60481,18 @@
             },
             "ProductMeiliSearchResponse": {
                 "type": "object",
+                "description": "Common disclosure fields every search response carries.\n\n``query_id`` attributes later clicks to this query (see the\n``search/click`` endpoint); ``relaxed_query`` reports the trimmed\nquery the zero-result fallback actually matched, so clients can\ndisclose \"showing results for …\" instead of silently swapping.",
                 "properties": {
+                    "queryId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier for this search, used to attribute clicks"
+                    },
+                    "relaxedQuery": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The relaxed query used by the zero-result fallback, or null when results matched the original query"
+                    },
                     "limit": {
                         "type": "integer"
                     },
@@ -60919,6 +60531,8 @@
                     "estimatedTotalHits",
                     "limit",
                     "offset",
+                    "queryId",
+                    "relaxedQuery",
                     "results"
                 ]
             },
@@ -61068,40 +60682,30 @@
                                 "$ref": "#/components/schemas/RateEnum"
                             }
                         ],
-                        "title": "Συντ.",
                         "minimum": 0,
                         "maximum": 32767
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ReviewStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/ReviewStatus"
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "publishedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Δημοσιεύθηκε στις"
+                        "nullable": true
                     },
                     "uuid": {
                         "type": "string",
@@ -61180,40 +60784,30 @@
                                 "$ref": "#/components/schemas/RateEnum"
                             }
                         ],
-                        "title": "Συντ.",
                         "minimum": 0,
                         "maximum": 32767
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ReviewStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/ReviewStatus"
                     },
                     "isPublished": {
-                        "type": "boolean",
-                        "title": "Δημοσιευμένο"
+                        "type": "boolean"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "publishedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Δημοσιεύθηκε στις"
+                        "nullable": true
                     },
                     "uuid": {
                         "type": "string",
@@ -61275,7 +60869,6 @@
                                 "$ref": "#/components/schemas/RateEnum"
                             }
                         ],
-                        "title": "Συντ.",
                         "minimum": 0,
                         "maximum": 32767
                     },
@@ -61368,13 +60961,11 @@
                     },
                     "active": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Ενεργή"
+                        "readOnly": true
                     },
                     "stock": {
                         "type": "integer",
-                        "readOnly": true,
-                        "title": "Απόθεμα"
+                        "readOnly": true
                     },
                     "price": {
                         "type": "number",
@@ -61401,8 +60992,7 @@
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
-                        "readOnly": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "readOnly": true
                     },
                     "mainImagePath": {
                         "type": "string",
@@ -61520,8 +61110,7 @@
                     "stock": {
                         "type": "integer",
                         "maximum": 2147483647,
-                        "minimum": 0,
-                        "title": "Απόθεμα"
+                        "minimum": 0
                     },
                     "weight": {
                         "type": "object",
@@ -61545,27 +61134,22 @@
                         "maximum": 1000000000,
                         "minimum": -1000000000,
                         "exclusiveMaximum": true,
-                        "exclusiveMinimum": true,
-                        "title": "Ποσοστό Έκπτωσης"
+                        "exclusiveMinimum": true
                     },
                     "seoTitle": {
                         "type": "string",
-                        "title": "Τίτλος SEO",
                         "maxLength": 70
                     },
                     "seoDescription": {
                         "type": "string",
-                        "title": "Περιγραφή SEO",
                         "maxLength": 300
                     },
                     "seoKeywords": {
                         "type": "string",
-                        "title": "Λέξεις-κλειδιά SEO",
                         "maxLength": 255
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -61590,7 +61174,7 @@
                     10
                 ],
                 "type": "integer",
-                "description": "* `1` - Ένα\n* `2` - Δύο\n* `3` - Τρία\n* `4` - Τέσσερα\n* `5` - Πέντε\n* `6` - Έξι\n* `7` - Επτά\n* `8` - Οκτώ\n* `9` - Εννέα\n* `10` - Δέκα"
+                "description": "* `1` - One\n* `2` - Two\n* `3` - Three\n* `4` - Four\n* `5` - Five\n* `6` - Six\n* `7` - Seven\n* `8` - Eight\n* `9` - Nine\n* `10` - Ten"
             },
             "RedeemPointsRequestRequest": {
                 "type": "object",
@@ -61693,30 +61277,27 @@
                     },
                     "alpha": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "maxLength": 10
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -61769,30 +61350,27 @@
                     },
                     "alpha": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "maxLength": 10
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -61846,13 +61424,13 @@
                     "alpha": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "maxLength": 10
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     }
                 },
                 "required": [
@@ -61870,7 +61448,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID δεσμεύσεων προς απελευθέρωση"
+                        "description": "List of reservation IDs to release"
                     }
                 },
                 "required": [
@@ -61883,11 +61461,11 @@
                 "properties": {
                     "message": {
                         "type": "string",
-                        "description": "Μήνυμα επιτυχίας"
+                        "description": "Success message"
                     },
                     "releasedCount": {
                         "type": "integer",
-                        "description": "Αριθμός αποδεσμευμένων κρατήσεων"
+                        "description": "Number of reservations released"
                     },
                     "failedReleases": {
                         "type": "array",
@@ -61895,7 +61473,7 @@
                             "type": "object",
                             "additionalProperties": {}
                         },
-                        "description": "Λίστα αποτυχημένων απελευθερώσεων με λεπτομέρειες σφάλματος"
+                        "description": "List of failed releases with error details"
                     }
                 },
                 "required": [
@@ -61961,17 +61539,25 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "Λίστα ID δημιουργημένων δεσμεύσεων αποθέματος"
+                        "description": "List of created stock reservation IDs"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Μήνυμα επιτυχίας"
+                        "description": "Success message"
                     }
                 },
                 "required": [
                     "message",
                     "reservationIds"
                 ]
+            },
+            "ResultTypeEnum": {
+                "enum": [
+                    "product",
+                    "blog_post"
+                ],
+                "type": "string",
+                "description": "* `product` - product\n* `blog_post` - blog_post"
             },
             "ReviewStatus": {
                 "enum": [
@@ -61980,7 +61566,7 @@
                     "FALSE"
                 ],
                 "type": "string",
-                "description": "* `NEW` - Νέο\n* `TRUE` - Ναι\n* `FALSE` - Όχι"
+                "description": "* `NEW` - New\n* `TRUE` - True\n* `FALSE` - False"
             },
             "SearchAnalyticsResponse": {
                 "type": "object",
@@ -62037,6 +61623,53 @@
                     "searchVolume",
                     "topQueries",
                     "zeroResultQueries"
+                ]
+            },
+            "SearchClickRequestRequest": {
+                "type": "object",
+                "description": "Payload for attributing a result click to a search query.",
+                "properties": {
+                    "queryId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The query_id returned by the search response"
+                    },
+                    "resultId": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "ID of the clicked result (Product or BlogPost ID)",
+                        "maxLength": 100
+                    },
+                    "resultType": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ResultTypeEnum"
+                            }
+                        ],
+                        "description": "Type of the clicked result\n\n* `product` - product\n* `blog_post` - blog_post"
+                    },
+                    "position": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "0-indexed position of the result in the result list"
+                    }
+                },
+                "required": [
+                    "position",
+                    "queryId",
+                    "resultId",
+                    "resultType"
+                ]
+            },
+            "SearchClickResponse": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "detail"
                 ]
             },
             "SearchVolume": {
@@ -62116,7 +61749,7 @@
                     "lost"
                 ],
                 "type": "string",
-                "description": "* `pending_creation` - Εκκρεμής δημιουργία\n* `new` - Νέο\n* `in_transit` - Σε μεταφορά\n* `at_destination` - Στο κατάστημα παράδοσης\n* `out_for_delivery` - Σε διανομή\n* `delivered` - Παραδόθηκε\n* `attempted` - Απόπειρα παράδοσης\n* `returned` - Επιστράφηκε\n* `canceled` - Ακυρώθηκε\n* `lost` - Χάθηκε"
+                "description": "* `pending_creation` - Pending creation\n* `new` - New\n* `in_transit` - In transit\n* `at_destination` - At destination station\n* `out_for_delivery` - Out for delivery\n* `delivered` - Delivered\n* `attempted` - Delivery attempted\n* `returned` - Returned\n* `canceled` - Canceled\n* `lost` - Lost"
             },
             "ShippingKind": {
                 "enum": [
@@ -62124,7 +61757,7 @@
                     "pickup_point"
                 ],
                 "type": "string",
-                "description": "* `home_delivery` - Κατ' οίκον παράδοση\n* `pickup_point` - Σημείο παραλαβής / locker"
+                "description": "* `home_delivery` - Home delivery\n* `pickup_point` - Pickup point / locker"
             },
             "ShippingOption": {
                 "type": "object",
@@ -62147,7 +61780,7 @@
                         "exclusiveMaximum": true,
                         "exclusiveMinimum": true,
                         "nullable": true,
-                        "description": "Null όταν ο πάροχος παραπέμπει στη γενική πάγια χρέωση."
+                        "description": "Null when the provider defers to the global flat rate."
                     },
                     "currency": {
                         "type": "string",
@@ -62163,7 +61796,7 @@
                         "type": "string",
                         "format": "uri",
                         "nullable": true,
-                        "description": "Απόλυτο URL για το λογότυπο μάρκας που ανέβασε ο χειριστής, υπολογισμένο ανά (πάροχο, τύπο) ώστε η γραμμή κατ' οίκον παράδοσης και η γραμμή σημείου παραλαβής του ίδιου μεταφορέα να μπορούν να εμφανίζουν διαφορετικές εικόνες. Null όταν δεν έχει μεταφορτωθεί λογότυπο — το κατάστημα τότε επιστρέφει στην ενσωματωμένη προεπιλογή του. Το ``settings.MEDIA_URL`` είναι απόλυτο σε κάθε περιβάλλον, οπότε αυτό είναι πάντα πλήρες URL όταν υπάρχει."
+                        "description": "Absolute URL for the operator-uploaded brand logo, resolved per (provider, kind) so the home-delivery row and the pickup-point row of the same carrier can show different images. Null when no logo is uploaded — the storefront then falls back to its bundled default. ``settings.MEDIA_URL`` is absolute in every environment so this is always a full URL when present."
                     },
                     "metadata": {
                         "type": "object",
@@ -62192,41 +61825,36 @@
                         "type": "string",
                         "readOnly": true,
                         "title": "Κωδικός",
-                        "description": "Σταθερό αναγνωριστικό που αντιστοιχεί στον καταχωρημένο προσαρμογέα μεταφορέα (π.χ. 'acs', 'boxnow').",
+                        "description": "Stable identifier matching the registered carrier adapter (e.g. 'acs', 'boxnow').",
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
                     "name": {
                         "type": "string",
                         "readOnly": true,
-                        "title": "Όνομα",
-                        "description": "Όνομα εμφάνισης προς τους πελάτες (π.χ. 'ACS Courier')."
+                        "description": "Display name shown to customers (e.g. 'ACS Courier')."
                     },
                     "isActive": {
                         "type": "boolean",
                         "readOnly": true,
-                        "title": "Ενεργό",
-                        "description": "Κύριος διακόπτης — όταν είναι False, ο πάροχος αποκρύπτεται από το checkout ανεξάρτητα από τις σημαίες δυνατοτήτων."
+                        "description": "Master switch — when False the provider is hidden from checkout regardless of capability flags."
                     },
                     "supportsHomeDelivery": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Υποστηρίζει Κατ' Οίκον Παράδοση"
+                        "readOnly": true
                     },
                     "supportsPickupPoint": {
                         "type": "boolean",
-                        "readOnly": true,
-                        "title": "Υποστηρίζει σημείο παραλαβής"
+                        "readOnly": true
                     },
                     "liveMode": {
                         "type": "boolean",
                         "readOnly": true,
-                        "description": "False = διαπιστευτήρια sandbox / δοκιμής. Χρησιμοποιείται από το UI διαχείρισης για να προειδοποιεί τους χειριστές ότι τα vouchers δεν θα αποσταλούν πραγματικά."
+                        "description": "False = sandbox / test credentials. Used by the admin UI to warn operators that vouchers won't actually ship."
                     },
                     "priority": {
                         "type": "integer",
                         "readOnly": true,
-                        "title": "Προτεραιότητα",
-                        "description": "Σειρά ταξινόμησης στο checkout — οι μικρότεροι αριθμοί εμφανίζονται πρώτοι."
+                        "description": "Sort order in checkout — lower numbers appear first."
                     },
                     "logo": {
                         "type": "string",
@@ -62259,20 +61887,17 @@
                     },
                     "metadata": {
                         "readOnly": true,
-                        "title": "Μεταδεδομένα",
-                        "description": "Διαμόρφωση ειδική για τον πάροχο (υποστηριζόμενες χώρες, σημαίες λειτουργιών, υποδείξεις branding)."
+                        "description": "Provider-specific configuration (supported countries, feature flags, branding hints)."
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -62305,7 +61930,7 @@
                     8
                 ],
                 "type": "integer",
-                "description": "* `1` - Κατάστημα\n* `2` - Συνεργαζόμενο κατάστημα (2)\n* `3` - Συνεργαζόμενο κατάστημα (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (χωρίς locker)\n* `8` - Smartpoint locker"
+                "description": "* `1` - Shop\n* `2` - Partner shop (2)\n* `3` - Partner shop (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (no locker)\n* `8` - Smartpoint locker"
             },
             "SubscriptionStatus": {
                 "enum": [
@@ -62315,7 +61940,7 @@
                     "BOUNCED"
                 ],
                 "type": "string",
-                "description": "* `ACTIVE` - Ενεργή\n* `PENDING` - Εκκρεμεί Επιβεβαίωση\n* `UNSUBSCRIBED` - Διαγραφή\n* `BOUNCED` - Επιστράφηκε"
+                "description": "* `ACTIVE` - Active\n* `PENDING` - Pending Confirmation\n* `UNSUBSCRIBED` - Unsubscribed\n* `BOUNCED` - Bounced"
             },
             "SubscriptionTopic": {
                 "type": "object",
@@ -62370,7 +61995,7 @@
                     },
                     "slug": {
                         "type": "string",
-                        "description": "Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')",
+                        "description": "Unique identifier for the topic (e.g., 'weekly-newsletter')",
                         "maxLength": 50,
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
@@ -62380,23 +62005,21 @@
                                 "$ref": "#/components/schemas/TopicCategory"
                             }
                         ],
-                        "title": "Κατηγορία",
-                        "description": "Κατηγορία του θέματος εγγραφής\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Category of the subscription topic\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     "isActive": {
                         "type": "boolean",
-                        "title": "Ενεργή",
-                        "description": "Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή"
+                        "title": "Active",
+                        "description": "Whether this topic is currently available for subscription"
                     },
                     "isDefault": {
                         "type": "boolean",
-                        "title": "Προεπιλεγμένη συνδρομή",
-                        "description": "Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα"
+                        "title": "Default Subscription",
+                        "description": "Whether new users are automatically subscribed to this topic"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email"
+                        "description": "Whether subscription to this topic requires email confirmation"
                     },
                     "subscriberCount": {
                         "type": "integer",
@@ -62464,7 +62087,7 @@
                     },
                     "slug": {
                         "type": "string",
-                        "description": "Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')",
+                        "description": "Unique identifier for the topic (e.g., 'weekly-newsletter')",
                         "maxLength": 50,
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
@@ -62474,23 +62097,21 @@
                                 "$ref": "#/components/schemas/TopicCategory"
                             }
                         ],
-                        "title": "Κατηγορία",
-                        "description": "Κατηγορία του θέματος εγγραφής\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Category of the subscription topic\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     "isActive": {
                         "type": "boolean",
-                        "title": "Ενεργή",
-                        "description": "Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή"
+                        "title": "Active",
+                        "description": "Whether this topic is currently available for subscription"
                     },
                     "isDefault": {
                         "type": "boolean",
-                        "title": "Προεπιλεγμένη συνδρομή",
-                        "description": "Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα"
+                        "title": "Default Subscription",
+                        "description": "Whether new users are automatically subscribed to this topic"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email"
+                        "description": "Whether subscription to this topic requires email confirmation"
                     },
                     "subscriberCount": {
                         "type": "integer",
@@ -62499,14 +62120,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -62564,7 +62183,7 @@
                     "slug": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')",
+                        "description": "Unique identifier for the topic (e.g., 'weekly-newsletter')",
                         "maxLength": 50,
                         "pattern": "^[-a-zA-Z0-9_]+$"
                     },
@@ -62574,23 +62193,21 @@
                                 "$ref": "#/components/schemas/TopicCategory"
                             }
                         ],
-                        "title": "Κατηγορία",
-                        "description": "Κατηγορία του θέματος εγγραφής\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                        "description": "Category of the subscription topic\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
                     },
                     "isActive": {
                         "type": "boolean",
-                        "title": "Ενεργή",
-                        "description": "Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή"
+                        "title": "Active",
+                        "description": "Whether this topic is currently available for subscription"
                     },
                     "isDefault": {
                         "type": "boolean",
-                        "title": "Προεπιλεγμένη συνδρομή",
-                        "description": "Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα"
+                        "title": "Default Subscription",
+                        "description": "Whether new users are automatically subscribed to this topic"
                     },
                     "requiresConfirmation": {
                         "type": "boolean",
-                        "title": "Απαιτείται Επιβεβαίωση",
-                        "description": "Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email"
+                        "description": "Whether subscription to this topic requires email confirmation"
                     }
                 },
                 "required": [
@@ -62636,31 +62253,27 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "usageCount": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Πόσες φορές χρησιμοποιείται η ετικέτα"
+                        "description": "Number of times this tag is used"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -62716,31 +62329,27 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     },
                     "sortOrder": {
                         "type": "integer",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Σειρά ταξινόμησης"
+                        "nullable": true
                     },
                     "usageCount": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Πόσες φορές χρησιμοποιείται η ετικέτα"
+                        "description": "Number of times this tag is used"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -62750,7 +62359,7 @@
                     "contentTypes": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Τύποι περιεχομένου με τους οποίους χρησιμοποιείται αυτή η ετικέτα"
+                        "description": "Content types this tag is used with"
                     }
                 },
                 "required": [
@@ -62798,8 +62407,7 @@
                         }
                     },
                     "active": {
-                        "type": "boolean",
-                        "title": "Ενεργή"
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -62827,7 +62435,7 @@
                     "contentTypeName": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Όνομα τύπου περιεχομένου"
+                        "description": "Name of the content type"
                     },
                     "objectId": {
                         "type": "integer",
@@ -62836,7 +62444,7 @@
                     },
                     "contentObject": {
                         "type": "object",
-                        "description": "Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου",
+                        "description": "Serialized representation of the related content object",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -62865,14 +62473,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -62913,7 +62519,7 @@
                     "contentTypeName": {
                         "type": "string",
                         "readOnly": true,
-                        "description": "Όνομα τύπου περιεχομένου"
+                        "description": "Name of the content type"
                     },
                     "objectId": {
                         "type": "integer",
@@ -62922,7 +62528,7 @@
                     },
                     "contentObject": {
                         "type": "object",
-                        "description": "Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου",
+                        "description": "Serialized representation of the related content object",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -62951,14 +62557,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -62984,7 +62588,7 @@
                     "tagId": {
                         "type": "integer",
                         "writeOnly": true,
-                        "description": "ID ετικέτας προς ανάθεση"
+                        "description": "ID of the tag to assign"
                     },
                     "contentType": {
                         "type": "integer"
@@ -63237,7 +62841,7 @@
                     "OTHER"
                 ],
                 "type": "string",
-                "description": "* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο"
+                "description": "* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other"
             },
             "TransactionTypeEnum": {
                 "enum": [
@@ -63248,7 +62852,7 @@
                     "BONUS"
                 ],
                 "type": "string",
-                "description": "* `EARN` - Κερδίστε\n* `REDEEM` - Εξαργύρωση\n* `EXPIRE` - Λήξη\n* `ADJUST` - Προσαρμογή\n* `BONUS` - Bonus"
+                "description": "* `EARN` - Earn\n* `REDEEM` - Redeem\n* `EXPIRE` - Expire\n* `ADJUST` - Adjust\n* `BONUS` - Bonus"
             },
             "TrendingSearchItem": {
                 "type": "object",
@@ -63306,7 +62910,7 @@
                     "depot"
                 ],
                 "type": "string",
-                "description": "* `apm` - APM\n* `any_apm` - Οποιοδήποτε APM\n* `warehouse` - Αποθήκη\n* `depot` - Αποθήκη"
+                "description": "* `apm` - APM\n* `any_apm` - Any APM\n* `warehouse` - Warehouse\n* `depot` - Depot"
             },
             "UnsubscribeResponse": {
                 "type": "object",
@@ -63355,41 +62959,34 @@
                     },
                     "title": {
                         "type": "string",
-                        "title": "Τίτλος",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "street": {
                         "type": "string",
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -63400,7 +62997,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -63415,13 +63011,11 @@
                     },
                     "notes": {
                         "type": "string",
-                        "title": "Σημειώσεις",
                         "maxLength": 255
                     },
                     "isMain": {
                         "type": "boolean",
-                        "default": false,
-                        "title": "Κύριο"
+                        "default": false
                     },
                     "user": {
                         "type": "integer",
@@ -63429,23 +63023,21 @@
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "region": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας"
+                        "title": "Region Code"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -63480,41 +63072,34 @@
                     },
                     "title": {
                         "type": "string",
-                        "title": "Τίτλος",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "street": {
                         "type": "string",
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -63525,7 +63110,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -63540,13 +63124,11 @@
                     },
                     "notes": {
                         "type": "string",
-                        "title": "Σημειώσεις",
                         "maxLength": 255
                     },
                     "isMain": {
                         "type": "boolean",
-                        "default": false,
-                        "title": "Κύριο"
+                        "default": false
                     },
                     "user": {
                         "type": "integer",
@@ -63554,23 +63136,21 @@
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "region": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας"
+                        "title": "Region Code"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -63602,47 +63182,40 @@
                     "title": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Τίτλος",
                         "maxLength": 255
                     },
                     "firstName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "street": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Οδός",
                         "maxLength": 255
                     },
                     "streetNumber": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Αριθμός",
                         "maxLength": 255
                     },
                     "city": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "floor": {
-                        "title": "Όροφος",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/FloorEnum"
@@ -63653,7 +63226,6 @@
                         ]
                     },
                     "locationType": {
-                        "title": "Τύπος τοποθεσίας",
                         "oneOf": [
                             {
                                 "$ref": "#/components/schemas/LocationTypeEnum"
@@ -63669,23 +63241,21 @@
                     },
                     "notes": {
                         "type": "string",
-                        "title": "Σημειώσεις",
                         "maxLength": 255
                     },
                     "isMain": {
                         "type": "boolean",
-                        "default": false,
-                        "title": "Κύριο"
+                        "default": false
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)"
+                        "title": "Country Code Alpha 2"
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας"
+                        "title": "Region Code"
                     }
                 },
                 "required": [
@@ -63760,17 +63330,15 @@
                     "email": {
                         "type": "string",
                         "format": "email",
-                        "title": "Διεύθυνση Email",
+                        "title": "Διεύθυνση ηλεκτρονικού ταχυδρομείου",
                         "maxLength": 254
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "id": {
@@ -63799,108 +63367,103 @@
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "address": {
                         "type": "string",
-                        "title": "Διεύθυνση",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "country": {
                         "type": "string",
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "birthDate": {
                         "type": "string",
                         "format": "date",
-                        "nullable": true,
-                        "title": "Ημ/νία γέννησης"
+                        "nullable": true
                     },
                     "twitter": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "linkedin": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "facebook": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "instagram": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "website": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "youtube": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "github": {
                         "type": "string",
                         "nullable": true,
                         "maxLength": 200,
-                        "description": "Σύνδεσμος URL ή κενή τιμή",
+                        "description": "URL link or empty string",
                         "readOnly": true
                     },
                     "bio": {
-                        "type": "string",
-                        "title": "Βιογραφικό"
+                        "type": "string"
                     },
                     "languageCode": {
                         "type": "string",
-                        "title": "Γλώσσα",
-                        "description": "Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.",
+                        "title": "Language",
+                        "description": "Preferred language for emails and UI messages.",
                         "maxLength": 10
                     },
                     "isActive": {
                         "type": "boolean",
                         "readOnly": true,
-                        "title": "Ενεργή"
+                        "title": "Active"
                     },
                     "isStaff": {
                         "type": "boolean",
                         "readOnly": true,
-                        "title": "Προσωπικό"
+                        "title": "Staff"
                     },
                     "isSuperuser": {
                         "type": "boolean",
@@ -63911,14 +63474,12 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     },
                     "uuid": {
                         "type": "string",
@@ -63974,41 +63535,31 @@
                         "readOnly": true
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SubscriptionStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/SubscriptionStatus"
                     },
                     "subscribedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Εγγραφή στις"
+                        "readOnly": true
                     },
                     "unsubscribedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Διαγραφή στις"
+                        "nullable": true
                     },
                     "metadata": {
-                        "title": "Μεταδεδομένα",
-                        "description": "Επιπλέον προτιμήσεις ή δεδομένα εγγραφής"
+                        "description": "Additional subscription preferences or data"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -64046,41 +63597,31 @@
                         "readOnly": true
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SubscriptionStatus"
-                            }
-                        ],
-                        "title": "Κατάσταση"
+                        "$ref": "#/components/schemas/SubscriptionStatus"
                     },
                     "subscribedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Εγγραφή στις"
+                        "readOnly": true
                     },
                     "unsubscribedAt": {
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true,
-                        "nullable": true,
-                        "title": "Διαγραφή στις"
+                        "nullable": true
                     },
                     "metadata": {
-                        "title": "Μεταδεδομένα",
-                        "description": "Επιπλέον προτιμήσεις ή δεδομένα εγγραφής"
+                        "description": "Additional subscription preferences or data"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Δημιουργήθηκε στις"
+                        "readOnly": true
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "readOnly": true,
-                        "title": "Ενημερώθηκε στις"
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -64101,8 +63642,7 @@
                         "type": "integer"
                     },
                     "metadata": {
-                        "title": "Μεταδεδομένα",
-                        "description": "Επιπλέον προτιμήσεις ή δεδομένα εγγραφής"
+                        "description": "Additional subscription preferences or data"
                     }
                 },
                 "required": [
@@ -64116,17 +63656,15 @@
                         "type": "string",
                         "format": "email",
                         "minLength": 1,
-                        "title": "Διεύθυνση Email",
+                        "title": "Διεύθυνση ηλεκτρονικού ταχυδρομείου",
                         "maxLength": 254
                     },
                     "firstName": {
                         "type": "string",
-                        "title": "Όνομα",
                         "maxLength": 255
                     },
                     "lastName": {
                         "type": "string",
-                        "title": "Επώνυμο",
                         "maxLength": 255
                     },
                     "username": {
@@ -64157,45 +63695,41 @@
                     },
                     "city": {
                         "type": "string",
-                        "title": "Πόλη",
                         "maxLength": 255
                     },
                     "zipcode": {
                         "type": "string",
-                        "title": "Ταχ. Κώδικας",
+                        "title": "Zip Code",
                         "maxLength": 255
                     },
                     "address": {
                         "type": "string",
-                        "title": "Διεύθυνση",
                         "maxLength": 255
                     },
                     "place": {
                         "type": "string",
-                        "title": "Τόπος",
                         "maxLength": 255
                     },
                     "country": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός Χώρας (Alpha 2)",
+                        "title": "Country Code Alpha 2",
                         "nullable": true
                     },
                     "region": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Κωδικός περιφέρειας",
+                        "title": "Region Code",
                         "nullable": true
                     },
                     "birthDate": {
                         "type": "string",
                         "format": "date",
-                        "nullable": true,
-                        "title": "Ημ/νία γέννησης"
+                        "nullable": true
                     },
                     "twitter": {
                         "nullable": true,
-                        "title": "Προφίλ Twitter",
+                        "title": "Twitter Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64210,7 +63744,7 @@
                     },
                     "linkedin": {
                         "nullable": true,
-                        "title": "Προφίλ LinkedIn",
+                        "title": "LinkedIn Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64225,7 +63759,7 @@
                     },
                     "facebook": {
                         "nullable": true,
-                        "title": "Προφίλ Facebook",
+                        "title": "Facebook Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64240,7 +63774,7 @@
                     },
                     "instagram": {
                         "nullable": true,
-                        "title": "Προφίλ Instagram",
+                        "title": "Instagram Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64255,7 +63789,6 @@
                     },
                     "website": {
                         "nullable": true,
-                        "title": "Ιστότοπος",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64270,7 +63803,7 @@
                     },
                     "youtube": {
                         "nullable": true,
-                        "title": "Προφίλ Youtube",
+                        "title": "Youtube Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64285,7 +63818,7 @@
                     },
                     "github": {
                         "nullable": true,
-                        "title": "Προφίλ Github",
+                        "title": "Github Profile",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -64299,14 +63832,13 @@
                         ]
                     },
                     "bio": {
-                        "type": "string",
-                        "title": "Βιογραφικό"
+                        "type": "string"
                     },
                     "languageCode": {
                         "type": "string",
                         "minLength": 1,
-                        "title": "Γλώσσα",
-                        "description": "Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.",
+                        "title": "Language",
+                        "description": "Preferred language for emails and UI messages.",
                         "maxLength": 10
                     }
                 },
@@ -64320,7 +63852,7 @@
                     "username": {
                         "type": "string",
                         "minLength": 1,
-                        "description": "Νέο όνομα χρήστη",
+                        "description": "New username",
                         "maxLength": 150
                     }
                 },
@@ -64333,7 +63865,7 @@
                 "properties": {
                     "detail": {
                         "type": "string",
-                        "description": "Μήνυμα επιτυχίας για ενημέρωση ονόματος χρήστη"
+                        "description": "Success message for username update"
                     }
                 },
                 "required": [

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -67,14 +67,14 @@ paths:
   /api/v1/blog/author:
     get:
       operationId: listBlogAuthor
-      description: 'Ανάκτηση λίστας Συντάκτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Συντάκτες Blog
+      description: 'Retrieve a list of Blog Authors with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Authors
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -84,7 +84,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -108,7 +108,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -117,7 +117,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -127,7 +127,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -178,8 +178,8 @@ paths:
           description: ''
     post:
       operationId: createBlogAuthor
-      description: Δημιουργία νέου Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Συντάκτης Blog
+      description: Create a new Blog Author. Requires authentication.
+      summary: Create a Blog Author
       parameters:
         - in: query
           name: languageCode
@@ -190,7 +190,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -247,8 +247,8 @@ paths:
   /api/v1/blog/author/{id}:
     get:
       operationId: retrieveBlogAuthor
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συντάκτης Blog.
-      summary: Ανάκτηση Συντάκτης Blog
+      description: Get detailed information about a specific Blog Author.
+      summary: Retrieve a Blog Author
       parameters:
         - in: path
           name: id
@@ -267,7 +267,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       security:
@@ -306,8 +306,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogAuthor
-      description: Ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Συντάκτης Blog
+      description: Update Blog Author information. Requires authentication.
+      summary: Update a Blog Author
       parameters:
         - in: path
           name: id
@@ -326,7 +326,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -382,8 +382,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogAuthor
-      description: Μερική ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Συντάκτης Blog
+      description: Partially update Blog Author information. Requires authentication.
+      summary: Partially update a Blog Author
       parameters:
         - in: path
           name: id
@@ -402,7 +402,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -457,8 +457,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogAuthor
-      description: Διαγραφή Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Συντάκτης Blog
+      description: Delete a Blog Author. Requires authentication.
+      summary: Delete a Blog Author
       parameters:
         - in: path
           name: id
@@ -496,8 +496,8 @@ paths:
   /api/v1/blog/author/{id}/posts:
     get:
       operationId: getBlogAuthorPosts
-      description: Ανάκτηση όλων των άρθρων που έχει γράψει αυτός ο συντάκτης, με σελιδοποίηση.
-      summary: Λήψη άρθρων συντάκτη
+      description: Retrieve all blog posts written by this author with proper pagination.
+      summary: Get author's blog posts
       parameters:
         - in: path
           name: id
@@ -583,8 +583,8 @@ paths:
   /api/v1/blog/category:
     get:
       operationId: listBlogCategory
-      description: 'Ανάκτηση λίστας Κατηγορίες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κατηγορίες Blog
+      description: 'Retrieve a list of Blog Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Categories
       parameters:
         - in: query
           name: languageCode
@@ -595,7 +595,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -619,7 +619,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -628,7 +628,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -638,7 +638,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -689,8 +689,8 @@ paths:
           description: ''
     post:
       operationId: createBlogCategory
-      description: Δημιουργία νέου Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κατηγορία Blog
+      description: Create a new Blog Category. Requires authentication.
+      summary: Create a Blog Category
       parameters:
         - in: query
           name: languageCode
@@ -701,7 +701,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -758,8 +758,8 @@ paths:
   /api/v1/blog/category/{id}:
     get:
       operationId: retrieveBlogCategory
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Blog.
-      summary: Ανάκτηση Κατηγορία Blog
+      description: Get detailed information about a specific Blog Category.
+      summary: Retrieve a Blog Category
       parameters:
         - in: path
           name: id
@@ -778,7 +778,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       security:
@@ -817,8 +817,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogCategory
-      description: Ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κατηγορία Blog
+      description: Update Blog Category information. Requires authentication.
+      summary: Update a Blog Category
       parameters:
         - in: path
           name: id
@@ -837,7 +837,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -893,8 +893,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogCategory
-      description: Μερική ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κατηγορία Blog
+      description: Partially update Blog Category information. Requires authentication.
+      summary: Partially update a Blog Category
       parameters:
         - in: path
           name: id
@@ -913,7 +913,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -968,8 +968,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogCategory
-      description: Διαγραφή Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κατηγορία Blog
+      description: Delete a Blog Category. Requires authentication.
+      summary: Delete a Blog Category
       parameters:
         - in: path
           name: id
@@ -1007,8 +1007,8 @@ paths:
   /api/v1/blog/category/{id}/ancestors:
     get:
       operationId: listBlogCategoryAncestors
-      description: Λήψη όλων των προγόνων (γονέας, παππούς κ.λπ.) αυτής της κατηγορίας.
-      summary: Λήψη προγόνων κατηγορίας
+      description: Get all ancestors (parent, grandparent, etc.) of this category.
+      summary: Get category ancestors
       parameters:
         - in: path
           name: id
@@ -1094,8 +1094,8 @@ paths:
   /api/v1/blog/category/{id}/children:
     get:
       operationId: listBlogCategoryChildren
-      description: Λήψη άμεσων θυγατρικών κατηγοριών αυτής της κατηγορίας.
-      summary: Λήψη θυγατρικών κατηγοριών
+      description: Get direct children of this category.
+      summary: Get category children
       parameters:
         - in: path
           name: id
@@ -1181,8 +1181,8 @@ paths:
   /api/v1/blog/category/{id}/descendants:
     get:
       operationId: listBlogCategoryDescendants
-      description: Λήψη όλων των απογόνων (θυγατρικές, εγγόνια κ.λπ.) αυτής της κατηγορίας.
-      summary: Λήψη απογόνων κατηγορίας
+      description: Get all descendants (children, grandchildren, etc.) of this category.
+      summary: Get category descendants
       parameters:
         - in: path
           name: id
@@ -1268,8 +1268,8 @@ paths:
   /api/v1/blog/category/{id}/posts:
     get:
       operationId: listBlogCategoryPosts
-      description: Ανάκτηση όλων των άρθρων σε αυτή την κατηγορία και τις υποκατηγορίες της. Χρησιμοποιήστε 'recursive=true' για να συμπεριληφθούν άρθρα από όλες τις κατηγορίες-απογόνους.
-      summary: Λήψη άρθρων κατηγορίας
+      description: Retrieve all blog posts in this category and its subcategories. Use 'recursive=true' to include posts from all descendant categories.
+      summary: Get category's blog posts
       parameters:
         - in: path
           name: id
@@ -1367,8 +1367,8 @@ paths:
   /api/v1/blog/category/{id}/siblings:
     get:
       operationId: listBlogCategorySiblings
-      description: Λήψη κατηγοριών-αδερφών (ίδιο επίπεδο γονέα).
-      summary: Λήψη αδερφών κατηγοριών
+      description: Get sibling categories (same parent level).
+      summary: Get category siblings
       parameters:
         - in: path
           name: id
@@ -1454,8 +1454,8 @@ paths:
   /api/v1/blog/category/reorder:
     post:
       operationId: reorderBlogCategories
-      description: Μαζική αναδιάταξη κατηγοριών με ενημέρωση των τιμών sort_order.
-      summary: Αναδιάταξη κατηγοριών
+      description: Batch reorder categories by updating their sort_order values.
+      summary: Reorder categories
       tags:
         - Blog Categories
       requestBody:
@@ -1512,8 +1512,8 @@ paths:
   /api/v1/blog/category/tree:
     get:
       operationId: getBlogCategoryTree
-      description: Λήψη της πλήρους δενδρικής δομής κατηγοριών με ένθετες σχέσεις. Είναι πιο αποδοτικό από τη χρήση list?tree=true για την εμφάνιση μενού πλοήγησης ή ιεραρχιών κατηγοριών.
-      summary: Λήψη πλήρους δέντρου κατηγοριών
+      description: Get the complete category tree structure with nested relationships. This is more efficient than using list?tree=true for displaying navigation menus or category hierarchies.
+      summary: Get complete category tree
       parameters:
         - name: ordering
           in: query
@@ -1591,8 +1591,8 @@ paths:
   /api/v1/blog/comment:
     get:
       operationId: listBlogComment
-      description: 'Ανάκτηση λίστας Σχόλια Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Σχόλια Blog
+      description: 'Retrieve a list of Blog Comments with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Comments
       parameters:
         - in: query
           name: ancestorOf
@@ -1601,7 +1601,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -1613,12 +1613,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -1626,7 +1626,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -1658,7 +1658,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: descendantOf
           schema:
@@ -1666,7 +1666,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -1678,7 +1678,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -1690,7 +1690,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -1702,7 +1702,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: query
           name: id
           schema:
@@ -1715,7 +1715,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -1733,7 +1733,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -1745,7 +1745,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: languageCode
           schema:
@@ -1755,7 +1755,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: level
           schema:
@@ -1763,7 +1763,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -1771,7 +1771,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -1779,7 +1779,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -1787,7 +1787,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -1809,7 +1809,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -1817,7 +1817,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -1825,7 +1825,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -1833,7 +1833,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -1841,7 +1841,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -1849,7 +1849,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -1857,7 +1857,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -1869,7 +1869,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -1881,7 +1881,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -1905,7 +1905,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -1914,7 +1914,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -1924,7 +1924,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: parent
           schema:
@@ -1932,7 +1932,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -1944,7 +1944,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -1952,7 +1952,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -1960,7 +1960,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -1968,12 +1968,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -1985,17 +1985,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -2003,7 +2003,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -2031,7 +2031,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -2066,12 +2066,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -2083,7 +2083,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -2095,7 +2095,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -2144,8 +2144,8 @@ paths:
           description: ''
     post:
       operationId: createBlogComment
-      description: Δημιουργία νέου Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Σχόλιο Blog
+      description: Create a new Blog Comment. Requires authentication.
+      summary: Create a Blog Comment
       parameters:
         - in: query
           name: languageCode
@@ -2156,7 +2156,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2213,8 +2213,8 @@ paths:
   /api/v1/blog/comment/{id}:
     get:
       operationId: retrieveBlogComment
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχόλιο Blog.
-      summary: Ανάκτηση Σχόλιο Blog
+      description: Get detailed information about a specific Blog Comment.
+      summary: Retrieve a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2233,7 +2233,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       security:
@@ -2271,8 +2271,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogComment
-      description: Ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Σχόλιο Blog
+      description: Update Blog Comment information. Requires authentication.
+      summary: Update a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2291,7 +2291,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2347,8 +2347,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogComment
-      description: Μερική ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Σχόλιο Blog
+      description: Partially update Blog Comment information. Requires authentication.
+      summary: Partially update a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2367,7 +2367,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2422,8 +2422,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogComment
-      description: Διαγραφή Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Σχόλιο Blog
+      description: Delete a Blog Comment. Requires authentication.
+      summary: Delete a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2461,8 +2461,8 @@ paths:
   /api/v1/blog/comment/{id}/post:
     get:
       operationId: getBlogCommentPost
-      description: Λήψη του άρθρου στο οποίο ανήκει αυτό το σχόλιο.
-      summary: Λήψη άρθρου σχολίου
+      description: Get the blog post that this comment belongs to.
+      summary: Get comment's blog post
       parameters:
         - in: path
           name: id
@@ -2516,8 +2516,8 @@ paths:
   /api/v1/blog/comment/{id}/replies:
     get:
       operationId: listBlogCommentReplies
-      description: Λήψη όλων των απαντήσεων (θυγατρικά) αυτού του σχολίου σε δομή νήματος.
-      summary: Λήψη απαντήσεων σχολίου
+      description: Get all replies (children) of this comment in threaded structure.
+      summary: Get comment replies
       parameters:
         - in: query
           name: ancestorOf
@@ -2526,7 +2526,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -2538,12 +2538,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -2551,7 +2551,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -2586,7 +2586,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -2598,7 +2598,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -2610,7 +2610,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -2622,7 +2622,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: path
           name: id
           schema:
@@ -2643,7 +2643,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -2661,7 +2661,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -2673,7 +2673,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -2681,7 +2681,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -2689,7 +2689,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -2697,7 +2697,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -2705,7 +2705,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -2727,7 +2727,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -2735,7 +2735,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -2743,7 +2743,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -2751,7 +2751,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -2759,7 +2759,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -2767,7 +2767,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -2775,7 +2775,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -2787,7 +2787,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -2799,7 +2799,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -2832,7 +2832,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -2844,7 +2844,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -2852,7 +2852,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -2860,7 +2860,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -2868,12 +2868,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -2885,17 +2885,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -2903,7 +2903,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -2931,7 +2931,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -2966,12 +2966,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -2983,7 +2983,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -2995,7 +2995,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -3045,8 +3045,8 @@ paths:
   /api/v1/blog/comment/{id}/thread:
     get:
       operationId: getBlogCommentThread
-      description: Λήψη ολόκληρου του νήματος (όλοι οι πρόγονοι και απόγονοι) αυτού του σχολίου.
-      summary: Λήψη νήματος σχολίων
+      description: Get the complete thread (all ancestors and descendants) of this comment.
+      summary: Get comment thread
       parameters:
         - in: query
           name: ancestorOf
@@ -3055,7 +3055,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -3067,12 +3067,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -3080,7 +3080,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -3115,7 +3115,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -3127,7 +3127,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -3139,7 +3139,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -3151,7 +3151,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: path
           name: id
           schema:
@@ -3172,7 +3172,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -3190,7 +3190,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -3202,7 +3202,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -3210,7 +3210,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -3218,7 +3218,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -3226,7 +3226,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -3234,7 +3234,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -3256,7 +3256,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -3264,7 +3264,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -3272,7 +3272,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -3280,7 +3280,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -3288,7 +3288,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -3296,7 +3296,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -3304,7 +3304,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -3316,7 +3316,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -3328,7 +3328,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -3361,7 +3361,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -3373,7 +3373,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -3381,7 +3381,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -3389,7 +3389,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -3397,12 +3397,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -3414,17 +3414,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -3432,7 +3432,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -3460,7 +3460,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -3495,12 +3495,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -3512,7 +3512,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -3524,7 +3524,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -3574,8 +3574,8 @@ paths:
   /api/v1/blog/comment/{id}/update_likes:
     post:
       operationId: toggleBlogCommentLike
-      description: Επισήμανση ή αναίρεση επισήμανσης σχολίου. Εναλλάσσει την κατάσταση επισήμανσης.
-      summary: Εναλλαγή επισήμανσης σχολίου
+      description: Like or unlike a comment. Toggles the like status.
+      summary: Toggle comment like
       parameters:
         - in: path
           name: id
@@ -3629,8 +3629,8 @@ paths:
   /api/v1/blog/comment/liked_comments:
     post:
       operationId: checkBlogCommentLikes
-      description: Έλεγχος ποια σχόλια από μια λίστα έχει επισημάνει ο τρέχων χρήστης.
-      summary: Έλεγχος μαζικής κατάστασης επισήμανσης
+      description: Check which comments from a list are liked by the current user.
+      summary: Check bulk like status
       tags:
         - Blog Comments
       requestBody:
@@ -3687,8 +3687,8 @@ paths:
   /api/v1/blog/comment/my_comments:
     get:
       operationId: listMyBlogComments
-      description: Λήψη όλων των σχολίων που έχει κάνει ο συνδεδεμένος χρήστης.
-      summary: Λήψη σχολίων τρέχοντος χρήστη
+      description: Get all comments made by the currently authenticated user.
+      summary: Get current user's comments
       parameters:
         - in: query
           name: ancestorOf
@@ -3697,7 +3697,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -3709,12 +3709,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -3722,7 +3722,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -3757,7 +3757,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -3769,7 +3769,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -3781,7 +3781,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -3793,7 +3793,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: query
           name: id
           schema:
@@ -3806,7 +3806,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -3824,7 +3824,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -3836,7 +3836,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -3844,7 +3844,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -3852,7 +3852,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -3860,7 +3860,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -3868,7 +3868,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -3890,7 +3890,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -3898,7 +3898,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -3906,7 +3906,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -3914,7 +3914,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -3922,7 +3922,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -3930,7 +3930,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -3938,7 +3938,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -3950,7 +3950,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -3962,7 +3962,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -3995,7 +3995,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -4007,7 +4007,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -4015,7 +4015,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -4023,7 +4023,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -4031,12 +4031,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -4048,17 +4048,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -4066,7 +4066,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -4094,7 +4094,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -4129,12 +4129,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -4146,7 +4146,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -4158,7 +4158,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -4208,8 +4208,8 @@ paths:
   /api/v1/blog/post:
     get:
       operationId: listBlogPost
-      description: 'Ανάκτηση λίστας Άρθρα Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Άρθρα Blog
+      description: 'Retrieve a list of Blog Posts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Posts
       parameters:
         - in: query
           name: author
@@ -4218,17 +4218,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -4236,18 +4236,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -4268,7 +4268,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -4280,12 +4280,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: featured
           schema:
@@ -4297,7 +4297,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -4310,7 +4310,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -4328,7 +4328,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: languageCode
           schema:
@@ -4338,7 +4338,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: minComments
           schema:
@@ -4346,7 +4346,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -4354,7 +4354,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -4362,7 +4362,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -4370,7 +4370,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -4394,7 +4394,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -4403,7 +4403,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -4413,13 +4413,13 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: publishedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -4440,7 +4440,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -4459,30 +4459,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -4503,7 +4503,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -4574,8 +4574,8 @@ paths:
           description: ''
     post:
       operationId: createBlogPost
-      description: Δημιουργία νέου Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Άρθρο Blog
+      description: Create a new Blog Post. Requires authentication.
+      summary: Create a Blog Post
       parameters:
         - in: query
           name: languageCode
@@ -4586,7 +4586,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4643,8 +4643,8 @@ paths:
   /api/v1/blog/post/{id}:
     get:
       operationId: retrieveBlogPost
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Άρθρο Blog.
-      summary: Ανάκτηση Άρθρο Blog
+      description: Get detailed information about a specific Blog Post.
+      summary: Retrieve a Blog Post
       parameters:
         - in: path
           name: id
@@ -4663,7 +4663,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       security:
@@ -4702,8 +4702,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogPost
-      description: Ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Άρθρο Blog
+      description: Update Blog Post information. Requires authentication.
+      summary: Update a Blog Post
       parameters:
         - in: path
           name: id
@@ -4722,7 +4722,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4778,8 +4778,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogPost
-      description: Μερική ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Άρθρο Blog
+      description: Partially update Blog Post information. Requires authentication.
+      summary: Partially update a Blog Post
       parameters:
         - in: path
           name: id
@@ -4798,7 +4798,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4853,8 +4853,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogPost
-      description: Διαγραφή Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Άρθρο Blog
+      description: Delete a Blog Post. Requires authentication.
+      summary: Delete a Blog Post
       parameters:
         - in: path
           name: id
@@ -4892,8 +4892,8 @@ paths:
   /api/v1/blog/post/{id}/comments:
     get:
       operationId: listBlogPostComments
-      description: Λήψη όλων των σχολίων ενός άρθρου.
-      summary: Λήψη σχολίων άρθρου
+      description: Get all comments for a blog post.
+      summary: Get post comments
       parameters:
         - in: path
           name: id
@@ -4996,8 +4996,8 @@ paths:
   /api/v1/blog/post/{id}/related_posts:
     get:
       operationId: listBlogPostRelated
-      description: Λήψη σχετικών άρθρων για ένα άρθρο.
-      summary: Λήψη σχετικών άρθρων
+      description: Get related posts for a blog post.
+      summary: Get related posts
       parameters:
         - in: query
           name: author
@@ -5006,17 +5006,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5024,18 +5024,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5056,7 +5056,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5068,7 +5068,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5080,7 +5080,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5102,7 +5102,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5120,7 +5120,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5128,7 +5128,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5136,7 +5136,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5144,7 +5144,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5152,7 +5152,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -5165,7 +5165,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -5186,7 +5186,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -5205,30 +5205,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -5249,7 +5249,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -5323,8 +5323,8 @@ paths:
   /api/v1/blog/post/{id}/update_likes:
     post:
       operationId: toggleBlogPostLike
-      description: Επισήμανση ή αναίρεση επισήμανσης άρθρου. Εναλλάσσει την κατάσταση επισήμανσης.
-      summary: Εναλλαγή επισήμανσης άρθρου
+      description: Like or unlike a blog post. Toggles the like status.
+      summary: Toggle post like
       parameters:
         - in: path
           name: id
@@ -5379,8 +5379,8 @@ paths:
   /api/v1/blog/post/{id}/update_view_count:
     post:
       operationId: incrementBlogPostViews
-      description: Αύξηση του μετρητή προβολών ενός άρθρου.
-      summary: Αύξηση προβολών άρθρου
+      description: Increment the view count for a blog post.
+      summary: Increment post view count
       parameters:
         - in: path
           name: id
@@ -5435,8 +5435,8 @@ paths:
   /api/v1/blog/post/featured:
     get:
       operationId: listFeaturedBlogPosts
-      description: Λήψη άρθρων που έχουν επισημανθεί ως προτεινόμενα, ταξινομημένα κατά ημερομηνία δημοσίευσης.
-      summary: Λήψη προτεινόμενων άρθρων
+      description: Get posts marked as featured, ordered by publication date.
+      summary: Get featured posts
       parameters:
         - in: query
           name: author
@@ -5445,17 +5445,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5463,18 +5463,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5495,7 +5495,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5507,7 +5507,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5519,7 +5519,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5532,7 +5532,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5550,7 +5550,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5558,7 +5558,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5566,7 +5566,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5574,7 +5574,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5582,7 +5582,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -5613,7 +5613,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -5634,7 +5634,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -5653,30 +5653,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -5697,7 +5697,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -5769,8 +5769,8 @@ paths:
   /api/v1/blog/post/liked_posts:
     post:
       operationId: checkBlogPostLikes
-      description: Λήψη όλων των άρθρων που έχει επισημάνει ο συνδεδεμένος χρήστης.
-      summary: Λήψη άρθρων με επισήμανση
+      description: Get all posts that the authenticated user has liked.
+      summary: Get liked posts
       tags:
         - Blog Posts
       requestBody:
@@ -5828,8 +5828,8 @@ paths:
   /api/v1/blog/post/popular:
     get:
       operationId: listPopularBlogPosts
-      description: Λήψη των πιο δημοφιλών άρθρων βάσει δεικτών αλληλεπίδρασης όλων των εποχών.
-      summary: Λήψη δημοφιλών άρθρων
+      description: Get most popular blog posts based on all-time engagement metrics.
+      summary: Get popular posts
       parameters:
         - in: query
           name: author
@@ -5838,17 +5838,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5856,18 +5856,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5888,7 +5888,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5900,7 +5900,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5912,7 +5912,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5925,7 +5925,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5943,7 +5943,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5951,7 +5951,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5959,7 +5959,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5967,7 +5967,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5975,7 +5975,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -6006,7 +6006,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -6027,7 +6027,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -6046,30 +6046,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -6090,7 +6090,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -6162,8 +6162,8 @@ paths:
   /api/v1/blog/post/trending:
     get:
       operationId: listTrendingBlogPosts
-      description: Λήψη δημοφιλών άρθρων βάσει πρόσφατων δεικτών αλληλεπίδρασης. Συνδυάζει προβολές, επισημάνσεις και σχόλια πρόσφατης περιόδου.
-      summary: Λήψη trending άρθρων
+      description: Get trending blog posts based on recent engagement metrics. Combines views, likes, and comments from recent time period.
+      summary: Get trending posts
       parameters:
         - in: query
           name: author
@@ -6172,17 +6172,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -6190,18 +6190,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -6222,7 +6222,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -6234,7 +6234,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: days
           schema:
@@ -6254,7 +6254,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -6267,7 +6267,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -6285,7 +6285,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -6293,7 +6293,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -6301,7 +6301,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -6309,7 +6309,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -6317,7 +6317,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -6348,7 +6348,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -6369,7 +6369,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -6388,30 +6388,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -6432,7 +6432,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -6504,8 +6504,8 @@ paths:
   /api/v1/blog/tag:
     get:
       operationId: listBlogTag
-      description: 'Ανάκτηση λίστας Ετικέτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ετικέτες Blog
+      description: 'Retrieve a list of Blog Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Tags
       parameters:
         - in: query
           name: active
@@ -6518,7 +6518,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: createdAfter
           schema:
@@ -6550,7 +6550,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasLikedPosts
           schema:
@@ -6562,7 +6562,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα με/χωρίς επισημάνσεις
+          description: Filter tags used in posts that have/don't have likes
         - in: query
           name: hasName
           schema:
@@ -6574,7 +6574,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς όνομα
+          description: Filter tags that have/don't have a name
         - in: query
           name: hasPosts
           schema:
@@ -6586,7 +6586,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς άρθρα
+          description: Filter tags that have/don't have posts
         - in: query
           name: id
           schema:
@@ -6599,7 +6599,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -6615,7 +6615,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxPosts
           schema:
@@ -6623,7 +6623,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με έως X άρθρα
+          description: Filter tags with at most X posts
         - in: query
           name: minPosts
           schema:
@@ -6631,7 +6631,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με τουλάχιστον X άρθρα
+          description: Filter tags with at least X posts
         - in: query
           name: minTotalLikes
           schema:
@@ -6639,7 +6639,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με άρθρα που έχουν τουλάχιστον X συνολικές επισημάνσεις
+          description: Filter tags with posts having at least X total likes
         - in: query
           name: mostLiked
           schema:
@@ -6651,7 +6651,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά συνολικές επισημάνσεις στα άρθρα που τις χρησιμοποιούν
+          description: Order tags by total likes on posts using them
         - in: query
           name: mostUsed
           schema:
@@ -6663,22 +6663,22 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+          description: Order tags by usage count (most used first)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα ετικέτας (μερική αντιστοίχιση)
+          description: Filter by tag name (partial match)
         - in: query
           name: name_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές όνομα ετικέτας
+          description: Filter by exact tag name
         - in: query
           name: name_Startswith
           schema:
             type: string
-          description: Φίλτρο ετικετών με όνομα που ξεκινά με
+          description: Filter tags with names starting with
         - name: ordering
           in: query
           required: false
@@ -6702,7 +6702,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -6711,7 +6711,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -6721,7 +6721,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: post
           schema:
@@ -6729,7 +6729,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται από συγκεκριμένο άρθρο
+          description: Filter tags used by specific post ID
         - in: query
           name: post_Author
           schema:
@@ -6737,7 +6737,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένου συντάκτη
+          description: Filter tags used in posts by specific author
         - in: query
           name: post_Category
           schema:
@@ -6745,7 +6745,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένης κατηγορίας
+          description: Filter tags used in posts from specific category
         - in: query
           name: post_IsPublished
           schema:
@@ -6757,7 +6757,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε δημοσιευμένα/μη δημοσιευμένα άρθρα
+          description: Filter tags used in published/unpublished posts
         - name: search
           required: false
           in: query
@@ -6808,7 +6808,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που δεν χρησιμοποιούνται σε κανένα άρθρο
+          description: Filter tags not used in any posts
         - in: query
           name: updatedAfter
           schema:
@@ -6885,8 +6885,8 @@ paths:
           description: ''
     post:
       operationId: createBlogTag
-      description: Δημιουργία νέου Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ετικέτα Blog
+      description: Create a new Blog Tag. Requires authentication.
+      summary: Create a Blog Tag
       parameters:
         - in: query
           name: languageCode
@@ -6897,7 +6897,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -6954,8 +6954,8 @@ paths:
   /api/v1/blog/tag/{id}:
     get:
       operationId: retrieveBlogTag
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα Blog.
-      summary: Ανάκτηση Ετικέτα Blog
+      description: Get detailed information about a specific Blog Tag.
+      summary: Retrieve a Blog Tag
       parameters:
         - in: path
           name: id
@@ -6974,7 +6974,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       security:
@@ -7013,8 +7013,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogTag
-      description: Ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Ετικέτα Blog
+      description: Update Blog Tag information. Requires authentication.
+      summary: Update a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7033,7 +7033,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -7089,8 +7089,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogTag
-      description: Μερική ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Ετικέτα Blog
+      description: Partially update Blog Tag information. Requires authentication.
+      summary: Partially update a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7109,7 +7109,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -7164,8 +7164,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogTag
-      description: Διαγραφή Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ετικέτα Blog
+      description: Delete a Blog Tag. Requires authentication.
+      summary: Delete a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7203,8 +7203,8 @@ paths:
   /api/v1/cart:
     get:
       operationId: retrieveCart
-      description: Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λήψη καλαθιού
+      description: Get a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Get cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7250,8 +7250,8 @@ paths:
           description: ''
     put:
       operationId: updateCart
-      description: Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση καλαθιού
+      description: Update a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7303,8 +7303,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCart
-      description: Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση καλαθιού
+      description: Update a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7356,8 +7356,8 @@ paths:
           description: ''
     delete:
       operationId: destroyCart
-      description: Διαγραφή καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Διαγραφή καλαθιού
+      description: Delete a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Delete cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7392,8 +7392,8 @@ paths:
   /api/v1/cart/create-payment-intent:
     post:
       operationId: createCartPaymentIntent
-      description: Δημιουργία Stripe payment intent βάσει του συνόλου του καλαθιού πριν τη δημιουργία παραγγελίας. Απαιτείται για μεθόδους online πληρωμής (Stripe) στη ροή πληρωμής πριν την παραγγελία. Επιστρέφει client_secret για επιβεβαίωση πληρωμής στο frontend και payment_intent_id προς συμπερίληψη στο αίτημα δημιουργίας παραγγελίας.
-      summary: Δημιουργία payment intent από καλάθι
+      description: Create a Stripe payment intent based on cart total before order creation. This is required for online payment methods (Stripe) in the payment-first flow. Returns client_secret for frontend payment confirmation and payment_intent_id to be included in order creation request.
+      summary: Create payment intent from cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7458,8 +7458,8 @@ paths:
   /api/v1/cart/item:
     get:
       operationId: listCartItem
-      description: Ανάκτηση λίστας ειδών καλαθιού με δυνατότητες φιλτραρίσματος και αναζήτησης. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λίστα αντικειμένων καλαθιού
+      description: Retrieve a list of cart items with filtering and search capabilities. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: List cart items
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7474,7 +7474,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID καλαθιού
+          description: Filter by cart ID
         - in: query
           name: cart_IsGuest
           schema:
@@ -7486,7 +7486,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων σε καλάθια επισκεπτών
+          description: Filter items in guest carts
         - in: query
           name: cart_User
           schema:
@@ -7494,35 +7494,35 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη καλαθιού
+          description: Filter by cart user ID
         - in: query
           name: cart_User_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη καλαθιού (μερική αντιστοίχιση)
+          description: Filter by cart user email (partial match)
         - in: query
           name: cart_User_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη καλαθιού (όνομα ή επώνυμο)
+          description: Filter by cart user name (first or last)
         - in: query
           name: cart_Uuid
           schema:
             type: string
             format: uuid
-          description: Φίλτρο ανά UUID καλαθιού
+          description: Filter by cart UUID
         - in: query
           name: cartLastActivityAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά τελευταία δραστηριότητα καλαθιού μετά από ημερομηνία
+          description: Filter by cart last activity after date
         - in: query
           name: cartLastActivityBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά τελευταία δραστηριότητα καλαθιού πριν από ημερομηνία
+          description: Filter by cart last activity before date
         - in: query
           name: createdAfter
           schema:
@@ -7554,7 +7554,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -7567,7 +7567,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -7585,7 +7585,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών σε εγκαταλελειμμένα καλάθια (30+ ημέρες)
+          description: Filter items in abandoned carts (30+ days)
         - in: query
           name: inActiveCarts
           schema:
@@ -7597,7 +7597,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών σε ενεργά καλάθια (24ωρο)
+          description: Filter items in active carts (24hr)
         - in: query
           name: languageCode
           schema:
@@ -7607,7 +7607,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxDiscountPercent
           schema:
@@ -7615,7 +7615,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο ποσοστό έκπτωσης
+          description: Filter by maximum discount percentage
         - in: query
           name: maxPrice
           schema:
@@ -7623,7 +7623,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη τιμή προϊόντος
+          description: Filter by maximum product price
         - in: query
           name: maxQuantity
           schema:
@@ -7631,7 +7631,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα
+          description: Filter by maximum quantity
         - in: query
           name: maxTotalPrice
           schema:
@@ -7639,7 +7639,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη συνολική τιμή (ποσότητα * τιμή)
+          description: Filter by maximum total price (quantity * price)
         - in: query
           name: minDiscountPercent
           schema:
@@ -7647,7 +7647,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο ποσοστό έκπτωσης
+          description: Filter by minimum discount percentage
         - in: query
           name: minPrice
           schema:
@@ -7655,7 +7655,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη τιμή προϊόντος
+          description: Filter by minimum product price
         - in: query
           name: minQuantity
           schema:
@@ -7663,7 +7663,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα
+          description: Filter by minimum quantity
         - in: query
           name: minTotalPrice
           schema:
@@ -7671,7 +7671,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη συνολική τιμή (ποσότητα * τιμή)
+          description: Filter by minimum total price (quantity * price)
         - name: ordering
           in: query
           required: false
@@ -7695,7 +7695,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -7704,7 +7704,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -7714,7 +7714,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -7722,7 +7722,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: product_Active
           schema:
@@ -7734,7 +7734,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: product_Category
           schema:
@@ -7742,28 +7742,28 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: product_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας προϊόντος
+          description: Filter by product category slug
         - in: query
           name: product_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+          description: Filter by product name (partial match)
         - in: query
           name: product_Sku
           schema:
             type: string
-          description: Φίλτρο ανά sku προϊόντος (ακριβής αντιστοίχιση)
+          description: Filter by product sku (exact match)
         - in: query
           name: product_Uuid
           schema:
             type: string
             format: uuid
-          description: Φίλτρο ανά UUID προϊόντος
+          description: Filter by product UUID
         - in: query
           name: quantity
           schema:
@@ -7771,7 +7771,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ποσότητα
+          description: Filter by exact quantity
         - in: query
           name: quantity_Gte
           schema:
@@ -7835,7 +7835,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με εκπτώσεις προϊόντος
+          description: Filter items with product discounts
       tags:
         - Cart Items
       security:
@@ -7880,8 +7880,8 @@ paths:
           description: ''
     post:
       operationId: createCartItem
-      description: Δημιουργία νέου είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Δημιουργία αντικειμένου καλαθιού
+      description: Create a new cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Create a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7946,8 +7946,8 @@ paths:
   /api/v1/cart/item/{id}:
     get:
       operationId: retrieveCartItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο είδος καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ανάκτηση είδους καλαθιού
+      description: Get detailed information about a specific cart item. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Retrieve a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7972,7 +7972,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Cart Items
       security:
@@ -8011,8 +8011,8 @@ paths:
           description: ''
     put:
       operationId: updateCartItem
-      description: Ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση αντικειμένου καλαθιού
+      description: Update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8083,8 +8083,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCartItem
-      description: Μερική ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Μερική ενημέρωση είδους καλαθιού
+      description: Partially update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Partially update a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8109,7 +8109,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Cart Items
       requestBody:
@@ -8165,8 +8165,8 @@ paths:
           description: ''
     delete:
       operationId: destroyCartItem
-      description: Διαγραφή είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Διαγραφή αντικειμένου καλαθιού
+      description: Delete a cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Delete a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8209,8 +8209,8 @@ paths:
   /api/v1/cart/list:
     get:
       operationId: listCart
-      description: Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λήψη καλαθιού
+      description: Get a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Get cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8227,7 +8227,7 @@ paths:
               - guest
               - user
           description: |-
-            Φίλτρο ανά τύπο καλαθιού
+            Filter by cart type
 
             * `user` - User Cart
             * `guest` - Guest Cart
@@ -8263,7 +8263,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: daysInactive
           schema:
@@ -8271,7 +8271,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών αδρανών για τουλάχιστον X ημέρες
+          description: Filter carts inactive for at least X days
         - in: query
           name: hasDiscounts
           schema:
@@ -8283,7 +8283,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς είδη σε έκπτωση
+          description: Filter carts with/without discounted items
         - in: query
           name: hasItems
           schema:
@@ -8295,7 +8295,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς είδη
+          description: Filter carts that have/don't have items
         - in: query
           name: id
           schema:
@@ -8308,7 +8308,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -8326,7 +8326,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο εγκαταλελειμμένων καλαθιών (αδρανή για 30+ ημέρες)
+          description: Filter abandoned carts (inactive for 30+ days)
         - in: query
           name: isActive
           schema:
@@ -8338,7 +8338,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών/εγκαταλελειμμένων καλαθιών (βάσει 30 ημερών αδράνειας)
+          description: Filter active/abandoned carts (based on 30-day inactivity)
         - in: query
           name: isGuest
           schema:
@@ -8350,7 +8350,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών επισκεπτών (True) ή καλαθιών χρηστών (False)
+          description: Filter guest carts (True) or user carts (False)
         - in: query
           name: languageCode
           schema:
@@ -8360,13 +8360,13 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastActivity
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά ακριβή ημερομηνία τελευταίας δραστηριότητας
+          description: Filter by exact last activity date
         - in: query
           name: lastActivity_Date
           schema:
@@ -8387,13 +8387,13 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο καλαθιών με τελευταία δραστηριότητα μετά από αυτή την ημερομηνία
+          description: Filter carts with last activity after this date
         - in: query
           name: lastActivityBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο καλαθιών με τελευταία δραστηριότητα πριν από αυτή την ημερομηνία
+          description: Filter carts with last activity before this date
         - in: query
           name: maxItems
           schema:
@@ -8401,7 +8401,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με έως X συνολικά είδη (ποσότητα)
+          description: Filter carts with at most X total items (quantity)
         - in: query
           name: maxTotalValue
           schema:
@@ -8409,7 +8409,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με συνολική αξία έως X
+          description: Filter carts with total value at most X
         - in: query
           name: maxUniqueItems
           schema:
@@ -8417,7 +8417,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με έως X μοναδικά είδη
+          description: Filter carts with at most X unique items
         - in: query
           name: minItems
           schema:
@@ -8425,7 +8425,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με τουλάχιστον X συνολικά είδη (ποσότητα)
+          description: Filter carts with at least X total items (quantity)
         - in: query
           name: minTotalValue
           schema:
@@ -8433,7 +8433,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με συνολική αξία τουλάχιστον X
+          description: Filter carts with total value at least X
         - in: query
           name: minUniqueItems
           schema:
@@ -8441,7 +8441,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με τουλάχιστον X μοναδικά είδη
+          description: Filter carts with at least X unique items
         - name: ordering
           in: query
           required: false
@@ -8465,7 +8465,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -8474,7 +8474,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -8484,7 +8484,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -8525,7 +8525,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_IsActive
           schema:
@@ -8537,7 +8537,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργούς χρήστες
+          description: Filter by active users
         - in: query
           name: user_Isnull
           schema:
@@ -8549,17 +8549,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς χρήστες
+          description: Filter carts with/without users
         - in: query
           name: userEmail
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+          description: Filter by user email (partial match)
         - in: query
           name: userName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα χρήστη (όνομα ή επώνυμο)
+          description: Filter by user full name (first or last name)
         - in: query
           name: uuid
           schema:
@@ -8609,8 +8609,8 @@ paths:
   /api/v1/cart/release-reservations:
     post:
       operationId: releaseCartReservations
-      description: Απελευθέρωση δεσμεύσεων αποθέματος όταν το checkout εγκαταλείπεται ή η πληρωμή αποτυγχάνει. Αυτό καθιστά το δεσμευμένο απόθεμα διαθέσιμο για άλλους πελάτες.
-      summary: Αποδέσμευση δεσμεύσεων αποθέματος
+      description: Release stock reservations when checkout is abandoned or payment fails. This makes the reserved stock available for other customers.
+      summary: Release stock reservations
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8675,8 +8675,8 @@ paths:
   /api/v1/cart/reserve-stock:
     post:
       operationId: reserveCartStock
-      description: Δέσμευση αποθέματος για όλα τα είδη του καλαθιού κατά το checkout. Δημιουργεί προσωρινές δεσμεύσεις αποθέματος με διάρκεια ζωής 15 λεπτών. Επιστρέφει λίστα ID δεσμεύσεων για χρήση κατά τη δημιουργία της παραγγελίας.
-      summary: Δέσμευση αποθέματος για αντικείμενα καλαθιού
+      description: Reserve stock for all items in the cart during checkout. Creates temporary stock reservations with 15-minute TTL. Returns list of reservation IDs to be used during order creation.
+      summary: Reserve stock for cart items
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8729,8 +8729,8 @@ paths:
   /api/v1/contact:
     post:
       operationId: createContact
-      description: Αποστολή μηνύματος επικοινωνίας στους διαχειριστές του ιστότοπου.
-      summary: Δημιουργία μηνύματος επικοινωνίας
+      description: Send a contact message to the site administrators.
+      summary: Create a contact message
       tags:
         - Contact
       requestBody:
@@ -8764,19 +8764,19 @@ paths:
   /api/v1/country:
     get:
       operationId: listCountry
-      description: 'Ανάκτηση λίστας Χώρες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χώρες
+      description: 'Retrieve a list of Countries with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Countries
       parameters:
         - in: query
           name: alpha2
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή διψήφιο κωδικό χώρας
+          description: Filter by exact 2-letter country code
         - in: query
           name: alpha2_Icontains
           schema:
             type: string
-          description: Φίλτρο ανά διψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+          description: Filter by 2-letter country code (partial match)
         - in: query
           name: alpha2_Iexact
           schema:
@@ -8786,7 +8786,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -8797,12 +8797,12 @@ paths:
           name: alpha3
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή τριψήφιο κωδικό χώρας
+          description: Filter by exact 3-letter country code
         - in: query
           name: alpha3_Icontains
           schema:
             type: string
-          description: Φίλτρο ανά τριψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+          description: Filter by 3-letter country code (partial match)
         - in: query
           name: alpha3_Iexact
           schema:
@@ -8812,7 +8812,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -8832,7 +8832,7 @@ paths:
               - OC
               - SA
           description: |-
-            Φίλτρο ανά ήπειρο (βάσει κωδικών ISO)
+            Filter by continent (based on ISO codes)
 
             * `AF` - Africa
             * `AS` - Asia
@@ -8872,7 +8872,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasAllData
           schema:
@@ -8884,7 +8884,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με πλήρη δεδομένα (ISO, κλήση, σημαία, όνομα)
+          description: Filter countries that have complete data (ISO, phone, flag, name)
         - in: query
           name: hasFlagImage
           schema:
@@ -8896,7 +8896,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς εικόνα σημαίας
+          description: Filter countries that have/don't have flag image
         - in: query
           name: hasIsoCc
           schema:
@@ -8908,7 +8908,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς κωδικό ISO
+          description: Filter countries that have/don't have ISO country code
         - in: query
           name: hasName
           schema:
@@ -8920,7 +8920,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς μετάφραση ονόματος
+          description: Filter countries that have/don't have name translation
         - in: query
           name: hasPhoneCode
           schema:
@@ -8932,7 +8932,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς κωδικό κλήσης
+          description: Filter countries that have/don't have phone code
         - in: query
           name: isEu
           schema:
@@ -8944,7 +8944,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών μελών ΕΕ
+          description: Filter EU member countries
         - in: query
           name: isoCc
           schema:
@@ -8952,7 +8952,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ISO κωδικό χώρας
+          description: Filter by exact ISO country code
         - in: query
           name: isoCc_Gte
           schema:
@@ -8965,7 +8965,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -8986,7 +8986,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό ISO μικρότερο ή ίσο με
+          description: Filter countries with ISO code less than or equal to
         - in: query
           name: isoCcMin
           schema:
@@ -8994,7 +8994,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό ISO μεγαλύτερο ή ίσο με
+          description: Filter countries with ISO code greater than or equal to
         - in: query
           name: languageCode
           schema:
@@ -9004,27 +9004,27 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: multipleCodes
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλούς κωδικούς χωρών (διαχωρισμένους με κόμμα, alpha-2 ή alpha-3)
+          description: Filter by multiple country codes (comma-separated, alpha-2 or alpha-3)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: name_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές όνομα χώρας
+          description: Filter by exact country name
         - in: query
           name: name_Startswith
           schema:
             type: string
-          description: Φίλτρο χωρών με όνομα που ξεκινά με
+          description: Filter countries with names starting with
         - name: ordering
           in: query
           required: false
@@ -9048,7 +9048,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -9057,7 +9057,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -9067,7 +9067,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: phoneCode
           schema:
@@ -9075,7 +9075,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή κωδικό κλήσης
+          description: Filter by exact phone code
         - in: query
           name: phoneCode_Gte
           schema:
@@ -9088,7 +9088,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -9109,7 +9109,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό κλήσης μικρότερο ή ίσο με
+          description: Filter countries with phone code less than or equal to
         - in: query
           name: phoneCodeMin
           schema:
@@ -9117,7 +9117,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό κλήσης μεγαλύτερο ή ίσο με
+          description: Filter countries with phone code greater than or equal to
         - name: search
           required: false
           in: query
@@ -9221,8 +9221,8 @@ paths:
           description: ''
     post:
       operationId: createCountry
-      description: Δημιουργία νέου Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Χώρα
+      description: Create a new Country. Requires authentication.
+      summary: Create a Country
       parameters:
         - in: query
           name: languageCode
@@ -9233,7 +9233,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9290,15 +9290,15 @@ paths:
   /api/v1/country/{alpha_2}:
     get:
       operationId: retrieveCountry
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χώρα.
-      summary: Ανάκτηση Χώρα
+      description: Get detailed information about a specific Country.
+      summary: Retrieve a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9309,7 +9309,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       security:
@@ -9348,15 +9348,15 @@ paths:
           description: ''
     put:
       operationId: updateCountry
-      description: Ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Χώρα
+      description: Update Country information. Requires authentication.
+      summary: Update a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9367,7 +9367,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9423,15 +9423,15 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCountry
-      description: Μερική ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Χώρα
+      description: Partially update Country information. Requires authentication.
+      summary: Partially update a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9442,7 +9442,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9497,15 +9497,15 @@ paths:
           description: ''
     delete:
       operationId: destroyCountry
-      description: Διαγραφή Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Χώρα
+      description: Delete a Country. Requires authentication.
+      summary: Delete a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
       tags:
         - Countries
@@ -9535,8 +9535,8 @@ paths:
   /api/v1/health:
     get:
       operationId: api_v1_health_retrieve
-      description: Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery
-      summary: Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery
+      description: Check the health status of database, Redis, and Celery
+      summary: Check the health status of database, Redis, and Celery
       tags:
         - Health
       security:
@@ -9552,8 +9552,8 @@ paths:
   /api/v1/loyalty/product/{id}/points:
     get:
       operationId: getProductLoyaltyPoints
-      description: Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος
-      summary: Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος
+      description: Get product loyalty points preview
+      summary: Get product loyalty points preview
       parameters:
         - in: path
           name: id
@@ -9607,8 +9607,8 @@ paths:
   /api/v1/loyalty/redeem:
     post:
       operationId: redeemLoyaltyPoints
-      description: Εξαργύρωση πόντων πιστότητας
-      summary: Εξαργύρωση πόντων πιστότητας
+      description: Redeem loyalty points
+      summary: Redeem loyalty points
       tags:
         - Loyalty
       requestBody:
@@ -9665,8 +9665,8 @@ paths:
   /api/v1/loyalty/summary:
     get:
       operationId: getLoyaltySummary
-      description: Λήψη σύνοψης πιστότητας
-      summary: Λήψη σύνοψης πιστότητας
+      description: Get loyalty summary
+      summary: Get loyalty summary
       tags:
         - Loyalty
       security:
@@ -9711,8 +9711,8 @@ paths:
   /api/v1/loyalty/tiers:
     get:
       operationId: listLoyaltyTiers
-      description: Λίστα όλων των tier πιστότητας
-      summary: Λίστα όλων των tier πιστότητας
+      description: List all loyalty tiers
+      summary: List all loyalty tiers
       parameters:
         - name: page
           required: false
@@ -9782,8 +9782,8 @@ paths:
   /api/v1/loyalty/transactions:
     get:
       operationId: listLoyaltyTransactions
-      description: Λίστα συναλλαγών πιστότητας
-      summary: Λίστα συναλλαγών πιστότητας
+      description: List loyalty transactions
+      summary: List loyalty transactions
       parameters:
         - name: page
           required: false
@@ -9853,8 +9853,8 @@ paths:
   /api/v1/notification/ids:
     post:
       operationId: getNotificationsByIds
-      description: Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.
-      summary: Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.
+      description: Returns the notifications for a list of ids.
+      summary: Returns the notifications for a list of ids.
       parameters:
         - in: query
           name: seen
@@ -9867,7 +9867,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων κατά κατάσταση προβολής. Αν είναι false, επιστρέφει μόνο τις μη ορατές ειδοποιήσεις.
+          description: Filter notifications by seen status. If false, returns only unseen notifications.
       tags:
         - Notifications
       requestBody:
@@ -9896,8 +9896,8 @@ paths:
   /api/v1/notification/user:
     get:
       operationId: listNotificationUser
-      description: 'Ανάκτηση λίστας Χρήστες ειδοποίησης με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χρήστες ειδοποίησης
+      description: 'Retrieve a list of Notification Users with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Notification Users
       parameters:
         - in: query
           name: createdAfter
@@ -9930,7 +9930,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasSeenAt
           schema:
@@ -9942,7 +9942,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων που έχουν προβληθεί (true) ή όχι (false)
+          description: Filter notifications that have been seen (true) or not seen (false)
         - in: query
           name: highPriority
           schema:
@@ -9954,7 +9954,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων υψηλής προτεραιότητας
+          description: Filter high priority notifications
         - in: query
           name: id
           schema:
@@ -9967,7 +9967,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -9983,7 +9983,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: notification
           schema:
@@ -9991,24 +9991,24 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID ειδοποίησης
+          description: Filter by notification ID
         - in: query
           name: notification_Category
           schema:
             type: string
-          description: Φίλτρο ανά κατηγορία ειδοποίησης
+          description: Filter by notification category
         - in: query
           name: notification_ExpiresAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που λήγουν μετά από αυτή την ημερομηνία
+          description: Filter notifications expiring after this date
         - in: query
           name: notification_ExpiresBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που λήγουν πριν από αυτή την ημερομηνία
+          description: Filter notifications expiring before this date
         - in: query
           name: notification_IsExpired
           schema:
@@ -10020,47 +10020,47 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση λήξης ειδοποίησης
+          description: Filter by notification expiry status
         - in: query
           name: notification_Kind
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης
+          description: Filter by notification kind
         - in: query
           name: notification_Link
           schema:
             type: string
-          description: Φίλτρο ανά σύνδεσμο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification link (case-insensitive)
         - in: query
           name: notification_Message
           schema:
             type: string
-          description: Φίλτρο ανά μήνυμα ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification message (case-insensitive)
         - in: query
           name: notification_Priority
           schema:
             type: string
-          description: Φίλτρο ανά προτεραιότητα ειδοποίησης
+          description: Filter by notification priority
         - in: query
           name: notification_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification title (case-insensitive)
         - in: query
           name: notification_Type
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification type (case-insensitive)
         - in: query
           name: notificationIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID ειδοποιήσεων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple notification IDs (comma-separated)
         - in: query
           name: notificationKind
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης
+          description: Filter by notification kind
         - name: ordering
           in: query
           required: false
@@ -10084,7 +10084,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -10093,7 +10093,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -10103,7 +10103,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: recentNotifications
           schema:
@@ -10115,7 +10115,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων των τελευταίων 7 ημερών
+          description: Filter notifications from the last 7 days
         - name: search
           required: false
           in: query
@@ -10133,13 +10133,13 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προβολής
+          description: Filter by seen status
         - in: query
           name: seenAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που προβλήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter notifications seen after this date
         - in: query
           name: seenAt_Date
           schema:
@@ -10160,7 +10160,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που προβλήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter notifications seen before this date
         - in: query
           name: seenOnly
           schema:
@@ -10172,7 +10172,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μόνο ορατών ειδοποιήσεων
+          description: Filter only seen notifications
         - in: query
           name: unseenOnly
           schema:
@@ -10184,7 +10184,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μόνο μη ορατών ειδοποιήσεων
+          description: Filter only unseen notifications
         - in: query
           name: updatedAfter
           schema:
@@ -10219,17 +10219,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -10241,7 +10241,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_IsStaff
           schema:
@@ -10253,17 +10253,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά staff status χρήστη
+          description: Filter by user staff status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -10313,8 +10313,8 @@ paths:
   /api/v1/notification/user/{id}:
     get:
       operationId: retrieveNotificationUser
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραλήπτης Ειδοποίησης.
-      summary: Ανάκτηση Παραλήπτης Ειδοποίησης
+      description: Get detailed information about a specific Notification User.
+      summary: Retrieve a Notification User
       parameters:
         - in: path
           name: id
@@ -10330,7 +10330,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       security:
@@ -10368,8 +10368,8 @@ paths:
           description: ''
     put:
       operationId: updateNotificationUser
-      description: Ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Παραλήπτης Ειδοποίησης
+      description: Update Notification User information. Requires authentication.
+      summary: Update a Notification User
       parameters:
         - in: path
           name: id
@@ -10385,7 +10385,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       requestBody:
@@ -10440,8 +10440,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateNotificationUser
-      description: Μερική ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Παραλήπτης Ειδοποίησης
+      description: Partially update Notification User information. Requires authentication.
+      summary: Partially update a Notification User
       parameters:
         - in: path
           name: id
@@ -10457,7 +10457,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       requestBody:
@@ -10512,8 +10512,8 @@ paths:
           description: ''
     delete:
       operationId: destroyNotificationUser
-      description: Διαγραφή Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Παραλήπτης Ειδοποίησης
+      description: Delete a Notification User. Requires authentication.
+      summary: Delete a Notification User
       parameters:
         - in: path
           name: id
@@ -10548,8 +10548,8 @@ paths:
   /api/v1/notification/user/mark_all_as_seen:
     post:
       operationId: markAllNotificationUsersAsSeen
-      description: Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως ορατών.
-      summary: Σήμανση όλων ως ορατές
+      description: Mark all of the authenticated user's notifications as seen.
+      summary: Mark all notifications as seen
       tags:
         - Notification Users
       security:
@@ -10594,8 +10594,8 @@ paths:
   /api/v1/notification/user/mark_all_as_unseen:
     post:
       operationId: markAllNotificationUsersAsUnseen
-      description: Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως μη ορατών.
-      summary: Σήμανση όλων ως μη ορατές
+      description: Mark all of the authenticated user's notifications as unseen.
+      summary: Mark all notifications as unseen
       tags:
         - Notification Users
       security:
@@ -10640,8 +10640,8 @@ paths:
   /api/v1/notification/user/mark_as_seen:
     post:
       operationId: markNotificationUsersAsSeen
-      description: Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών για τον συνδεδεμένο χρήστη.
-      summary: Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών
+      description: Mark specific notifications as seen for the authenticated user.
+      summary: Mark specific notifications as seen
       tags:
         - Notification Users
       requestBody:
@@ -10698,8 +10698,8 @@ paths:
   /api/v1/notification/user/mark_as_unseen:
     post:
       operationId: markNotificationUsersAsUnseen
-      description: Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών για τον συνδεδεμένο χρήστη.
-      summary: Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών
+      description: Mark specific notifications as unseen for the authenticated user.
+      summary: Mark specific notifications as unseen
       tags:
         - Notification Users
       requestBody:
@@ -10756,8 +10756,8 @@ paths:
   /api/v1/notification/user/unseen_count:
     get:
       operationId: getNotificationUserUnseenCount
-      description: Λήψη του πλήθους μη ορατών ειδοποιήσεων για τον συνδεδεμένο χρήστη.
-      summary: Λήψη πλήθους μη ορατών ειδοποιήσεων
+      description: Get the count of unseen notifications for the authenticated user.
+      summary: Get unseen notifications count
       tags:
         - Notification Users
       security:
@@ -10802,8 +10802,8 @@ paths:
   /api/v1/order:
     get:
       operationId: listOrder
-      description: 'Ανάκτηση λίστας Παραγγελίες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Παραγγελίες
+      description: 'Retrieve a list of Orders with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Orders
       parameters:
         - in: query
           name: activeOrders
@@ -10816,7 +10816,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+          description: Filter active orders (pending, processing, shipped, delivered)
         - in: query
           name: canBeCanceled
           schema:
@@ -10828,12 +10828,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+          description: Filter orders that can be canceled
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+          description: Filter by city (case-insensitive)
         - in: query
           name: city_Icontains
           schema:
@@ -10842,22 +10842,22 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας
+          description: Filter by country code
         - in: query
           name: country_Alpha2
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: country_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by country name (case-insensitive)
         - in: query
           name: countryIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple country IDs (comma-separated)
         - in: query
           name: createdAfter
           schema:
@@ -10889,7 +10889,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: customerNotes
           schema:
@@ -10902,12 +10902,12 @@ paths:
           name: documentType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο εγγράφου
+          description: Filter by document type
         - in: query
           name: email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer email (case-insensitive)
         - in: query
           name: email_Icontains
           schema:
@@ -10923,12 +10923,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+          description: Filter final orders (completed, canceled, refunded)
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer first name (case-insensitive)
         - in: query
           name: firstName_Icontains
           schema:
@@ -10937,7 +10937,7 @@ paths:
           name: floor
           schema:
             type: string
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: hasCustomerNotes
           schema:
@@ -10949,7 +10949,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+          description: Filter orders that have/don't have customer notes
         - in: query
           name: hasPaymentId
           schema:
@@ -10961,7 +10961,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+          description: Filter orders that have/don't have payment ID
         - in: query
           name: hasStatusUpdatedAt
           schema:
@@ -10973,7 +10973,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+          description: Filter orders that have status update timestamp
         - in: query
           name: hasTracking
           schema:
@@ -10985,7 +10985,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+          description: Filter orders that have/don't have tracking number
         - in: query
           name: hasUser
           schema:
@@ -10997,7 +10997,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς χρήστη
+          description: Filter orders that have/don't have a user
         - in: query
           name: id
           schema:
@@ -11010,7 +11010,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -11028,7 +11028,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ακυρωμένων παραγγελιών
+          description: Filter canceled orders
         - in: query
           name: isCompleted
           schema:
@@ -11040,7 +11040,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ολοκληρωμένων παραγγελιών
+          description: Filter completed orders
         - in: query
           name: isPaid
           schema:
@@ -11052,7 +11052,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+          description: Filter paid/unpaid orders
         - in: query
           name: languageCode
           schema:
@@ -11062,12 +11062,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer last name (case-insensitive)
         - in: query
           name: lastName_Icontains
           schema:
@@ -11076,7 +11076,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας
+          description: Filter by location type
         - in: query
           name: needsProcessing
           schema:
@@ -11088,7 +11088,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+          description: Filter orders that need processing
         - name: ordering
           in: query
           required: false
@@ -11112,7 +11112,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -11121,7 +11121,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -11131,7 +11131,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: paidAmount_Gte
           schema:
@@ -11153,7 +11153,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο πληρωμένο ποσό
+          description: Filter by maximum paid amount
         - in: query
           name: paidAmountMin
           schema:
@@ -11161,7 +11161,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+          description: Filter by minimum paid amount
         - in: query
           name: payWay
           schema:
@@ -11169,7 +11169,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: payWay_IsOnlinePayment
           schema:
@@ -11181,17 +11181,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά online μεθόδους πληρωμής
+          description: Filter by online payment methods
         - in: query
           name: payWay_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by payment method name (case-insensitive)
         - in: query
           name: paymentId
           schema:
             type: string
-          description: Φίλτρο ανά ID πληρωμής
+          description: Filter by payment ID
         - in: query
           name: paymentId_Icontains
           schema:
@@ -11200,7 +11200,7 @@ paths:
           name: paymentMethod
           schema:
             type: string
-          description: Φίλτρο ανά μέθοδο πληρωμής
+          description: Filter by payment method
         - in: query
           name: paymentMethod_Icontains
           schema:
@@ -11209,7 +11209,6 @@ paths:
           name: paymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -11219,21 +11218,21 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής
+            Filter by payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: paymentStatus_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -11244,7 +11243,7 @@ paths:
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου
+          description: Filter by phone number
         - in: query
           name: phone_Icontains
           schema:
@@ -11253,7 +11252,7 @@ paths:
           name: place
           schema:
             type: string
-          description: Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by place (case-insensitive)
         - in: query
           name: place_Icontains
           schema:
@@ -11269,17 +11268,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+          description: Filter orders from the last 30 days
         - in: query
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: region_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by region name (case-insensitive)
         - name: search
           required: false
           in: query
@@ -11290,7 +11289,7 @@ paths:
           name: shippingCarrier
           schema:
             type: string
-          description: Φίλτρο ανά εταιρεία μεταφοράς
+          description: Filter by shipping carrier
         - in: query
           name: shippingCarrier_Icontains
           schema:
@@ -11316,7 +11315,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστα έξοδα αποστολής
+          description: Filter by maximum shipping price
         - in: query
           name: shippingPriceMin
           schema:
@@ -11324,12 +11323,11 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστα έξοδα αποστολής
+          description: Filter by minimum shipping price
         - in: query
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -11340,22 +11338,22 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: status_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -11366,13 +11364,13 @@ paths:
           name: statusList
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+          description: Filter by multiple statuses (comma-separated)
         - in: query
           name: statusUpdatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+          description: Filter orders with status updated after this date
         - in: query
           name: statusUpdatedAt_Date
           schema:
@@ -11393,12 +11391,12 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+          description: Filter orders with status updated before this date
         - in: query
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by street (case-insensitive)
         - in: query
           name: street_Icontains
           schema:
@@ -11407,7 +11405,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -11416,7 +11414,7 @@ paths:
           name: trackingNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό παρακολούθησης
+          description: Filter by tracking number
         - in: query
           name: trackingNumber_Icontains
           schema:
@@ -11455,17 +11453,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -11477,17 +11475,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -11497,7 +11495,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά Τ.Κ.
+          description: Filter by zipcode
       tags:
         - Orders
       security:
@@ -11541,8 +11539,8 @@ paths:
           description: ''
     post:
       operationId: createOrder
-      description: Δημιουργία νέου Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Παραγγελία
+      description: Create a new Ταξινόμηση. Requires authentication.
+      summary: Create a Ταξινόμηση
       parameters:
         - in: query
           name: languageCode
@@ -11553,7 +11551,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -11610,8 +11608,8 @@ paths:
   /api/v1/order-items:
     get:
       operationId: listOrderItem
-      description: 'Ανάκτηση λίστας Προϊόντα Παραγγελίας με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Προϊόντα Παραγγελίας
+      description: 'Retrieve a list of Order Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Order Items
       parameters:
         - in: query
           name: bulkItems
@@ -11624,7 +11622,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χονδρικής (ποσότητα > 5)
+          description: Filter bulk items (quantity > 5)
         - in: query
           name: createdAfter
           schema:
@@ -11656,7 +11654,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasNotes
           schema:
@@ -11668,7 +11666,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με/χωρίς σημειώσεις
+          description: Filter items that have/don't have notes
         - in: query
           name: hasRefundedQuantity
           schema:
@@ -11680,7 +11678,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με/χωρίς ποσότητα επιστροφής
+          description: Filter items that have/don't have refunded quantity
         - in: query
           name: highValueItems
           schema:
@@ -11692,7 +11690,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών υψηλής αξίας (τιμή > 100)
+          description: Filter high value items (price > 100)
         - in: query
           name: id
           schema:
@@ -11705,7 +11703,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -11723,7 +11721,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πλήρως επιστραμμένων αντικειμένων
+          description: Filter fully refunded items
         - in: query
           name: isPartiallyRefunded
           schema:
@@ -11735,7 +11733,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μερικώς επιστραμμένων αντικειμένων
+          description: Filter partially refunded items
         - in: query
           name: isRefunded
           schema:
@@ -11747,7 +11745,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση επιστροφής χρημάτων
+          description: Filter by refund status
         - in: query
           name: languageCode
           schema:
@@ -11757,12 +11755,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: notes
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σημειώσεων (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notes content (case-insensitive)
         - in: query
           name: notes_Icontains
           schema:
@@ -11774,32 +11772,31 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID παραγγελίας
+          description: Filter by order ID
         - in: query
           name: order_Country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας παραγγελίας
+          description: Filter by order country code
         - in: query
           name: order_Email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer email (case-insensitive)
         - in: query
           name: order_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer first name (case-insensitive)
         - in: query
           name: order_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer last name (case-insensitive)
         - in: query
           name: order_PaymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -11809,25 +11806,24 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής παραγγελίας
+            Filter by order payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: order_Region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας παραγγελίας
+          description: Filter by order region code
         - in: query
           name: order_Status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -11838,16 +11834,16 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: order_User
           schema:
@@ -11855,22 +11851,22 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη παραγγελίας
+          description: Filter by order user ID
         - in: query
           name: order_User_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order user email (case-insensitive)
         - in: query
           name: orderIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID παραγγελιών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple order IDs (comma-separated)
         - in: query
           name: orderStatuses
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις παραγγελιών (διαχωρισμένες με κόμμα)
+          description: Filter by multiple order statuses (comma-separated)
         - name: ordering
           in: query
           required: false
@@ -11906,7 +11902,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη αρχική ποσότητα
+          description: Filter by maximum original quantity
         - in: query
           name: originalQuantityMin
           schema:
@@ -11914,7 +11910,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη αρχική ποσότητα
+          description: Filter by minimum original quantity
         - name: page
           required: false
           in: query
@@ -11931,7 +11927,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -11940,7 +11936,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -11950,7 +11946,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: price
           schema:
@@ -11979,7 +11975,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβή τιμή
+          description: Filter by exact price
         - in: query
           name: priceMax
           schema:
@@ -11987,7 +11983,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη τιμή
+          description: Filter by maximum price
         - in: query
           name: priceMin
           schema:
@@ -11995,7 +11991,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη τιμή
+          description: Filter by minimum price
         - in: query
           name: product
           schema:
@@ -12003,7 +11999,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: product_Active
           schema:
@@ -12015,7 +12011,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: product_Category
           schema:
@@ -12023,27 +12019,27 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: product_Category_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by product category name (case-insensitive)
         - in: query
           name: product_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by product name (case-insensitive)
         - in: query
           name: product_Sku
           schema:
             type: string
-          description: Φίλτρο ανά SKU προϊόντος
+          description: Filter by product SKU
         - in: query
           name: productIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID προϊόντων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple product IDs (comma-separated)
         - in: query
           name: quantity
           schema:
@@ -12072,7 +12068,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ποσότητα
+          description: Filter by exact quantity
         - in: query
           name: quantityMax
           schema:
@@ -12080,7 +12076,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα
+          description: Filter by maximum quantity
         - in: query
           name: quantityMin
           schema:
@@ -12088,7 +12084,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα
+          description: Filter by minimum quantity
         - in: query
           name: recentItems
           schema:
@@ -12100,7 +12096,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών των τελευταίων 7 ημερών
+          description: Filter items from the last 7 days
         - in: query
           name: refundedQuantity
           schema:
@@ -12129,7 +12125,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα επιστροφής
+          description: Filter by maximum refunded quantity
         - in: query
           name: refundedQuantityMin
           schema:
@@ -12137,7 +12133,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα επιστροφής
+          description: Filter by minimum refunded quantity
         - name: search
           required: false
           in: query
@@ -12240,8 +12236,8 @@ paths:
           description: ''
     post:
       operationId: createOrderItem
-      description: Δημιουργία νέου Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Είδος Παραγγελίας
+      description: Create a new Order Item. Requires authentication.
+      summary: Create a Order Item
       parameters:
         - in: query
           name: languageCode
@@ -12252,7 +12248,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12309,8 +12305,8 @@ paths:
   /api/v1/order-items/{id}:
     get:
       operationId: retrieveOrderItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Είδος Παραγγελίας.
-      summary: Ανάκτηση Είδος Παραγγελίας
+      description: Get detailed information about a specific Order Item.
+      summary: Retrieve a Order Item
       parameters:
         - in: path
           name: id
@@ -12329,7 +12325,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       security:
@@ -12367,8 +12363,8 @@ paths:
           description: ''
     put:
       operationId: updateOrderItem
-      description: Ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Είδος Παραγγελίας
+      description: Update Order Item information. Requires authentication.
+      summary: Update a Order Item
       parameters:
         - in: path
           name: id
@@ -12387,7 +12383,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12443,8 +12439,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateOrderItem
-      description: Μερική ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Είδος Παραγγελίας
+      description: Partially update Order Item information. Requires authentication.
+      summary: Partially update a Order Item
       parameters:
         - in: path
           name: id
@@ -12463,7 +12459,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12518,8 +12514,8 @@ paths:
           description: ''
     delete:
       operationId: destroyOrderItem
-      description: Διαγραφή Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Είδος Παραγγελίας
+      description: Delete a Order Item. Requires authentication.
+      summary: Delete a Order Item
       parameters:
         - in: path
           name: id
@@ -12557,8 +12553,8 @@ paths:
   /api/v1/order-items/{id}/refund:
     post:
       operationId: refundOrderItem
-      description: Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας.
-      summary: Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας
+      description: Process a refund for an order item.
+      summary: Process a refund for an order item
       parameters:
         - in: path
           name: id
@@ -12623,8 +12619,8 @@ paths:
   /api/v1/order/{id}:
     get:
       operationId: retrieveOrder
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραγγελία.
-      summary: Ανάκτηση Παραγγελία
+      description: Get detailed information about a specific Ταξινόμηση.
+      summary: Retrieve a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12643,7 +12639,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       security:
@@ -12681,8 +12677,8 @@ paths:
           description: ''
     put:
       operationId: updateOrder
-      description: Ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Παραγγελία
+      description: Update Ταξινόμηση information. Requires authentication.
+      summary: Update a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12701,7 +12697,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -12757,8 +12753,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateOrder
-      description: Μερική ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Παραγγελία
+      description: Partially update Ταξινόμηση information. Requires authentication.
+      summary: Partially update a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12777,7 +12773,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -12832,8 +12828,8 @@ paths:
           description: ''
     delete:
       operationId: destroyOrder
-      description: Διαγραφή Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Παραγγελία
+      description: Delete a Ταξινόμηση. Requires authentication.
+      summary: Delete a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12871,8 +12867,8 @@ paths:
   /api/v1/order/{id}/acs_cancel:
     post:
       operationId: cancelAcsShipmentForOrder
-      description: Μόνο για διαχειριστές. Καλεί το ACS_Delete_Voucher. Έγκυρο μόνο πριν το voucher οριστικοποιηθεί σε λίστα παραλαβής.
-      summary: Ακύρωση της αποστολής ACS για παραγγελία
+      description: Admin-only. Calls ACS_Delete_Voucher. Only valid before the voucher is finalised in a pickup list.
+      summary: Cancel the ACS shipment for an order
       parameters:
         - in: path
           name: id
@@ -12920,8 +12916,8 @@ paths:
   /api/v1/order/{id}/acs_label:
     get:
       operationId: getAcsLabelForOrder
-      description: Μεταδίδει το PDF ετικέτας ACS μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή ACS για την παραγγελία ή δεν έχει εκδοθεί ακόμα το voucher.
-      summary: Λήψη του PDF ετικέτας voucher ACS για παραγγελία
+      description: Streams the ACS label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no ACS shipment exists for the order or the voucher has not been minted yet.
+      summary: Download the ACS voucher label PDF for an order
       parameters:
         - in: path
           name: id
@@ -12969,8 +12965,8 @@ paths:
   /api/v1/order/{id}/add_tracking:
     post:
       operationId: addOrderTracking
-      description: Προσθήκη πληροφοριών παρακολούθησης σε υπάρχουσα παραγγελία
-      summary: Προσθήκη πληροφοριών παρακολούθησης σε παραγγελία
+      description: Add tracking information to an existing order
+      summary: Add tracking information to an order
       parameters:
         - in: path
           name: id
@@ -13036,8 +13032,8 @@ paths:
   /api/v1/order/{id}/boxnow_cancel:
     post:
       operationId: cancelBoxNowShipmentForOrder
-      description: Μόνο για διαχειριστές. Ζητά ακύρωση δέματος μέσω του API του BoxNow. Έγκυρο μόνο όταν η κατάσταση δέματος είναι NEW (διαφορετικά σφάλμα BoxNow P420). Δέχεται προαιρετικό πεδίο ``reason`` στο σώμα του αιτήματος.
-      summary: Ακύρωση της αποστολής BoxNow για παραγγελία
+      description: Admin-only. Requests parcel cancellation via the BoxNow API. Only valid when the parcel state is NEW (BoxNow error P420 otherwise). Accepts an optional ``reason`` field in the request body.
+      summary: Cancel the BoxNow shipment for an order
       parameters:
         - in: path
           name: id
@@ -13085,8 +13081,8 @@ paths:
   /api/v1/order/{id}/boxnow_label:
     get:
       operationId: getBoxNowLabelForOrder
-      description: Μεταδίδει το PDF ετικέτας BoxNow μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή BoxNow για την παραγγελία ή δεν έχει ακόμα ανατεθεί ID δέματος.
-      summary: Λήψη του PDF ετικέτας δέματος BoxNow για παραγγελία
+      description: Streams the BoxNow label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no BoxNow shipment exists for the order or the parcel ID has not yet been assigned.
+      summary: Download the BoxNow parcel label PDF for an order
       parameters:
         - in: path
           name: id
@@ -13134,8 +13130,8 @@ paths:
   /api/v1/order/{id}/cancel:
     post:
       operationId: cancelOrder
-      description: Ακύρωση υπάρχουσας παραγγελίας και αποκατάσταση αποθέματος προϊόντων
-      summary: Ακύρωση παραγγελίας
+      description: Cancel an existing order and restore product stock
+      summary: Cancel an order
       parameters:
         - in: path
           name: id
@@ -13267,8 +13263,8 @@ paths:
   /api/v1/order/{id}/create_checkout_session:
     post:
       operationId: createOrderCheckoutSession
-      description: Δημιουργία φιλοξενούμενης συνεδρίας checkout (Stripe ή Viva Wallet). Ο πελάτης θα ανακατευθυνθεί στη σελίδα πληρωμής του παρόχου για να ολοκληρώσει την πληρωμή.
-      summary: Δημιουργία φιλοξενούμενης συνεδρίας checkout για παραγγελία
+      description: Create a hosted checkout session (Stripe or Viva Wallet). The customer will be redirected to the provider's checkout page to complete payment.
+      summary: Create a hosted checkout session for an order
       parameters:
         - in: path
           name: id
@@ -13334,8 +13330,8 @@ paths:
   /api/v1/order/{id}/create_payment_intent:
     post:
       operationId: createOrderPaymentIntent
-      description: Δημιουργία payment intent για πληρωμές Stripe σε υπάρχουσα παραγγελία
-      summary: Δημιουργία payment intent για παραγγελία
+      description: Create a payment intent for Stripe payments on an existing order
+      summary: Create a payment intent for an order
       parameters:
         - in: path
           name: id
@@ -13400,8 +13396,8 @@ paths:
   /api/v1/order/{id}/invoice:
     get:
       operationId: retrieveOrderInvoice
-      description: Επιστρέφει τα μεταδεδομένα τιμολογίου της παραγγελίας και ένα απόλυτο URL προς το endpoint λήψης μέσω ροής (``/order/{id}/invoice/download``). Το URL προστατεύεται από τον ίδιο έλεγχο δικαιώματος ιδιοκτήτη/διαχειριστή όπως και αυτό το endpoint μεταδεδομένων — δεν εκτίθενται ακατέργαστα URL αποθήκευσης στον client. 404 αν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα (π.χ. η παραγγελία δεν έχει ολοκληρωθεί).
-      summary: Λήψη μεταδεδομένων λήψης τιμολογίου για παραγγελία
+      description: Return the order's invoice metadata and an absolute URL to the streaming download endpoint (``/order/{id}/invoice/download``). The URL is gated by the same owner/admin permission check as this metadata endpoint — no raw storage URLs are exposed to the client. 404 if the invoice has not been generated yet (e.g. order not completed).
+      summary: Get invoice download metadata for an order
       parameters:
         - in: path
           name: id
@@ -13455,8 +13451,8 @@ paths:
   /api/v1/order/{id}/invoice/download:
     get:
       operationId: downloadOrderInvoice
-      description: Μεταδίδει το παραχθέν PDF μέσω ταυτοποίησης Django. 404 όταν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα. Ίδιος έλεγχος ιδιοκτησίας όπως και το endpoint μεταδεδομένων — επιστρέφει υπογεγραμμένη ροή S3 σε παραγωγή και ροή αρχείου συστήματος σε ανάπτυξη, χωρίς να εκθέτει το URL αποθήκευσης στον client.
-      summary: Λήψη PDF τιμολογίου
+      description: Streams the rendered PDF through Django auth. 404 when the invoice has not been generated yet. Same ownership check as the metadata endpoint — returns a signed S3 stream on prod and a filesystem stream in dev without exposing the storage URL to the client.
+      summary: Download the invoice PDF
       parameters:
         - in: path
           name: id
@@ -13478,8 +13474,8 @@ paths:
   /api/v1/order/{id}/payment_status:
     get:
       operationId: getOrderPaymentStatus
-      description: Ανάκτηση της τρέχουσας κατάστασης πληρωμής από τον πάροχο πληρωμών. Αυτό λαμβάνει την πιο πρόσφατη κατάσταση απευθείας από το Stripe/PayPal.
-      summary: Λήψη κατάστασης πληρωμής παραγγελίας
+      description: Retrieve the current payment status from the payment provider. This fetches the latest status directly from Stripe/PayPal.
+      summary: Get payment status for an order
       parameters:
         - in: path
           name: id
@@ -13533,8 +13529,8 @@ paths:
   /api/v1/order/{id}/reorder:
     post:
       operationId: reorderOrder
-      description: Αντιγραφή κάθε είδους από προηγούμενη παραγγελία πίσω στο ενεργό καλάθι του συνδεδεμένου χρήστη. Τα είδη των οποίων τα προϊόντα είναι ανενεργά ή εξαντλημένα επιστρέφονται στο skipped_items· οι ποσότητες περιορίζονται στο τρέχον απόθεμα.
-      summary: Επανάληψη παραγγελίας των ειδών από προηγούμενη παραγγελία
+      description: Copy each item from a past order back into the authenticated user's active cart. Items whose products are inactive or out of stock are returned in skipped_items; quantities are capped at current stock.
+      summary: Reorder the items from a past order
       parameters:
         - in: path
           name: id
@@ -13588,8 +13584,8 @@ paths:
   /api/v1/order/{id}/retry-payment:
     post:
       operationId: retryOrderPayment
-      description: Δημιουργία νέου Stripe PaymentIntent για παραγγελία της οποίας η προηγούμενη πληρωμή απέτυχε ή δεν ολοκληρώθηκε ποτέ, ώστε ο πελάτης να μπορεί να δοκιμάσει ξανά χωρίς να ξεκινήσει νέα παραγγελία.
-      summary: Επανάληψη πληρωμής για αποτυχημένη ή εκκρεμή παραγγελία
+      description: Create a fresh Stripe PaymentIntent for an order whose previous payment failed or was never completed, so the customer can try again without starting a new order.
+      summary: Retry payment for a failed or pending order
       parameters:
         - in: path
           name: id
@@ -13654,8 +13650,8 @@ paths:
   /api/v1/order/{id}/shipment_cancel:
     post:
       operationId: cancelShipmentForOrder
-      description: 'Μόνο για διαχειριστές. Ακύρωση ανεξάρτητη παρόχου: αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον προσαρμογέα μεταφορέα. Ισχύουν οι κανόνες του κάθε παρόχου (το BoxNow ακυρώνει μόνο δέματα σε κατάσταση NEW· η ACS ακυρώνει μόνο vouchers που δεν έχουν οριστικοποιηθεί σε λίστα παραλαβής).'
-      summary: Ακύρωση της αποστολής μεταφορέα για παραγγελία
+      description: 'Admin-only. Provider-agnostic cancellation: looks up the order''s shipping provider and dispatches to the carrier adapter. The provider''s own rules apply (BoxNow only cancels parcels in NEW state; ACS only cancels vouchers not yet finalised in a pickup list).'
+      summary: Cancel the carrier shipment for an order
       parameters:
         - in: path
           name: id
@@ -13709,8 +13705,8 @@ paths:
   /api/v1/order/{id}/shipment_label:
     get:
       operationId: getShipmentLabelForOrder
-      description: Λήψη ετικέτας ανεξάρτητη παρόχου. Αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον αντίστοιχο προσαρμογέα μεταφορέα μέσω του μητρώου αποστολών — τα frontends μπορούν να καλούν το ίδιο endpoint ανεξάρτητα από τον courier που εκτελεί την παραγγελία.
-      summary: Λήψη του PDF ετικέτας μεταφορέα για παραγγελία
+      description: Provider-agnostic label download. Looks up the order's shipping provider and dispatches to the matching carrier adapter via the shipping registry — frontends can call the same endpoint regardless of which courier is fulfilling the order.
+      summary: Download the carrier label PDF for an order
       parameters:
         - in: path
           name: id
@@ -13764,8 +13760,8 @@ paths:
   /api/v1/order/{id}/update_status:
     post:
       operationId: updateOrderStatus
-      description: Ενημέρωση της κατάστασης υπάρχουσας παραγγελίας
-      summary: Ενημέρωση κατάστασης παραγγελίας
+      description: Update the status of an existing order
+      summary: Update the status of an order
       parameters:
         - in: path
           name: id
@@ -13831,8 +13827,8 @@ paths:
   /api/v1/order/my_orders:
     get:
       operationId: listMyOrders
-      description: Επιστρέφει λίστα με τις παραγγελίες του συνδεδεμένου χρήστη
-      summary: Λίστα παραγγελιών τρέχοντος χρήστη
+      description: Returns a list of the authenticated user's orders
+      summary: List current user's orders
       parameters:
         - in: query
           name: activeOrders
@@ -13845,7 +13841,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+          description: Filter active orders (pending, processing, shipped, delivered)
         - in: query
           name: canBeCanceled
           schema:
@@ -13857,12 +13853,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+          description: Filter orders that can be canceled
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+          description: Filter by city (case-insensitive)
         - in: query
           name: city_Icontains
           schema:
@@ -13871,22 +13867,22 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας
+          description: Filter by country code
         - in: query
           name: country_Alpha2
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: country_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by country name (case-insensitive)
         - in: query
           name: countryIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple country IDs (comma-separated)
         - in: query
           name: createdAfter
           schema:
@@ -13926,12 +13922,12 @@ paths:
           name: documentType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο εγγράφου
+          description: Filter by document type
         - in: query
           name: email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer email (case-insensitive)
         - in: query
           name: email_Icontains
           schema:
@@ -13947,12 +13943,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+          description: Filter final orders (completed, canceled, refunded)
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer first name (case-insensitive)
         - in: query
           name: firstName_Icontains
           schema:
@@ -13961,7 +13957,7 @@ paths:
           name: floor
           schema:
             type: string
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: hasCustomerNotes
           schema:
@@ -13973,7 +13969,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+          description: Filter orders that have/don't have customer notes
         - in: query
           name: hasPaymentId
           schema:
@@ -13985,7 +13981,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+          description: Filter orders that have/don't have payment ID
         - in: query
           name: hasStatusUpdatedAt
           schema:
@@ -13997,7 +13993,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+          description: Filter orders that have status update timestamp
         - in: query
           name: hasTracking
           schema:
@@ -14009,7 +14005,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+          description: Filter orders that have/don't have tracking number
         - in: query
           name: hasUser
           schema:
@@ -14021,7 +14017,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς χρήστη
+          description: Filter orders that have/don't have a user
         - in: query
           name: id
           schema:
@@ -14034,7 +14030,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -14052,7 +14048,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ακυρωμένων παραγγελιών
+          description: Filter canceled orders
         - in: query
           name: isCompleted
           schema:
@@ -14064,7 +14060,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ολοκληρωμένων παραγγελιών
+          description: Filter completed orders
         - in: query
           name: isPaid
           schema:
@@ -14076,12 +14072,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+          description: Filter paid/unpaid orders
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer last name (case-insensitive)
         - in: query
           name: lastName_Icontains
           schema:
@@ -14090,7 +14086,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας
+          description: Filter by location type
         - in: query
           name: needsProcessing
           schema:
@@ -14102,7 +14098,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+          description: Filter orders that need processing
         - name: ordering
           in: query
           required: false
@@ -14149,7 +14145,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο πληρωμένο ποσό
+          description: Filter by maximum paid amount
         - in: query
           name: paidAmountMin
           schema:
@@ -14157,7 +14153,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+          description: Filter by minimum paid amount
         - in: query
           name: payWay
           schema:
@@ -14165,7 +14161,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: payWay_IsOnlinePayment
           schema:
@@ -14177,17 +14173,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά online μεθόδους πληρωμής
+          description: Filter by online payment methods
         - in: query
           name: payWay_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by payment method name (case-insensitive)
         - in: query
           name: paymentId
           schema:
             type: string
-          description: Φίλτρο ανά ID πληρωμής
+          description: Filter by payment ID
         - in: query
           name: paymentId_Icontains
           schema:
@@ -14196,7 +14192,7 @@ paths:
           name: paymentMethod
           schema:
             type: string
-          description: Φίλτρο ανά μέθοδο πληρωμής
+          description: Filter by payment method
         - in: query
           name: paymentMethod_Icontains
           schema:
@@ -14205,7 +14201,6 @@ paths:
           name: paymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -14215,21 +14210,21 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής
+            Filter by payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: paymentStatus_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -14240,7 +14235,7 @@ paths:
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου
+          description: Filter by phone number
         - in: query
           name: phone_Icontains
           schema:
@@ -14249,7 +14244,7 @@ paths:
           name: place
           schema:
             type: string
-          description: Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by place (case-insensitive)
         - in: query
           name: place_Icontains
           schema:
@@ -14265,17 +14260,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+          description: Filter orders from the last 30 days
         - in: query
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: region_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by region name (case-insensitive)
         - name: search
           required: false
           in: query
@@ -14286,7 +14281,7 @@ paths:
           name: shippingCarrier
           schema:
             type: string
-          description: Φίλτρο ανά εταιρεία μεταφοράς
+          description: Filter by shipping carrier
         - in: query
           name: shippingCarrier_Icontains
           schema:
@@ -14312,7 +14307,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστα έξοδα αποστολής
+          description: Filter by maximum shipping price
         - in: query
           name: shippingPriceMin
           schema:
@@ -14320,12 +14315,11 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστα έξοδα αποστολής
+          description: Filter by minimum shipping price
         - in: query
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -14336,22 +14330,22 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: status_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -14362,13 +14356,13 @@ paths:
           name: statusList
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+          description: Filter by multiple statuses (comma-separated)
         - in: query
           name: statusUpdatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+          description: Filter orders with status updated after this date
         - in: query
           name: statusUpdatedAt_Date
           schema:
@@ -14389,12 +14383,12 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+          description: Filter orders with status updated before this date
         - in: query
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by street (case-insensitive)
         - in: query
           name: street_Icontains
           schema:
@@ -14403,7 +14397,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -14412,7 +14406,7 @@ paths:
           name: trackingNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό παρακολούθησης
+          description: Filter by tracking number
         - in: query
           name: trackingNumber_Icontains
           schema:
@@ -14451,17 +14445,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -14473,17 +14467,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -14493,7 +14487,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά Τ.Κ.
+          description: Filter by zipcode
       tags:
         - Orders
       security:
@@ -14538,8 +14532,8 @@ paths:
   /api/v1/order/uuid/{uuid}:
     get:
       operationId: retrieveOrderByUuid
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένη παραγγελία βάσει του UUID της
-      summary: Ανάκτηση παραγγελίας με UUID
+      description: Get detailed information about a specific order using its UUID
+      summary: Retrieve an order by UUID
       parameters:
         - in: path
           name: uuid
@@ -14591,8 +14585,8 @@ paths:
   /api/v1/order/viva_return:
     get:
       operationId: vivaReturnLookup
-      description: Το Smart Checkout του Viva ανακατευθύνει σε ένα στατικό URL επιτυχίας που έχει διαμορφωθεί στο merchant portal και προσθέτει ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (βλ. ενσωμάτωση Smart Checkout στο developer.viva.com). Αυτό το endpoint μετατρέπει αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t`` επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code`` που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση και το payment_status της παραγγελίας.
-      summary: Αναζήτηση παραγγελίας από τις παραμέτρους ανακατεύθυνσης μετά την πληρωμή του Viva Wallet
+      description: Viva's Smart Checkout redirects to a static success URL configured in the merchant portal and appends ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (see developer.viva.com Smart Checkout integration). This endpoint translates those params into the order's UUID so the storefront can forward the customer to the canonical ``/checkout/success/{uuid}`` route. ``t`` resolves via ``payment_id`` (set by the webhook, may lag the redirect); ``s`` resolves via the ``viva_order_code`` stored at session creation, so it works during the webhook race. Permission is open because both keys are unguessable Viva-generated identifiers and the response carries no PII — just the order's UUID, public id, status, and payment_status.
+      summary: Look up an order from Viva Wallet's post-payment redirect params
       parameters:
         - in: query
           name: s
@@ -14622,8 +14616,8 @@ paths:
   /api/v1/pay_way:
     get:
       operationId: listPayWay
-      description: 'Ανάκτηση λίστας Τρόποι πληρωμής με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Τρόποι πληρωμής
+      description: 'Retrieve a list of Pay Ways with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Pay Ways
       parameters:
         - in: query
           name: active
@@ -14636,7 +14630,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: cost_Gte
           schema:
@@ -14658,7 +14652,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο κόστος
+          description: Filter by maximum cost
         - in: query
           name: costMin
           schema:
@@ -14666,17 +14660,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο κόστος
+          description: Filter by minimum cost
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: description
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+          description: Filter by description (partial match)
         - in: query
           name: freeThreshold_Gte
           schema:
@@ -14698,7 +14692,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο όριο δωρεάν
+          description: Filter by maximum free threshold
         - in: query
           name: freeThresholdMin
           schema:
@@ -14706,7 +14700,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο όριο δωρεάν
+          description: Filter by minimum free threshold
         - in: query
           name: hasConfiguration
           schema:
@@ -14718,7 +14712,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μεθόδων πληρωμής με/χωρίς διαμόρφωση
+          description: Filter payment methods that have/don't have configuration
         - in: query
           name: hasIcon
           schema:
@@ -14730,7 +14724,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μεθόδων πληρωμής με/χωρίς εικονίδιο
+          description: Filter payment methods that have/don't have an icon
         - in: query
           name: id
           schema:
@@ -14738,7 +14732,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: isOnlinePayment
           schema:
@@ -14750,7 +14744,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση online πληρωμής
+          description: Filter by online payment status
         - in: query
           name: languageCode
           schema:
@@ -14760,12 +14754,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by name (partial match)
         - name: ordering
           in: query
           required: false
@@ -14789,7 +14783,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -14798,7 +14792,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -14808,12 +14802,12 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: providerCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό παρόχου (μερική αντιστοίχιση)
+          description: Filter by provider code (partial match)
         - in: query
           name: providerCode_Icontains
           schema:
@@ -14829,7 +14823,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά απαίτηση επιβεβαίωσης
+          description: Filter by confirmation requirement
         - name: search
           required: false
           in: query
@@ -14840,12 +14834,12 @@ paths:
           name: shippingKind
           schema:
             type: string
-          description: Συνδυάστε με το ``shippingProviderCode`` για να φιλτράρετε τις μεθόδους πληρωμής βάσει των κανόνων συμβατότητας του μεταφορέα για αυτόν τον τύπο.
+          description: Pair with ``shippingProviderCode`` to filter pay ways by the carrier's compatibility rules for that kind.
         - in: query
           name: shippingProviderCode
           schema:
             type: string
-          description: Φίλτρο μεθόδων πληρωμής συμβατών με τον δεδομένο μεταφορέα αποστολής. Κάθε μεταφορέας διαθέτει τους δικούς του κανόνες συμβατότητας — το BoxNow (``boxnow``) υποστηρίζει αντικαταβολή σε lockers μέσω PAY ON THE GO και έτσι περνά κανονικά· η ACS περνά αμετάβλητη. Συνδυάστε με το ``shippingKind``.
+          description: Filter pay ways compatible with the given shipping carrier. Each carrier owns its own compatibility rules — BoxNow (``boxnow``) supports COD on lockers via PAY ON THE GO and so passes through; ACS passes through unchanged. Pair with ``shippingKind``.
         - in: query
           name: sortOrder
           schema:
@@ -14916,8 +14910,8 @@ paths:
           description: ''
     post:
       operationId: createPayWay
-      description: Δημιουργία νέου Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Μέθοδος Πληρωμής
+      description: Create a new Pay Way. Requires authentication.
+      summary: Create a Pay Way
       parameters:
         - in: query
           name: languageCode
@@ -14928,7 +14922,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -14985,8 +14979,8 @@ paths:
   /api/v1/pay_way/{id}:
     get:
       operationId: retrievePayWay
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Μέθοδος Πληρωμής.
-      summary: Ανάκτηση Μέθοδος Πληρωμής
+      description: Get detailed information about a specific Pay Way.
+      summary: Retrieve a Pay Way
       parameters:
         - in: path
           name: id
@@ -15002,7 +14996,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       security:
@@ -15041,8 +15035,8 @@ paths:
           description: ''
     put:
       operationId: updatePayWay
-      description: Ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Μέθοδος Πληρωμής
+      description: Update Pay Way information. Requires authentication.
+      summary: Update a Pay Way
       parameters:
         - in: path
           name: id
@@ -15058,7 +15052,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -15114,8 +15108,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdatePayWay
-      description: Μερική ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Μέθοδος Πληρωμής
+      description: Partially update Pay Way information. Requires authentication.
+      summary: Partially update a Pay Way
       parameters:
         - in: path
           name: id
@@ -15131,7 +15125,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -15186,8 +15180,8 @@ paths:
           description: ''
     delete:
       operationId: destroyPayWay
-      description: Διαγραφή Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Μέθοδος Πληρωμής
+      description: Delete a Pay Way. Requires authentication.
+      summary: Delete a Pay Way
       parameters:
         - in: path
           name: id
@@ -15222,8 +15216,8 @@ paths:
   /api/v1/product:
     get:
       operationId: listProduct
-      description: 'Ανάκτηση λίστας Προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Προϊόντα
+      description: 'Retrieve a list of Products with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Products
       parameters:
         - in: query
           name: active
@@ -15249,7 +15243,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -15269,7 +15263,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -15320,7 +15314,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: deletedAt_Date
           schema:
@@ -15408,7 +15402,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxDiscount
           schema:
@@ -15576,7 +15570,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -15585,7 +15579,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -15595,7 +15589,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: price
           schema:
@@ -15770,8 +15764,8 @@ paths:
           description: ''
     post:
       operationId: createProduct
-      description: Δημιουργία νέου Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Προϊόν
+      description: Create a new Product. Requires authentication.
+      summary: Create a Product
       parameters:
         - in: query
           name: languageCode
@@ -15782,7 +15776,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -15839,8 +15833,8 @@ paths:
   /api/v1/product/{id}:
     get:
       operationId: retrieveProduct
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Προϊόν.
-      summary: Ανάκτηση Προϊόν
+      description: Get detailed information about a specific Product.
+      summary: Retrieve a Product
       parameters:
         - in: path
           name: id
@@ -15859,7 +15853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       security:
@@ -15898,8 +15892,8 @@ paths:
           description: ''
     put:
       operationId: updateProduct
-      description: Ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Προϊόν
+      description: Update Product information. Requires authentication.
+      summary: Update a Product
       parameters:
         - in: path
           name: id
@@ -15918,7 +15912,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -15974,8 +15968,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProduct
-      description: Μερική ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Προϊόν
+      description: Partially update Product information. Requires authentication.
+      summary: Partially update a Product
       parameters:
         - in: path
           name: id
@@ -15994,7 +15988,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -16049,8 +16043,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProduct
-      description: Διαγραφή Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Προϊόν
+      description: Delete a Product. Requires authentication.
+      summary: Delete a Product
       parameters:
         - in: path
           name: id
@@ -16088,8 +16082,8 @@ paths:
   /api/v1/product/{id}/images:
     get:
       operationId: listProductImages
-      description: Λήψη όλων των εικόνων προϊόντος.
-      summary: Λήψη εικόνων προϊόντος
+      description: Get all images for a product.
+      summary: Get product images
       parameters:
         - in: path
           name: id
@@ -16109,7 +16103,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -16170,8 +16164,8 @@ paths:
   /api/v1/product/{id}/reviews:
     get:
       operationId: listProductReviews
-      description: Λήψη όλων των αξιολογήσεων ενός προϊόντος με υποστήριξη σελιδοποίησης.
-      summary: Λήψη κριτικών προϊόντος
+      description: Get all reviews for a product with pagination support.
+      summary: Get product reviews
       parameters:
         - in: path
           name: id
@@ -16205,7 +16199,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16214,7 +16208,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16224,7 +16218,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -16276,8 +16270,8 @@ paths:
   /api/v1/product/{id}/tags:
     get:
       operationId: listProductTags
-      description: Λήψη όλων των ετικετών που σχετίζονται με ένα προϊόν.
-      summary: Λήψη ετικετών προϊόντος
+      description: Get all tags associated with a product.
+      summary: Get product tags
       parameters:
         - in: path
           name: id
@@ -16348,8 +16342,8 @@ paths:
   /api/v1/product/{id}/update_view_count:
     post:
       operationId: incrementProductViews
-      description: Αύξηση του μετρητή προβολών ενός προϊόντος.
-      summary: Αύξηση προβολών προϊόντος
+      description: Increment the view count for a product.
+      summary: Increment product view count
       parameters:
         - in: path
           name: id
@@ -16404,8 +16398,8 @@ paths:
   /api/v1/product/{id}/variants:
     get:
       operationId: listProductVariants
-      description: Λήψη των αδερφών προϊόντων στην ομάδα παραλλαγών αυτού του προϊόντος, καθώς και των αξόνων παραλλαγής (π.χ. Χρώμα, Μνήμη) προς εμφάνιση ως επιλογείς. Επιστρέφει μόνο το ίδιο το προϊόν όταν δεν έχει ομάδα παραλλαγών.
-      summary: Λήψη παραλλαγών προϊόντος
+      description: Get the sibling products in this product's variant group, plus the variant axes (e.g. Colour, Memory) to render as selectors. Returns just the product itself when it has no variant group.
+      summary: Get product variants
       parameters:
         - in: path
           name: id
@@ -16425,7 +16419,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       security:
@@ -16471,14 +16465,14 @@ paths:
   /api/v1/product/alert:
     get:
       operationId: listProductAlert
-      description: 'Ανάκτηση λίστας Ειδοποιήσεις προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ειδοποιήσεις προϊόντος
+      description: 'Retrieve a list of Product alerts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product alerts
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: isActive
           schema:
@@ -16494,13 +16488,12 @@ paths:
           name: kind
           schema:
             type: string
-            title: Είδος
             enum:
               - price_drop
               - restock
           description: |-
-            * `restock` - Αναπλήρωση
-            * `price_drop` - Πτώση τιμής
+            * `restock` - Restock
+            * `price_drop` - Price drop
         - in: query
           name: languageCode
           schema:
@@ -16510,7 +16503,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -16534,7 +16527,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16543,7 +16536,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16553,7 +16546,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -16610,8 +16603,8 @@ paths:
           description: ''
     post:
       operationId: createProductAlert
-      description: Δημιουργία νέου Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ειδοποίηση προϊόντος
+      description: Create a new Product alert. Requires authentication.
+      summary: Create a Product alert
       parameters:
         - in: query
           name: languageCode
@@ -16622,7 +16615,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Alerts
       requestBody:
@@ -16680,8 +16673,8 @@ paths:
   /api/v1/product/alert/{id}:
     get:
       operationId: retrieveProductAlert
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ειδοποίηση προϊόντος.
-      summary: Ανάκτηση Ειδοποίηση προϊόντος
+      description: Get detailed information about a specific Product alert.
+      summary: Retrieve a Product alert
       parameters:
         - in: path
           name: id
@@ -16700,7 +16693,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Alerts
       security:
@@ -16738,8 +16731,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductAlert
-      description: Διαγραφή Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ειδοποίηση προϊόντος
+      description: Delete a Product alert. Requires authentication.
+      summary: Delete a Product alert
       parameters:
         - in: path
           name: id
@@ -16775,8 +16768,8 @@ paths:
   /api/v1/product/attribute:
     get:
       operationId: listAttribute
-      description: 'Ανάκτηση λίστας Χαρακτηριστικά με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χαρακτηριστικά
+      description: 'Retrieve a list of Attributes with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Attributes
       parameters:
         - in: query
           name: active
@@ -16820,7 +16813,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasValues
           schema:
@@ -16844,7 +16837,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -16860,7 +16853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
@@ -16888,7 +16881,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16897,7 +16890,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16907,7 +16900,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -17013,8 +17006,8 @@ paths:
           description: ''
     post:
       operationId: createAttribute
-      description: Δημιουργία νέου Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Χαρακτηριστικό
+      description: Create a new Attribute. Requires authentication.
+      summary: Create a Attribute
       parameters:
         - in: query
           name: languageCode
@@ -17025,7 +17018,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17070,8 +17063,8 @@ paths:
   /api/v1/product/attribute/{id}:
     get:
       operationId: retrieveAttribute
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χαρακτηριστικό.
-      summary: Ανάκτηση Χαρακτηριστικό
+      description: Get detailed information about a specific Attribute.
+      summary: Retrieve a Attribute
       parameters:
         - in: path
           name: id
@@ -17090,7 +17083,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17128,8 +17121,8 @@ paths:
           description: ''
     put:
       operationId: updateAttribute
-      description: Ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Χαρακτηριστικό
+      description: Update Attribute information. Requires authentication.
+      summary: Update a Attribute
       parameters:
         - in: path
           name: id
@@ -17148,7 +17141,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17192,8 +17185,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateAttribute
-      description: Μερική ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Χαρακτηριστικό
+      description: Partially update Attribute information. Requires authentication.
+      summary: Partially update a Attribute
       parameters:
         - in: path
           name: id
@@ -17212,7 +17205,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17256,8 +17249,8 @@ paths:
           description: ''
     delete:
       operationId: destroyAttribute
-      description: Διαγραφή Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Χαρακτηριστικό
+      description: Delete a Attribute. Requires authentication.
+      summary: Delete a Attribute
       parameters:
         - in: path
           name: id
@@ -17295,8 +17288,8 @@ paths:
   /api/v1/product/attribute/value:
     get:
       operationId: listAttributeValue
-      description: 'Ανάκτηση λίστας Τιμές Χαρακτηριστικών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Τιμές Χαρακτηριστικών
+      description: 'Retrieve a list of Attribute Values with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Attribute Values
       parameters:
         - in: query
           name: active
@@ -17321,7 +17314,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17359,7 +17352,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -17372,7 +17365,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17388,7 +17381,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -17412,7 +17405,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -17421,7 +17414,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -17431,7 +17424,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -17541,8 +17534,8 @@ paths:
           description: ''
     post:
       operationId: createAttributeValue
-      description: Δημιουργία νέου Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Τιμή Χαρακτηριστικού
+      description: Create a new Attribute Value. Requires authentication.
+      summary: Create a Attribute Value
       parameters:
         - in: query
           name: languageCode
@@ -17553,7 +17546,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17598,8 +17591,8 @@ paths:
   /api/v1/product/attribute/value/{id}:
     get:
       operationId: retrieveAttributeValue
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Τιμή Χαρακτηριστικού.
-      summary: Ανάκτηση Τιμή Χαρακτηριστικού
+      description: Get detailed information about a specific Attribute Value.
+      summary: Retrieve a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17618,7 +17611,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17656,8 +17649,8 @@ paths:
           description: ''
     put:
       operationId: updateAttributeValue
-      description: Ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Τιμή Χαρακτηριστικού
+      description: Update Attribute Value information. Requires authentication.
+      summary: Update a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17676,7 +17669,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17720,8 +17713,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateAttributeValue
-      description: Μερική ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Τιμή Χαρακτηριστικού
+      description: Partially update Attribute Value information. Requires authentication.
+      summary: Partially update a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17740,7 +17733,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17784,8 +17777,8 @@ paths:
           description: ''
     delete:
       operationId: destroyAttributeValue
-      description: Διαγραφή Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Τιμή Χαρακτηριστικού
+      description: Delete a Attribute Value. Requires authentication.
+      summary: Delete a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17823,8 +17816,8 @@ paths:
   /api/v1/product/category:
     get:
       operationId: listProductCategory
-      description: 'Ανάκτηση λίστας Κατηγορίες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κατηγορίες προϊόντος
+      description: 'Retrieve a list of Product Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Categories
       parameters:
         - in: query
           name: active
@@ -17876,7 +17869,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: descendantOf
           schema:
@@ -17921,7 +17914,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17961,7 +17954,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: level
           schema:
@@ -18039,7 +18032,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -18048,7 +18041,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -18058,7 +18051,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: parent
           schema:
@@ -18194,8 +18187,8 @@ paths:
           description: ''
     post:
       operationId: createProductCategory
-      description: Δημιουργία νέου Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κατηγορία Προϊόντος
+      description: Create a new Product Category. Requires authentication.
+      summary: Create a Product Category
       parameters:
         - in: query
           name: languageCode
@@ -18206,7 +18199,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18263,8 +18256,8 @@ paths:
   /api/v1/product/category/{id}:
     get:
       operationId: retrieveProductCategory
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Προϊόντος.
-      summary: Ανάκτηση Κατηγορία Προϊόντος
+      description: Get detailed information about a specific Product Category.
+      summary: Retrieve a Product Category
       parameters:
         - in: path
           name: id
@@ -18283,7 +18276,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       security:
@@ -18322,8 +18315,8 @@ paths:
           description: ''
     put:
       operationId: updateProductCategory
-      description: Ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κατηγορία Προϊόντος
+      description: Update Product Category information. Requires authentication.
+      summary: Update a Product Category
       parameters:
         - in: path
           name: id
@@ -18342,7 +18335,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18398,8 +18391,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductCategory
-      description: Μερική ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κατηγορία Προϊόντος
+      description: Partially update Product Category information. Requires authentication.
+      summary: Partially update a Product Category
       parameters:
         - in: path
           name: id
@@ -18418,7 +18411,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18473,8 +18466,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductCategory
-      description: Διαγραφή Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κατηγορία Προϊόντος
+      description: Delete a Product Category. Requires authentication.
+      summary: Delete a Product Category
       parameters:
         - in: path
           name: id
@@ -18605,7 +18598,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -18835,8 +18828,8 @@ paths:
   /api/v1/product/category/image:
     get:
       operationId: listProductCategoryImage
-      description: 'Ανάκτηση λίστας Εικόνες Κατηγορίας Προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Εικόνες Κατηγορίας Προϊόντος
+      description: 'Retrieve a list of Product Category Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Category Images
       parameters:
         - in: query
           name: active
@@ -18860,7 +18853,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -18872,7 +18865,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -18885,16 +18877,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - in: query
           name: languageCode
           schema:
@@ -18904,7 +18896,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -18928,7 +18920,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -18937,7 +18929,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -18947,7 +18939,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -18998,8 +18990,8 @@ paths:
           description: ''
     post:
       operationId: createProductCategoryImage
-      description: Δημιουργία νέου Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Εικόνα Κατηγορίας Προϊόντος
+      description: Create a new Product Category Image. Requires authentication.
+      summary: Create a Product Category Image
       parameters:
         - in: query
           name: languageCode
@@ -19010,7 +19002,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19067,8 +19059,8 @@ paths:
   /api/v1/product/category/image/{id}:
     get:
       operationId: retrieveProductCategoryImage
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Κατηγορίας Προϊόντος.
-      summary: Ανάκτηση Εικόνα Κατηγορίας Προϊόντος
+      description: Get detailed information about a specific Product Category Image.
+      summary: Retrieve a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19087,7 +19079,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       security:
@@ -19126,8 +19118,8 @@ paths:
           description: ''
     put:
       operationId: updateProductCategoryImage
-      description: Ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Εικόνα Κατηγορίας Προϊόντος
+      description: Update Product Category Image information. Requires authentication.
+      summary: Update a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19146,7 +19138,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19202,8 +19194,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductCategoryImage
-      description: Μερική ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Εικόνα Κατηγορίας Προϊόντος
+      description: Partially update Product Category Image information. Requires authentication.
+      summary: Partially update a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19222,7 +19214,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19277,8 +19269,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductCategoryImage
-      description: Διαγραφή Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Εικόνα Κατηγορίας Προϊόντος
+      description: Delete a Product Category Image. Requires authentication.
+      summary: Delete a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19316,8 +19308,8 @@ paths:
   /api/v1/product/category/image/bulk_update:
     patch:
       operationId: bulkUpdateProductCategoryImages
-      description: Ενημέρωση πολλαπλών εικόνων κατηγορίας ταυτόχρονα. Μπορεί να ενημερώσει την κατάσταση ενεργοποίησης και τη σειρά ταξινόμησης.
-      summary: Μαζική ενημέρωση εικόνων κατηγορίας
+      description: Update multiple category images at once. Can update active status and sort order.
+      summary: Bulk update category images
       tags:
         - Product Category Images
       requestBody:
@@ -19373,8 +19365,8 @@ paths:
   /api/v1/product/category/image/by_category:
     get:
       operationId: getProductCategoryImagesByCategory
-      description: Ανάκτηση όλων των εικόνων για συγκεκριμένη κατηγορία.
-      summary: Λήψη εικόνων ανά κατηγορία
+      description: Retrieve all images for a specific category.
+      summary: Get images by category
       parameters:
         - in: query
           name: active
@@ -19405,7 +19397,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -19418,16 +19409,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - name: ordering
           in: query
           required: false
@@ -19488,8 +19479,8 @@ paths:
   /api/v1/product/category/image/by_type:
     get:
       operationId: getProductCategoryImagesByType
-      description: Ανάκτηση όλων των εικόνων συγκεκριμένου τύπου (κύρια, banner, εικονίδιο κ.λπ.).
-      summary: Λήψη εικόνων ανά τύπο
+      description: Retrieve all images of a specific type (main, banner, icon, etc.).
+      summary: Get images by type
       parameters:
         - in: query
           name: active
@@ -19520,7 +19511,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -19533,16 +19523,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - name: ordering
           in: query
           required: false
@@ -19603,8 +19593,8 @@ paths:
   /api/v1/product/favourite:
     get:
       operationId: listProductFavourite
-      description: 'Ανάκτηση λίστας Αγαπημένα προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Αγαπημένα προϊόντα
+      description: 'Retrieve a list of Product Favourites with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Favourites
       parameters:
         - in: query
           name: createdAfter
@@ -19622,7 +19612,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -19639,7 +19629,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -19663,7 +19653,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -19672,7 +19662,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -19682,7 +19672,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -19777,8 +19767,8 @@ paths:
           description: ''
     post:
       operationId: createProductFavourite
-      description: Δημιουργία νέου Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Αγαπημένο Προϊόν
+      description: Create a new Product Favourite. Requires authentication.
+      summary: Create a Product Favourite
       parameters:
         - in: query
           name: languageCode
@@ -19789,7 +19779,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -19846,8 +19836,8 @@ paths:
   /api/v1/product/favourite/{id}:
     get:
       operationId: retrieveProductFavourite
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Αγαπημένο Προϊόν.
-      summary: Ανάκτηση Αγαπημένο Προϊόν
+      description: Get detailed information about a specific Product Favourite.
+      summary: Retrieve a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19863,7 +19853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       security:
@@ -19901,8 +19891,8 @@ paths:
           description: ''
     put:
       operationId: updateProductFavourite
-      description: Ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Αγαπημένο Προϊόν
+      description: Update Product Favourite information. Requires authentication.
+      summary: Update a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19918,7 +19908,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -19974,8 +19964,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductFavourite
-      description: Μερική ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Αγαπημένο Προϊόν
+      description: Partially update Product Favourite information. Requires authentication.
+      summary: Partially update a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19991,7 +19981,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -20046,8 +20036,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductFavourite
-      description: Διαγραφή Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Αγαπημένο Προϊόν
+      description: Delete a Product Favourite. Requires authentication.
+      summary: Delete a Product Favourite
       parameters:
         - in: path
           name: id
@@ -20082,8 +20072,8 @@ paths:
   /api/v1/product/favourite/{id}/product:
     get:
       operationId: getProductFavouriteProduct
-      description: Λήψη λεπτομερών πληροφοριών για το προϊόν σε αυτή την εγγραφή αγαπημένων.
-      summary: Λήψη λεπτομερειών αγαπημένου προϊόντος
+      description: Get detailed information about the product in this favourite entry.
+      summary: Get favourite product details
       parameters:
         - in: path
           name: id
@@ -20134,8 +20124,8 @@ paths:
   /api/v1/product/favourite/favourites_by_products:
     post:
       operationId: getProductFavouritesByProducts
-      description: Λήψη εγγραφών αγαπημένων για τα καθορισμένα ID προϊόντων. Απαιτεί ταυτοποίηση.
-      summary: Λήψη αγαπημένων ανά IDs προϊόντων
+      description: Get favourite entries for the specified product IDs. Requires authentication.
+      summary: Get favourites by product IDs
       parameters:
         - in: query
           name: createdAfter
@@ -20272,8 +20262,8 @@ paths:
   /api/v1/product/image:
     get:
       operationId: listProductImage
-      description: 'Ανάκτηση λίστας Εικόνες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Εικόνες προϊόντος
+      description: 'Retrieve a list of Product Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Images
       parameters:
         - in: query
           name: createdAt
@@ -20284,7 +20274,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -20312,7 +20302,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -20336,7 +20326,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -20345,7 +20335,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -20355,7 +20345,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -20425,8 +20415,8 @@ paths:
           description: ''
     post:
       operationId: createProductImage
-      description: Δημιουργία νέου Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Εικόνα Προϊόντος
+      description: Create a new Product Image. Requires authentication.
+      summary: Create a Product Image
       parameters:
         - in: query
           name: languageCode
@@ -20437,7 +20427,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20494,8 +20484,8 @@ paths:
   /api/v1/product/image/{id}:
     get:
       operationId: retrieveProductImage
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Προϊόντος.
-      summary: Ανάκτηση Εικόνα Προϊόντος
+      description: Get detailed information about a specific Product Image.
+      summary: Retrieve a Product Image
       parameters:
         - in: path
           name: id
@@ -20514,7 +20504,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       security:
@@ -20553,8 +20543,8 @@ paths:
           description: ''
     put:
       operationId: updateProductImage
-      description: Ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Εικόνα Προϊόντος
+      description: Update Product Image information. Requires authentication.
+      summary: Update a Product Image
       parameters:
         - in: path
           name: id
@@ -20573,7 +20563,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20629,8 +20619,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductImage
-      description: Μερική ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Εικόνα Προϊόντος
+      description: Partially update Product Image information. Requires authentication.
+      summary: Partially update a Product Image
       parameters:
         - in: path
           name: id
@@ -20649,7 +20639,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20704,8 +20694,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductImage
-      description: Διαγραφή Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Εικόνα Προϊόντος
+      description: Delete a Product Image. Requires authentication.
+      summary: Delete a Product Image
       parameters:
         - in: path
           name: id
@@ -20743,20 +20733,20 @@ paths:
   /api/v1/product/review:
     get:
       operationId: listProductReview
-      description: 'Ανάκτηση λίστας Κριτικές προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κριτικές προϊόντος
+      description: 'Retrieve a list of Product Reviews with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Reviews
       parameters:
         - in: query
           name: comment
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (μερική αντιστοίχιση)
+          description: Filter by comment content (partial match)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -20777,7 +20767,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -20789,12 +20779,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasComment
           schema:
@@ -20806,7 +20796,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αξιολογήσεων με/χωρίς σχόλια
+          description: Filter reviews that have/don't have comments
         - in: query
           name: id
           schema:
@@ -20814,7 +20804,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κριτικής
+          description: Filter by review ID
         - in: query
           name: isPublished
           schema:
@@ -20826,7 +20816,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: languageCode
           schema:
@@ -20836,7 +20826,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxRate
           schema:
@@ -20844,7 +20834,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη βαθμολογία (alias)
+          description: Filter by maximum rating (alias)
         - in: query
           name: minRate
           schema:
@@ -20852,7 +20842,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη βαθμολογία (alias)
+          description: Filter by minimum rating (alias)
         - name: ordering
           in: query
           required: false
@@ -20876,7 +20866,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -20885,7 +20875,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -20895,7 +20885,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -20903,7 +20893,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: productActive
           schema:
@@ -20915,7 +20905,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: productAvgRatingMax
           schema:
@@ -20923,7 +20913,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο προϊόντων με μέγιστη μέση βαθμολογία
+          description: Filter products with maximum average rating
         - in: query
           name: productAvgRatingMin
           schema:
@@ -20931,7 +20921,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο προϊόντων με ελάχιστη μέση βαθμολογία
+          description: Filter products with minimum average rating
         - in: query
           name: productCategory
           schema:
@@ -20939,7 +20929,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: productId
           schema:
@@ -20947,18 +20937,18 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: productName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+          description: Filter by product name (partial match)
         - in: query
           name: publishedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -20979,7 +20969,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - in: query
           name: publishedRecentDays
           schema:
@@ -20987,7 +20977,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο αξιολογήσεων που δημοσιεύθηκαν τις τελευταίες N ημέρες
+          description: Filter reviews published in the last N days
         - in: query
           name: rate
           schema:
@@ -20996,18 +20986,18 @@ paths:
                 pattern: ^-?\d+$
               - type: integer
           description: |-
-            Φίλτρο ανά ακριβή βαθμολογία
+            Filter by exact rating
 
-            * `1` - Ένα
-            * `2` - Δύο
-            * `3` - Τρία
-            * `4` - Τέσσερα
-            * `5` - Πέντε
-            * `6` - Έξι
-            * `7` - Επτά
-            * `8` - Οκτώ
-            * `9` - Εννέα
-            * `10` - Δέκα
+            * `1` - One
+            * `2` - Two
+            * `3` - Three
+            * `4` - Four
+            * `5` - Five
+            * `6` - Six
+            * `7` - Seven
+            * `8` - Eight
+            * `9` - Nine
+            * `10` - Ten
         - in: query
           name: rate_Gte
           schema:
@@ -21029,7 +21019,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη βαθμολογία
+          description: Filter by maximum rating
         - in: query
           name: rateMin
           schema:
@@ -21037,7 +21027,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη βαθμολογία
+          description: Filter by minimum rating
         - in: query
           name: recentDays
           schema:
@@ -21045,7 +21035,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο αξιολογήσεων των τελευταίων N ημερών
+          description: Filter reviews from the last N days
         - name: search
           required: false
           in: query
@@ -21056,23 +21046,22 @@ paths:
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - 'FALSE'
               - NEW
               - 'TRUE'
           description: |-
-            Φίλτρο ανά κατάσταση αξιολόγησης
+            Filter by review status
 
-            * `NEW` - Νέο
-            * `TRUE` - Ναι
-            * `FALSE` - Όχι
+            * `NEW` - New
+            * `TRUE` - True
+            * `FALSE` - False
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -21093,7 +21082,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: user
           schema:
@@ -21101,17 +21090,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: userEmail
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+          description: Filter by user email (partial match)
         - in: query
           name: userFirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (μερική αντιστοίχιση)
+          description: Filter by user first name (partial match)
         - in: query
           name: userId
           schema:
@@ -21119,12 +21108,12 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: userLastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (μερική αντιστοίχιση)
+          description: Filter by user last name (partial match)
         - in: query
           name: userReviewCountMin
           schema:
@@ -21132,7 +21121,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο χρηστών με ελάχιστο αριθμό αξιολογήσεων
+          description: Filter users with minimum number of reviews
         - in: query
           name: uuid
           schema:
@@ -21149,7 +21138,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αξιολογήσεων από επαληθευμένες αγορές
+          description: Filter reviews from verified purchases
       tags:
         - Product Reviews
       security:
@@ -21194,8 +21183,8 @@ paths:
           description: ''
     post:
       operationId: createProductReview
-      description: Δημιουργία νέου Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κριτική Προϊόντος
+      description: Create a new Product Review. Requires authentication.
+      summary: Create a Product Review
       parameters:
         - in: query
           name: languageCode
@@ -21206,7 +21195,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21263,8 +21252,8 @@ paths:
   /api/v1/product/review/{id}:
     get:
       operationId: retrieveProductReview
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κριτική Προϊόντος.
-      summary: Ανάκτηση Κριτική Προϊόντος
+      description: Get detailed information about a specific Product Review.
+      summary: Retrieve a Product Review
       parameters:
         - in: path
           name: id
@@ -21283,7 +21272,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       security:
@@ -21322,8 +21311,8 @@ paths:
           description: ''
     put:
       operationId: updateProductReview
-      description: Ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κριτική Προϊόντος
+      description: Update Product Review information. Requires authentication.
+      summary: Update a Product Review
       parameters:
         - in: path
           name: id
@@ -21342,7 +21331,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21398,8 +21387,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductReview
-      description: Μερική ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κριτική Προϊόντος
+      description: Partially update Product Review information. Requires authentication.
+      summary: Partially update a Product Review
       parameters:
         - in: path
           name: id
@@ -21418,7 +21407,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21473,8 +21462,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductReview
-      description: Διαγραφή Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κριτική Προϊόντος
+      description: Delete a Product Review. Requires authentication.
+      summary: Delete a Product Review
       parameters:
         - in: path
           name: id
@@ -21512,8 +21501,8 @@ paths:
   /api/v1/product/review/{id}/product:
     get:
       operationId: getProductReviewProduct
-      description: Λήψη λεπτομερών πληροφοριών για το προϊόν στο οποίο αναφέρεται αυτή η αξιολόγηση.
-      summary: Λήψη λεπτομερειών προϊόντος κριτικής
+      description: Get detailed information about the product this review is for.
+      summary: Get reviewed product details
       parameters:
         - in: path
           name: id
@@ -21565,8 +21554,8 @@ paths:
   /api/v1/product/review/{id}/user_product_review:
     get:
       operationId: getUserProductReview
-      description: Λήψη της αξιολόγησης του τρέχοντος χρήστη για συγκεκριμένο προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Λήψη κριτικής χρήστη για προϊόν
+      description: Get the current user's review for a specific product. Requires authentication.
+      summary: Get user's review for a product
       parameters:
         - in: path
           name: id
@@ -21617,14 +21606,14 @@ paths:
   /api/v1/region:
     get:
       operationId: listRegion
-      description: 'Ανάκτηση λίστας Περιοχές με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Περιοχές
+      description: 'Retrieve a list of Regions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Regions
       parameters:
         - in: query
           name: alpha
           schema:
             type: string
-          description: Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region alpha code (partial match)
         - in: query
           name: alpha_Icontains
           schema:
@@ -21633,17 +21622,17 @@ paths:
           name: alphaExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+          description: Filter by exact region alpha code
         - in: query
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -21660,7 +21649,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -21670,12 +21659,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: ordering
           in: query
           required: false
@@ -21699,7 +21688,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -21708,7 +21697,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -21718,7 +21707,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -21807,8 +21796,8 @@ paths:
           description: ''
     post:
       operationId: createRegion
-      description: Δημιουργία νέου Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Περιοχή
+      description: Create a new Region. Requires authentication.
+      summary: Create a Region
       parameters:
         - in: query
           name: languageCode
@@ -21819,7 +21808,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -21876,15 +21865,15 @@ paths:
   /api/v1/region/{alpha}:
     get:
       operationId: retrieveRegion
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Περιοχή.
-      summary: Ανάκτηση Περιοχή
+      description: Get detailed information about a specific Region.
+      summary: Retrieve a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -21895,7 +21884,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       security:
@@ -21934,15 +21923,15 @@ paths:
           description: ''
     put:
       operationId: updateRegion
-      description: Ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Περιοχή
+      description: Update Region information. Requires authentication.
+      summary: Update a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -21953,7 +21942,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -22009,15 +21998,15 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateRegion
-      description: Μερική ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Περιοχή
+      description: Partially update Region information. Requires authentication.
+      summary: Partially update a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -22028,7 +22017,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -22083,15 +22072,15 @@ paths:
           description: ''
     delete:
       operationId: destroyRegion
-      description: Διαγραφή Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Περιοχή
+      description: Delete a Region. Requires authentication.
+      summary: Delete a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
       tags:
         - Regions
@@ -22121,21 +22110,21 @@ paths:
   /api/v1/region/{alpha}/get_regions_by_country_alpha_2:
     get:
       operationId: listRegionsByCountry
-      description: Λήψη όλων των περιφερειών για συγκεκριμένη χώρα βάσει του κωδικού alpha-2 της.
-      summary: Λήψη περιφερειών ανά χώρα
+      description: Get all regions for a specific country using its alpha-2 code.
+      summary: Get regions by country
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: alpha
           schema:
             type: string
-          description: Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region alpha code (partial match)
         - in: query
           name: alpha_Icontains
           schema:
@@ -22144,17 +22133,17 @@ paths:
           name: alphaExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+          description: Filter by exact region alpha code
         - in: query
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -22171,7 +22160,7 @@ paths:
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: ordering
           in: query
           required: false
@@ -22286,24 +22275,24 @@ paths:
   /api/v1/search/analytics:
     get:
       operationId: api_v1_search_analytics_retrieve
-      description: Ανάκτηση συγκεντρωτικών αναλυτικών αναζήτησης, συμπεριλαμβανομένων των κορυφαίων ερωτημάτων, ερωτημάτων χωρίς αποτελέσματα, όγκου αναζήτησης ανά τύπο περιεχομένου και γλώσσα, μέσου αριθμού αποτελεσμάτων, μέσου χρόνου επεξεργασίας και ποσοστού κλικ. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά εύρος ημερομηνιών και τύπο περιεχομένου.
-      summary: Λήψη μετρικών αναζήτησης
+      description: Retrieve aggregated search analytics including top queries, zero-result queries, search volume by content type and language, average results count, average processing time, and click-through rate. Results can be filtered by date range and content type.
+      summary: Get search analytics metrics
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: 'Φίλτρο ανά τύπο περιεχομένου: ''product'', ''blog_post'', ή ''federated''. Αν δεν δοθεί, συμπεριλαμβάνει όλους τους τύπους περιεχομένου.'
+          description: 'Filter by content type: ''product'', ''blog_post'', or ''federated''. If not provided, includes all content types.'
         - in: query
           name: endDate
           schema:
             type: string
-          description: 'Ημερομηνία λήξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει δεδομένα έως τη σημερινή ημερομηνία.'
+          description: 'End date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes data up to current date.'
         - in: query
           name: startDate
           schema:
             type: string
-          description: 'Ημερομηνία έναρξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει όλα τα ιστορικά δεδομένα.'
+          description: 'Start date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes all historical data.'
       tags:
         - Search
       security:
@@ -22324,14 +22313,14 @@ paths:
   /api/v1/search/blog/post:
     get:
       operationId: api_v1_search_blog_post_retrieve
-      description: Αναζήτηση άρθρων με χρήση MeiliSearch. Παρέχει αναζήτηση πλήρους κειμένου με επισήμανση, κατάταξη και δυνατότητες facet. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά γλώσσα.
-      summary: Αναζήτηση άρθρων
+      description: Search blog posts using MeiliSearch. Provides full-text search with highlighting, ranking, and faceting capabilities. Results can be filtered by language.
+      summary: Search blog posts
       parameters:
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: limit
           schema:
@@ -22339,7 +22328,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum number of results to return
         - in: query
           name: offset
           schema:
@@ -22347,12 +22336,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: query
           schema:
             type: string
-          description: String αναζήτησης
+          description: Search query string
           required: true
       tags:
         - Search
@@ -22372,17 +22361,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: ''
+  /api/v1/search/click:
+    post:
+      operationId: api_v1_search_click_create
+      description: Attribute a click on a search result to the query that produced it. The query_id comes from the search response. Feeds the click-through ranking signal and search analytics.
+      summary: Log a click on a search result
+      tags:
+        - Search
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+        required: true
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchClickResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
   /api/v1/search/federated:
     get:
       operationId: api_v1_search_federated_retrieve
-      description: Ταυτόχρονη αναζήτηση σε πολλαπλούς τύπους περιεχομένου με χρήση του API multi_search του Meilisearch σε λειτουργία ομοσπονδίας. Τα αποτελέσματα σταθμίζονται και συγχωνεύονται, με τα προϊόντα να έχουν βάρος 1.0 και τα άρθρα βάρος 0.7.
-      summary: Ομοσπονδιακή αναζήτηση σε προϊόντα και άρθρα
+      description: Search multiple content types simultaneously using Meilisearch multi_search API with federation mode. Results are weighted and merged with products having weight 1.0 and blog posts having weight 0.7.
+      summary: Federated search across products and blog posts
       parameters:
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: limit
           schema:
@@ -22390,7 +22414,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος συνολικός αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum total number of results to return
         - in: query
           name: offset
           schema:
@@ -22398,12 +22422,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: query
           schema:
             type: string
-          description: String αναζήτησης
+          description: Search query string
           required: true
       tags:
         - Search
@@ -22426,29 +22450,29 @@ paths:
   /api/v1/search/product:
     get:
       operationId: api_v1_search_product_retrieve
-      description: Αναζήτηση προϊόντων με χρήση MeiliSearch, με υποστήριξη αναζήτησης πλήρους κειμένου, εύρους τιμής, δημοτικότητας, πλήθους προβολών και φίλτρων κατηγορίας. Επιστρέφει κατανομή facet και στατιστικά για δυναμικό UI φίλτρων.
-      summary: Αναζήτηση προϊόντων με προηγμένα φίλτρα
+      description: Search products using MeiliSearch with support for full-text search, price range, popularity, view count, and category filters. Returns facet distribution and statistics for dynamic filter UI.
+      summary: Search products with advanced filters
       parameters:
         - in: query
           name: attributeValues
           schema:
             type: string
-          description: ID τιμών χαρακτηριστικών διαχωρισμένα με κόμμα (attribute_values IN [ids])
+          description: Comma-separated attribute value IDs (attribute_values IN [ids])
         - in: query
           name: categories
           schema:
             type: string
-          description: ID κατηγοριών διαχωρισμένα με κόμμα (category IN [ids])
+          description: Comma-separated category IDs (category IN [ids])
         - in: query
           name: facets
           schema:
             type: string
-          description: Πεδία facet διαχωρισμένα με κόμμα για πλήθη και στατιστικά
+          description: Comma-separated facet fields for counts and stats
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: likesMin
           schema:
@@ -22456,7 +22480,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ελάχιστων επισημάνσεων (likes_count >= value)
+          description: Minimum likes filter (likes_count >= value)
         - in: query
           name: limit
           schema:
@@ -22464,7 +22488,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum number of results to return
         - in: query
           name: offset
           schema:
@@ -22472,7 +22496,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: priceMax
           schema:
@@ -22480,7 +22504,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο μέγιστης τιμής (final_price <= value)
+          description: Maximum price filter (final_price <= value)
         - in: query
           name: priceMin
           schema:
@@ -22488,17 +22512,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ελάχιστης τιμής (final_price >= value)
+          description: Minimum price filter (final_price >= value)
         - in: query
           name: query
           schema:
             type: string
-          description: Ερώτημα αναζήτησης πλήρους κειμένου (κενό για χωρίς φίλτρο αναζήτησης)
+          description: Full-text search query (empty for no search filter)
         - in: query
           name: sort
           schema:
             type: string
-          description: Πεδίο ταξινόμησης (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
+          description: Sort field (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
         - in: query
           name: viewsMin
           schema:
@@ -22506,7 +22530,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ελάχιστων προβολών (view_count >= value)
+          description: Minimum views filter (view_count >= value)
       tags:
         - Search
       security:
@@ -22528,19 +22552,19 @@ paths:
   /api/v1/search/trending:
     get:
       operationId: listTrendingSearches
-      description: Επιστρέφει τα πιο δημοφιλή ερωτήματα αναζήτησης των τελευταίων 24 ωρών, κατάλληλα για εμφάνιση στην κενή κατάσταση του modal αναζήτησης. Αποθηκεύεται σε cache για 5 λεπτά ανά (language_code, content_type, limit).
-      summary: Λίστα trending αναζητήσεων
+      description: Return the most popular search queries from the last 24 hours, suitable for surfacing in the search modal empty state. Cached for 5 minutes per (language_code, content_type, limit).
+      summary: List trending search queries
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: 'Φίλτρο ανά τύπο περιεχομένου: product, blog_post, federated. Προεπιλογή product.'
+          description: 'Filter by content type: product, blog_post, federated. Defaults to product.'
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Φίλτρο ερωτημάτων ανά γλώσσα (π.χ. 'el').
+          description: Filter queries by language (e.g. 'el').
         - in: query
           name: limit
           schema:
@@ -22548,7 +22572,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστα αποτελέσματα. Προεπιλογή 8, ανώτατο 20.
+          description: Max results. Default 8, cap 20.
       tags:
         - Search
       security:
@@ -22564,8 +22588,8 @@ paths:
   /api/v1/settings:
     get:
       operationId: api_v1_settings_list
-      description: Ανάκτηση όλων των ρυθμίσεων με τα ονόματα, τις τιμές και τους τύπους τους
-      summary: Λίστα όλων των ρυθμίσεων
+      description: Retrieve all settings with their names, values, and types
+      summary: List all available settings
       tags:
         - Settings
       security:
@@ -22588,14 +22612,14 @@ paths:
   /api/v1/settings/get:
     get:
       operationId: api_v1_settings_get_retrieve
-      description: Ανάκτηση συγκεκριμένης τιμής ρύθμισης βάσει του ονόματος κλειδιού της
-      summary: Λήψη ρύθμισης με κλειδί
+      description: Retrieve a specific setting value by its key name
+      summary: Get setting by key
       parameters:
         - in: query
           name: key
           schema:
             type: string
-          description: Όνομα κλειδιού ρύθμισης (π.χ. CHECKOUT_SHIPPING_PRICE)
+          description: Setting key name (e.g., CHECKOUT_SHIPPING_PRICE)
           required: true
       tags:
         - Settings
@@ -22889,14 +22913,14 @@ paths:
   /api/v1/shipping/boxnow/lockers:
     get:
       operationId: listBoxNowLocker
-      description: 'Ανάκτηση λίστας Lockers BoxNow με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Lockers BoxNow
+      description: 'Retrieve a list of BoxNow Lockers with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List BoxNow Lockers
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -22906,7 +22930,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -22930,7 +22954,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -22939,7 +22963,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -22949,7 +22973,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -23001,8 +23025,8 @@ paths:
   /api/v1/shipping/boxnow/lockers/{id}:
     get:
       operationId: retrieveBoxNowLocker
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Locker BoxNow.
-      summary: Ανάκτηση Locker BoxNow
+      description: Get detailed information about a specific BoxNow Locker.
+      summary: Retrieve a BoxNow Locker
       parameters:
         - in: path
           name: id
@@ -23018,7 +23042,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - BoxNow lockers
       security:
@@ -23266,8 +23290,8 @@ paths:
   /api/v1/tag:
     get:
       operationId: listTag
-      description: 'Ανάκτηση λίστας Ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ετικέτες
+      description: 'Retrieve a list of Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Tags
       parameters:
         - in: query
           name: active
@@ -23280,17 +23304,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: contentType
           schema:
             type: string
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο τύπο περιεχομένου
+          description: Filter tags used for specific content type
         - in: query
           name: contentType_AppLabel
           schema:
             type: string
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για περιεχόμενο από συγκεκριμένη εφαρμογή
+          description: Filter tags used for content from specific app
         - in: query
           name: createdAfter
           schema:
@@ -23322,7 +23346,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasLabel
           schema:
@@ -23334,7 +23358,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς ετικέτα
+          description: Filter tags that have/don't have a label
         - in: query
           name: hasUsage
           schema:
@@ -23346,7 +23370,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών χρησιμοποιούμενων/μη
+          description: Filter tags that are/aren't used
         - in: query
           name: id
           schema:
@@ -23359,7 +23383,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -23370,17 +23394,17 @@ paths:
           name: label
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+          description: Filter by tag label (partial match)
         - in: query
           name: label_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή ετικέτα
+          description: Filter by exact tag label
         - in: query
           name: label_Startswith
           schema:
             type: string
-          description: Φίλτρο ετικετών με ετικέτα που ξεκινά με
+          description: Filter tags with labels starting with
         - in: query
           name: languageCode
           schema:
@@ -23390,7 +23414,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxUsageCount
           schema:
@@ -23398,7 +23422,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών που χρησιμοποιούνται έως X φορές
+          description: Filter tags used at most X times
         - in: query
           name: minUsageCount
           schema:
@@ -23406,7 +23430,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών που χρησιμοποιούνται τουλάχιστον X φορές
+          description: Filter tags used at least X times
         - in: query
           name: mostUsed
           schema:
@@ -23418,7 +23442,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+          description: Order tags by usage count (most used first)
         - in: query
           name: objectId
           schema:
@@ -23426,7 +23450,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο ID αντικειμένου
+          description: Filter tags used for specific object ID
         - name: ordering
           in: query
           required: false
@@ -23450,7 +23474,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -23459,7 +23483,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -23469,7 +23493,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -23520,7 +23544,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που δεν χρησιμοποιούνται
+          description: Filter tags not used anywhere
         - in: query
           name: updatedAfter
           schema:
@@ -23597,8 +23621,8 @@ paths:
           description: ''
     post:
       operationId: createTag
-      description: Δημιουργία νέου Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ετικέτα
+      description: Create a new Tag. Requires authentication.
+      summary: Create a Tag
       parameters:
         - in: query
           name: languageCode
@@ -23609,7 +23633,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23666,8 +23690,8 @@ paths:
   /api/v1/tag/{id}:
     get:
       operationId: retrieveTag
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα.
-      summary: Ανάκτηση Ετικέτα
+      description: Get detailed information about a specific Tag.
+      summary: Retrieve a Tag
       parameters:
         - in: path
           name: id
@@ -23686,7 +23710,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       security:
@@ -23725,8 +23749,8 @@ paths:
           description: ''
     put:
       operationId: updateTag
-      description: Ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Ετικέτα
+      description: Update Tag information. Requires authentication.
+      summary: Update a Tag
       parameters:
         - in: path
           name: id
@@ -23745,7 +23769,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23801,8 +23825,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateTag
-      description: Μερική ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Ετικέτα
+      description: Partially update Tag information. Requires authentication.
+      summary: Partially update a Tag
       parameters:
         - in: path
           name: id
@@ -23821,7 +23845,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23876,8 +23900,8 @@ paths:
           description: ''
     delete:
       operationId: destroyTag
-      description: Διαγραφή Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ετικέτα
+      description: Delete a Tag. Requires authentication.
+      summary: Delete a Tag
       parameters:
         - in: path
           name: id
@@ -23915,19 +23939,19 @@ paths:
   /api/v1/tagged-item:
     get:
       operationId: listTaggedItem
-      description: 'Ανάκτηση λίστας Αντικείμενα με ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Αντικείμενα με ετικέτες
+      description: 'Retrieve a list of Tagged Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Tagged Items
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: Φίλτρο ανά όνομα model τύπου περιεχομένου
+          description: Filter by content type model name
         - in: query
           name: contentType_AppLabel
           schema:
             type: string
-          description: Φίλτρο ανά app label τύπου περιεχομένου
+          description: Filter by content type app label
         - in: query
           name: createdAfter
           schema:
@@ -23959,7 +23983,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -23972,7 +23996,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -23988,7 +24012,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: objectId
           schema:
@@ -23996,19 +24020,19 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID αντικειμένου
+          description: Filter by object ID
         - in: query
           name: objectId_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
                   maximum: 2147483647
                   minimum: 0
-          description: Φίλτρο ανά πολλαπλά ID αντικειμένων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple object IDs (comma-separated)
           explode: false
           style: form
         - name: ordering
@@ -24034,7 +24058,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -24043,7 +24067,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -24053,7 +24077,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -24067,7 +24091,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά συγκεκριμένο ID ετικέτας
+          description: Filter by specific tag ID
         - in: query
           name: tag_Active
           schema:
@@ -24079,12 +24103,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση ετικέτας
+          description: Filter by tag active status
         - in: query
           name: tag_Label
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+          description: Filter by tag label (partial match)
         - in: query
           name: updatedAfter
           schema:
@@ -24161,8 +24185,8 @@ paths:
           description: ''
     post:
       operationId: createTaggedItem
-      description: Δημιουργία νέου Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Σχετιζόμενο Είδος
+      description: Create a new Tagged Item. Requires authentication.
+      summary: Create a Tagged Item
       parameters:
         - in: query
           name: languageCode
@@ -24173,7 +24197,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24230,8 +24254,8 @@ paths:
   /api/v1/tagged-item/{id}:
     get:
       operationId: retrieveTaggedItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχετιζόμενο Είδος.
-      summary: Ανάκτηση Σχετιζόμενο Είδος
+      description: Get detailed information about a specific Tagged Item.
+      summary: Retrieve a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24250,7 +24274,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       security:
@@ -24289,8 +24313,8 @@ paths:
           description: ''
     put:
       operationId: updateTaggedItem
-      description: Ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Σχετιζόμενο Είδος
+      description: Update Tagged Item information. Requires authentication.
+      summary: Update a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24309,7 +24333,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24365,8 +24389,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateTaggedItem
-      description: Μερική ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Σχετιζόμενο Είδος
+      description: Partially update Tagged Item information. Requires authentication.
+      summary: Partially update a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24385,7 +24409,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24440,8 +24464,8 @@ paths:
           description: ''
     delete:
       operationId: destroyTaggedItem
-      description: Διαγραφή Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Σχετιζόμενο Είδος
+      description: Delete a Tagged Item. Requires authentication.
+      summary: Delete a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24500,14 +24524,14 @@ paths:
   /api/v1/user/account:
     get:
       operationId: listUserAccount
-      description: 'Ανάκτηση λίστας Λογαριασμοί Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Λογαριασμοί Χρηστών
+      description: 'Retrieve a list of User Accounts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Accounts
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -24517,7 +24541,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -24541,7 +24565,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -24550,7 +24574,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -24560,7 +24584,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -24610,8 +24634,8 @@ paths:
           description: ''
     post:
       operationId: createUserAccount
-      description: Δημιουργία νέου Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Λογαριασμός Χρήστη
+      description: Create a new User Account. Requires authentication.
+      summary: Create a User Account
       parameters:
         - in: query
           name: languageCode
@@ -24622,7 +24646,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24679,8 +24703,8 @@ paths:
   /api/v1/user/account/{id}:
     get:
       operationId: retrieveUserAccount
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Λογαριασμός Χρήστη.
-      summary: Ανάκτηση Λογαριασμός Χρήστη
+      description: Get detailed information about a specific User Account.
+      summary: Retrieve a User Account
       parameters:
         - in: path
           name: id
@@ -24699,7 +24723,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       security:
@@ -24737,8 +24761,8 @@ paths:
           description: ''
     put:
       operationId: updateUserAccount
-      description: Ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Λογαριασμός Χρήστη
+      description: Update User Account information. Requires authentication.
+      summary: Update a User Account
       parameters:
         - in: path
           name: id
@@ -24757,7 +24781,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24813,8 +24837,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserAccount
-      description: Μερική ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Λογαριασμός Χρήστη
+      description: Partially update User Account information. Requires authentication.
+      summary: Partially update a User Account
       parameters:
         - in: path
           name: id
@@ -24833,7 +24857,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24889,8 +24913,8 @@ paths:
   /api/v1/user/account/{id}/addresses:
     get:
       operationId: getUserAccountAddresses
-      description: Λήψη όλων των διευθύνσεων για συγκεκριμένο χρήστη.
-      summary: Λήψη διευθύνσεων χρήστη
+      description: Get all addresses for a specific user.
+      summary: Get user's addresses
       parameters:
         - in: path
           name: id
@@ -24975,8 +24999,8 @@ paths:
   /api/v1/user/account/{id}/blog_post_comments:
     get:
       operationId: getUserAccountBlogPostComments
-      description: Λήψη όλων των σχολίων σε άρθρα που έχει γράψει συγκεκριμένος χρήστης.
-      summary: Λήψη σχολίων blog χρήστη
+      description: Get all blog post comments written by a specific user.
+      summary: Get user's blog comments
       parameters:
         - in: path
           name: id
@@ -25061,8 +25085,8 @@ paths:
   /api/v1/user/account/{id}/change_username:
     post:
       operationId: changeUserAccountUsername
-      description: Αλλαγή του ονόματος χρήστη για συγκεκριμένο χρήστη.
-      summary: Αλλαγή ονόματος χρήστη
+      description: Change the username for a specific user.
+      summary: Change username
       parameters:
         - in: path
           name: id
@@ -25128,8 +25152,8 @@ paths:
   /api/v1/user/account/{id}/data_exports:
     get:
       operationId: listUserAccountDataExports
-      description: Λίστα πρόσφατων αιτημάτων εξαγωγής δεδομένων για αυτόν τον χρήστη, ώστε η διεπαφή να εμφανίζει την πρόοδο και τον τελευταίο σύνδεσμο λήψης.
-      summary: Λίστα εξαγωγών δεδομένων GDPR
+      description: List recent data-export requests for this user so the UI can show progress and the last download link.
+      summary: List GDPR data exports
       parameters:
         - in: path
           name: id
@@ -25214,8 +25238,8 @@ paths:
   /api/v1/user/account/{id}/delete_account:
     post:
       operationId: deleteUserAccountGdpr
-      description: Ανωνυμοποιεί τις παραγγελίες του χρήστη (διατηρούνται για φορολογικούς/λογιστικούς λόγους) και διαγράφει οριστικά κάθε άλλη συνδεδεμένη εγγραφή. Μη αναστρέψιμο. Ο καλών πρέπει να έχει επανα-ταυτοποιηθεί μέσω allauth εντός του χρονικού παραθύρου που ορίζεται από το ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.
-      summary: Διαγραφή λογαριασμού (δικαίωμα διαγραφής GDPR)
+      description: Anonymises the user's orders (kept for tax/accounting) and hard-deletes every other linked record. Irreversible. Caller must have re-authenticated via allauth within the window configured by ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.
+      summary: Delete account (GDPR right-to-erasure)
       parameters:
         - in: path
           name: id
@@ -25281,8 +25305,8 @@ paths:
   /api/v1/user/account/{id}/favourite_products:
     get:
       operationId: getUserAccountFavouriteProducts
-      description: Λήψη όλων των αγαπημένων προϊόντων για συγκεκριμένο χρήστη.
-      summary: Λήψη αγαπημένων προϊόντων χρήστη
+      description: Get all favourite products for a specific user.
+      summary: Get user's favourite products
       parameters:
         - in: path
           name: id
@@ -25367,8 +25391,8 @@ paths:
   /api/v1/user/account/{id}/liked_blog_posts:
     get:
       operationId: getUserAccountLikedBlogPosts
-      description: Λήψη όλων των άρθρων που έχει επισημάνει συγκεκριμένος χρήστης.
-      summary: Λήψη άρθρων με επισήμανση χρήστη
+      description: Get all blog posts liked by a specific user.
+      summary: Get user's liked blog posts
       parameters:
         - in: path
           name: id
@@ -25453,8 +25477,8 @@ paths:
   /api/v1/user/account/{id}/notifications:
     get:
       operationId: getUserAccountNotifications
-      description: Λήψη όλων των ειδοποιήσεων για συγκεκριμένο χρήστη.
-      summary: Λήψη ειδοποιήσεων χρήστη
+      description: Get all notifications for a specific user.
+      summary: Get user's notifications
       parameters:
         - in: path
           name: id
@@ -25506,7 +25530,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων κατά κατάσταση ορατότητας.
+          description: Filter notifications by seen/unseen state.
       tags:
         - User Accounts
       security:
@@ -25551,8 +25575,8 @@ paths:
   /api/v1/user/account/{id}/orders:
     get:
       operationId: getUserAccountOrders
-      description: Λήψη όλων των παραγγελιών για συγκεκριμένο χρήστη.
-      summary: Λήψη παραγγελιών χρήστη
+      description: Get all orders for a specific user.
+      summary: Get user's orders
       parameters:
         - in: path
           name: id
@@ -25637,8 +25661,8 @@ paths:
   /api/v1/user/account/{id}/product_reviews:
     get:
       operationId: getUserAccountProductReviews
-      description: Λήψη όλων των αξιολογήσεων προϊόντων που έχει γράψει συγκεκριμένος χρήστης.
-      summary: Λήψη κριτικών προϊόντος χρήστη
+      description: Get all product reviews written by a specific user.
+      summary: Get user's product reviews
       parameters:
         - in: path
           name: id
@@ -25723,8 +25747,8 @@ paths:
   /api/v1/user/account/{id}/request_data_export:
     post:
       operationId: requestUserAccountDataExport
-      description: Ουρά εργασίας που συγκεντρώνει τα προσωπικά δεδομένα του χρήστη και αποστέλλει με email έναν εφάπαξ σύνδεσμο λήψης. Επιστρέφει τη νέα εγγραφή UserDataExport.
-      summary: Αίτημα εξαγωγής δεδομένων GDPR
+      description: Queue a job that compiles the user's personal data and emails a one-off download link. Returns the new UserDataExport record.
+      summary: Request GDPR data export
       parameters:
         - in: path
           name: id
@@ -25778,14 +25802,14 @@ paths:
   /api/v1/user/address:
     get:
       operationId: listUserAddress
-      description: 'Ανάκτηση λίστας Διευθύνσεις Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Διευθύνσεις Χρηστών
+      description: 'Retrieve a list of User Addresses with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Addresses
       parameters:
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πόλης (μερική αντιστοίχιση)
+          description: Filter by city name (partial match)
         - in: query
           name: city_Icontains
           schema:
@@ -25794,17 +25818,17 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha_2 κωδικό χώρας
+          description: Filter by country alpha_2 code
         - in: query
           name: countryCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας (π.χ. 'US', 'CA')
+          description: Filter by country code (e.g., 'US', 'CA')
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -25836,12 +25860,12 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by first name (partial match)
         - in: query
           name: firstName_Icontains
           schema:
@@ -25850,7 +25874,6 @@ paths:
           name: floor
           schema:
             type: string
-            title: Όροφος
             enum:
               - ''
               - BASEMENT
@@ -25861,12 +25884,12 @@ paths:
               - SECOND_FLOOR
               - SIXTH_FLOOR_PLUS
               - THIRD_FLOOR
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: fullName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα (όνομα + επώνυμο)
+          description: Filter by full name (first + last name)
         - in: query
           name: hasNotes
           schema:
@@ -25878,7 +25901,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο διευθύνσεων με σημειώσεις
+          description: Filter addresses that have notes
         - in: query
           name: id
           schema:
@@ -25891,7 +25914,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -25909,7 +25932,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κύρια διεύθυνση
+          description: Filter by main address status
         - in: query
           name: languageCode
           schema:
@@ -25919,12 +25942,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο (μερική αντιστοίχιση)
+          description: Filter by last name (partial match)
         - in: query
           name: lastName_Icontains
           schema:
@@ -25933,7 +25956,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας (ακριβής αντιστοίχιση, χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by location type (exact match, case insensitive)
         - in: query
           name: locationType_Icontains
           schema:
@@ -25966,7 +25989,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -25975,7 +25998,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -25985,12 +26008,12 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου (μερική αντιστοίχιση)
+          description: Filter by phone number (partial match)
         - in: query
           name: phone_Icontains
           schema:
@@ -25999,17 +26022,17 @@ paths:
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά αλφαριθμητικό κωδικό περιφέρειας
+          description: Filter by region alpha code
         - in: query
           name: regionCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: regionName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: search
           required: false
           in: query
@@ -26020,7 +26043,7 @@ paths:
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά όνομα οδού (μερική αντιστοίχιση)
+          description: Filter by street name (partial match)
         - in: query
           name: street_Icontains
           schema:
@@ -26029,7 +26052,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -26078,7 +26101,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά ταχυδρομικό κώδικα (μερική αντιστοίχιση)
+          description: Filter by zipcode (partial match)
         - in: query
           name: zipcode_Icontains
           schema:
@@ -26087,7 +26110,7 @@ paths:
           name: zipcodeExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή ταχυδρομικό κώδικα
+          description: Filter by exact zipcode
       tags:
         - User Addresses
       security:
@@ -26131,8 +26154,8 @@ paths:
           description: ''
     post:
       operationId: createUserAddress
-      description: Δημιουργία νέου Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Διεύθυνση Χρήστη
+      description: Create a new User Address. Requires authentication.
+      summary: Create a User Address
       parameters:
         - in: query
           name: languageCode
@@ -26143,7 +26166,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26200,8 +26223,8 @@ paths:
   /api/v1/user/address/{id}:
     get:
       operationId: retrieveUserAddress
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Διεύθυνση Χρήστη.
-      summary: Ανάκτηση Διεύθυνση Χρήστη
+      description: Get detailed information about a specific User Address.
+      summary: Retrieve a User Address
       parameters:
         - in: path
           name: id
@@ -26220,7 +26243,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       security:
@@ -26258,8 +26281,8 @@ paths:
           description: ''
     put:
       operationId: updateUserAddress
-      description: Ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Διεύθυνση Χρήστη
+      description: Update User Address information. Requires authentication.
+      summary: Update a User Address
       parameters:
         - in: path
           name: id
@@ -26278,7 +26301,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26334,8 +26357,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserAddress
-      description: Μερική ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Διεύθυνση Χρήστη
+      description: Partially update User Address information. Requires authentication.
+      summary: Partially update a User Address
       parameters:
         - in: path
           name: id
@@ -26354,7 +26377,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26409,8 +26432,8 @@ paths:
           description: ''
     delete:
       operationId: destroyUserAddress
-      description: Διαγραφή Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Διεύθυνση Χρήστη
+      description: Delete a User Address. Requires authentication.
+      summary: Delete a User Address
       parameters:
         - in: path
           name: id
@@ -26448,8 +26471,8 @@ paths:
   /api/v1/user/address/{id}/set_main:
     post:
       operationId: setMainUserAddress
-      description: Ορισμός αυτής της διεύθυνσης ως κύριας διεύθυνσης του χρήστη.
-      summary: Ορισμός διεύθυνσης ως κύριας
+      description: Set this address as the user's main address.
+      summary: Set address as main
       parameters:
         - in: path
           name: id
@@ -26503,8 +26526,8 @@ paths:
   /api/v1/user/data_export/{token}/download:
     get:
       operationId: downloadUserDataExport
-      description: Επιστρέφει το πακέτο JSON που παρήγαγε η εργασία εξαγωγής. Το token έχει ένα μόνο πεδίο εφαρμογής, συνδέεται με μία εγγραφή UserDataExport, και λήγει 7 ημέρες μετά την παραγωγή της εξαγωγής.
-      summary: Λήψη πακέτου εξαγωγής δεδομένων GDPR
+      description: Returns the JSON bundle produced by the export task. The token is single-scope, tied to one UserDataExport row, and expires 7 days after the export was produced.
+      summary: Download a GDPR data export bundle
       parameters:
         - in: path
           name: token
@@ -26525,8 +26548,8 @@ paths:
   /api/v1/user/subscription:
     get:
       operationId: listUserSubscription
-      description: 'Ανάκτηση λίστας Συνδρομές Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Συνδρομές Χρηστών
+      description: 'Retrieve a list of User Subscriptions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Subscriptions
       parameters:
         - in: query
           name: createdAfter
@@ -26559,7 +26582,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasMetadata
           schema:
@@ -26571,7 +26594,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο εγγραφών με metadata
+          description: Filter subscriptions that have metadata
         - in: query
           name: id
           schema:
@@ -26584,7 +26607,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -26602,7 +26625,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση επιβεβαίωσης
+          description: Filter by confirmation status
         - in: query
           name: languageCode
           schema:
@@ -26612,7 +26635,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -26636,7 +26659,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -26645,7 +26668,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -26655,7 +26678,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -26666,25 +26689,24 @@ paths:
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - ACTIVE
               - BOUNCED
               - PENDING
               - UNSUBSCRIBED
           description: |-
-            Φίλτρο ανά κατάσταση συνδρομής
+            Filter by subscription status
 
-            * `ACTIVE` - Ενεργή
-            * `PENDING` - Εκκρεμεί Επιβεβαίωση
-            * `UNSUBSCRIBED` - Διαγραφή
-            * `BOUNCED` - Επιστράφηκε
+            * `ACTIVE` - Active
+            * `PENDING` - Pending Confirmation
+            * `UNSUBSCRIBED` - Unsubscribed
+            * `BOUNCED` - Bounced
         - in: query
           name: subscribedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter subscriptions created after this date
         - in: query
           name: subscribedAt_Date
           schema:
@@ -26705,7 +26727,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter subscriptions created before this date
         - in: query
           name: topic
           schema:
@@ -26713,12 +26735,11 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά θέμα συνδρομής
+          description: Filter by subscription topic
         - in: query
           name: topicCategory
           schema:
             type: string
-            title: Κατηγορία
             enum:
               - ACCOUNT
               - MARKETING
@@ -26728,41 +26749,41 @@ paths:
               - PROMOTIONAL
               - SYSTEM
           description: |-
-            Φίλτρο ανά κατηγορία θέματος
+            Filter by topic category
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         - in: query
           name: topicDescription
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή θέματος (μερική αντιστοίχιση)
+          description: Filter by topic description (partial match)
         - in: query
           name: topicName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα θέματος (μερική αντιστοίχιση)
+          description: Filter by topic name (partial match)
         - in: query
           name: topicSlug
           schema:
             type: string
-          description: Φίλτρο ανά slug θέματος (μερική αντιστοίχιση)
+          description: Filter by topic slug (partial match)
         - in: query
           name: topicSlugExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές slug θέματος
+          description: Filter by exact topic slug
         - in: query
           name: unsubscribedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών με διαγραφή μετά από αυτή την ημερομηνία
+          description: Filter subscriptions unsubscribed after this date
         - in: query
           name: unsubscribedAt_Date
           schema:
@@ -26783,7 +26804,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών με διαγραφή πριν από αυτή την ημερομηνία
+          description: Filter subscriptions unsubscribed before this date
         - in: query
           name: updatedAfter
           schema:
@@ -26859,8 +26880,8 @@ paths:
           description: ''
     post:
       operationId: createUserSubscription
-      description: Δημιουργία νέου Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Συνδρομή Χρήστη
+      description: Create a new User Subscription. Requires authentication.
+      summary: Create a User Subscription
       parameters:
         - in: query
           name: languageCode
@@ -26871,7 +26892,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -26928,8 +26949,8 @@ paths:
   /api/v1/user/subscription/{id}:
     get:
       operationId: retrieveUserSubscription
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συνδρομή Χρήστη.
-      summary: Ανάκτηση Συνδρομή Χρήστη
+      description: Get detailed information about a specific User Subscription.
+      summary: Retrieve a User Subscription
       parameters:
         - in: path
           name: id
@@ -26948,7 +26969,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       security:
@@ -26986,8 +27007,8 @@ paths:
           description: ''
     put:
       operationId: updateUserSubscription
-      description: Ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Συνδρομή Χρήστη
+      description: Update User Subscription information. Requires authentication.
+      summary: Update a User Subscription
       parameters:
         - in: path
           name: id
@@ -27006,7 +27027,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -27062,8 +27083,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserSubscription
-      description: Μερική ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Συνδρομή Χρήστη
+      description: Partially update User Subscription information. Requires authentication.
+      summary: Partially update a User Subscription
       parameters:
         - in: path
           name: id
@@ -27082,7 +27103,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -27137,8 +27158,8 @@ paths:
           description: ''
     delete:
       operationId: destroyUserSubscription
-      description: Διαγραφή Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Συνδρομή Χρήστη
+      description: Delete a User Subscription. Requires authentication.
+      summary: Delete a User Subscription
       parameters:
         - in: path
           name: id
@@ -27176,8 +27197,8 @@ paths:
   /api/v1/user/subscription/{id}/confirm:
     post:
       operationId: confirmUserSubscription
-      description: Επιβεβαίωση εκκρεμούς εγγραφής με χρήση του token επιβεβαίωσης.
-      summary: Επιβεβαίωση συνδρομής χρήστη
+      description: Confirm a pending subscription using the confirmation token.
+      summary: Confirm a user subscription
       parameters:
         - in: path
           name: id
@@ -27231,8 +27252,8 @@ paths:
   /api/v1/user/subscription/bulk_update:
     post:
       operationId: bulkUpdateUserSubscriptions
-      description: Εγγραφή ή διαγραφή από πολλαπλά θέματα ταυτόχρονα.
-      summary: Μαζική ενημέρωση συνδρομών χρήστη
+      description: Subscribe or unsubscribe from multiple topics at once.
+      summary: Bulk update user subscriptions
       tags:
         - User Subscriptions
       requestBody:
@@ -27295,7 +27316,7 @@ paths:
         The confirmation token itself is 64 chars of random entropy (sufficient
         authorization); no login required. Accepts both GET (user clicks the
         link in a mail client) and POST (for programmatic confirmation).
-      summary: Επιβεβαίωση εκκρεμούς εγγραφής μέσω token email
+      summary: Confirm a pending subscription via email token
       parameters:
         - in: path
           name: token
@@ -27355,14 +27376,13 @@ paths:
   /api/v1/user/subscription/topic:
     get:
       operationId: listSubscriptionTopic
-      description: 'Ανάκτηση λίστας Θέματα Συνδρομών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Θέματα Συνδρομών
+      description: 'Retrieve a list of Subscription Topics with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Subscription Topics
       parameters:
         - in: query
           name: category
           schema:
             type: string
-            title: Κατηγορία
             enum:
               - ACCOUNT
               - MARKETING
@@ -27372,15 +27392,15 @@ paths:
               - PROMOTIONAL
               - SYSTEM
           description: |-
-            Φίλτρο ανά κατηγορία θέματος
+            Filter by topic category
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         - in: query
           name: createdAfter
           schema:
@@ -27412,12 +27432,12 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: description
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+          description: Filter by description (partial match)
         - in: query
           name: hasSubscribers
           schema:
@@ -27429,7 +27449,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο θεμάτων με εγγεγραμμένους
+          description: Filter topics that have subscribers
         - in: query
           name: id
           schema:
@@ -27442,7 +27462,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -27460,7 +27480,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: isDefault
           schema:
@@ -27472,7 +27492,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά προεπιλεγμένη κατάσταση εγγραφής
+          description: Filter by default subscription status
         - in: query
           name: languageCode
           schema:
@@ -27482,12 +27502,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by name (partial match)
         - name: ordering
           in: query
           required: false
@@ -27511,7 +27531,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -27520,7 +27540,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -27530,7 +27550,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: requiresConfirmation
           schema:
@@ -27542,7 +27562,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά απαίτηση επιβεβαίωσης
+          description: Filter by confirmation requirement
         - name: search
           required: false
           in: query
@@ -27553,7 +27573,7 @@ paths:
           name: slug
           schema:
             type: string
-          description: Φίλτρο ανά slug (μερική αντιστοίχιση)
+          description: Filter by slug (partial match)
         - in: query
           name: slug_Icontains
           schema:
@@ -27562,7 +27582,7 @@ paths:
           name: slugExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές slug
+          description: Filter by exact slug
         - in: query
           name: updatedAfter
           schema:
@@ -27638,8 +27658,8 @@ paths:
           description: ''
     post:
       operationId: createSubscriptionTopic
-      description: Δημιουργία νέου Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Θέμα Συνδρομής
+      description: Create a new Subscription Topic. Requires authentication.
+      summary: Create a Subscription Topic
       parameters:
         - in: query
           name: languageCode
@@ -27650,7 +27670,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27707,8 +27727,8 @@ paths:
   /api/v1/user/subscription/topic/{id}:
     get:
       operationId: retrieveSubscriptionTopic
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Θέμα Συνδρομής.
-      summary: Ανάκτηση Θέμα Συνδρομής
+      description: Get detailed information about a specific Subscription Topic.
+      summary: Retrieve a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27727,7 +27747,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       security:
@@ -27765,8 +27785,8 @@ paths:
           description: ''
     put:
       operationId: updateSubscriptionTopic
-      description: Ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Θέμα Συνδρομής
+      description: Update Subscription Topic information. Requires authentication.
+      summary: Update a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27785,7 +27805,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27841,8 +27861,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateSubscriptionTopic
-      description: Μερική ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Θέμα Συνδρομής
+      description: Partially update Subscription Topic information. Requires authentication.
+      summary: Partially update a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27861,7 +27881,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27916,8 +27936,8 @@ paths:
           description: ''
     delete:
       operationId: destroySubscriptionTopic
-      description: Διαγραφή Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Θέμα Συνδρομής
+      description: Delete a Subscription Topic. Requires authentication.
+      summary: Delete a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27955,8 +27975,8 @@ paths:
   /api/v1/user/subscription/topic/{id}/subscribe:
     post:
       operationId: subscribeToTopic
-      description: Εγγραφή του τρέχοντος χρήστη σε συγκεκριμένο θέμα εγγραφής.
-      summary: Εγγραφή σε θέμα
+      description: Subscribe the current user to a specific subscription topic.
+      summary: Subscribe to a topic
       parameters:
         - in: path
           name: id
@@ -28016,8 +28036,8 @@ paths:
   /api/v1/user/subscription/topic/{id}/unsubscribe:
     post:
       operationId: unsubscribeFromTopic
-      description: Διαγραφή του τρέχοντος χρήστη από συγκεκριμένο θέμα εγγραφής.
-      summary: Διαγραφή από θέμα
+      description: Unsubscribe the current user from a specific subscription topic.
+      summary: Unsubscribe from a topic
       parameters:
         - in: path
           name: id
@@ -28071,8 +28091,8 @@ paths:
   /api/v1/user/subscription/topic/my_subscriptions:
     get:
       operationId: getMySubscriptionTopics
-      description: Λήψη των θεμάτων εγγραφής στα οποία είναι εγγεγραμμένος και των διαθέσιμων θεμάτων για τον τρέχοντα χρήστη.
-      summary: Λήψη συνδρομών μου
+      description: Get the current user's subscribed and available subscription topics.
+      summary: Get my subscriptions
       tags:
         - Subscription Topics
       security:
@@ -28131,7 +28151,7 @@ paths:
 
         Unsubscribes from ALL active subscriptions — used by emails without a
         topic binding such as re-engagement and abandoned-cart.
-      summary: Διαγραφή από όλα τα θέματα μέσω συνδέσμου email (GET)
+      summary: Unsubscribe from all topics via email link (GET)
       parameters:
         - in: path
           name: token
@@ -28155,8 +28175,8 @@ paths:
           description: ''
     post:
       operationId: unsubscribeFromAllOneClick
-      description: Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).
-      summary: Διαγραφή με ένα κλικ από όλα τα θέματα κατά RFC 8058
+      description: Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).
+      summary: RFC 8058 one-click unsubscribe from all topics
       parameters:
         - in: path
           name: token
@@ -28175,7 +28195,7 @@ paths:
         Topic-scoped unsubscribe: `/unsubscribe/<token>/<topic_slug>`.
 
         Used by marketing emails with a specific List-ID (newsletter etc.).
-      summary: Διαγραφή από θέμα μέσω συνδέσμου email (GET)
+      summary: Unsubscribe from a topic via email link (GET)
       parameters:
         - in: path
           name: token
@@ -28204,8 +28224,8 @@ paths:
           description: ''
     post:
       operationId: unsubscribeFromTopicOneClick
-      description: Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).
-      summary: Διαγραφή με ένα κλικ από θέμα κατά RFC 8058
+      description: Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).
+      summary: RFC 8058 one-click unsubscribe from a topic
       parameters:
         - in: path
           name: token
@@ -28333,8 +28353,8 @@ components:
         - 2
       type: integer
       description: |-
-        * `1` - Προπληρωμένο
-        * `2` - Αντικαταβολή
+        * `1` - Prepaid
+        * `2` - Cash on delivery
     AcsPickupList:
       type: object
       properties:
@@ -28344,19 +28364,17 @@ components:
         pickupListNo:
           type: string
           readOnly: true
-          title: Αριθμός λίστας παραλαβής
-          description: PickupList_No που επιστρέφεται από το ACS_Issue_Pickup_List.
+          title: Pickup list number
+          description: PickupList_No returned by ACS_Issue_Pickup_List.
         issuedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εκδόθηκε στις
         issuedBy:
           type: integer
           readOnly: true
           nullable: true
-          title: Εκδόθηκε από
-          description: Διαχειριστής που ενεργοποίησε τη χειροκίνητη έκδοση. Null όταν η λίστα εκδόθηκε από την καθημερινή εργασία Celery beat.
+          description: Admin who triggered the manual issue. Null when the daily Celery beat task issued the list.
         issuedByUsername:
           type: string
           nullable: true
@@ -28364,22 +28382,18 @@ components:
         billingCode:
           type: string
           readOnly: true
-          title: Κωδικός χρέωσης
-          description: Billing_Code που καταγράφεται τη στιγμή της έκδοσης, ώστε τα ιστορικά manifest να παραμένουν επανεκτυπώσιμα ακόμη κι αν αλλάξει η μεταβλητή περιβάλλοντος.
+          description: Billing_Code captured at issuance time so historical manifests stay reprintable even if the env var changes.
         voucherCount:
           type: integer
           readOnly: true
-          title: Πλήθος vouchers
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - billingCode
         - createdAt
@@ -28405,103 +28419,92 @@ components:
           type: string
           readOnly: true
           nullable: true
-          title: Αριθμός voucher
-          description: 10ψήφιο voucher ACS (Voucher_No από το ACS_Create_Voucher).
+          title: Voucher number
+          description: 10-digit ACS voucher (Voucher_No from ACS_Create_Voucher).
         shipmentState:
           allOf:
             - $ref: '#/components/schemas/ShipmentStateEnum'
           readOnly: true
-          title: Κατάσταση αποστολής
         shipmentStateDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή shipment_state
+          description: Human-readable label for the shipment_state choice
         deliveryKind:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
           readOnly: true
-          title: Τρόπος παράδοσης
         weightGrams:
           type: integer
           readOnly: true
-          title: Βάρος (γραμμάρια)
-          description: Εσωτερικά γραμμάρια· μετατρέπονται σε κιλά (>= 0,5) κατά την κλήση API σύμφωνα με τις απαιτήσεις βάρους της ACS.
+          title: Weight (grams)
+          description: Internal grams; converted to kilograms (>= 0.5) at API call time per ACS Weight requirements.
         itemQuantity:
           type: integer
           readOnly: true
-          title: Ποσότητα ειδών
         chargeType:
           allOf:
             - $ref: '#/components/schemas/AcsChargeType'
           readOnly: true
-          title: Τύπος χρέωσης
         deliveryProducts:
           type: string
           readOnly: true
-          title: Προϊόντα παράδοσης
-          description: Κωδικοί Acs_Delivery_Products διαχωρισμένοι με κόμμα (COD, REC, SAT, RDO …).
+          description: Comma-separated Acs_Delivery_Products codes (COD, REC, SAT, RDO …).
         lastEventAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίο συμβάν
         lastPolledAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταία ανάκτηση
-          description: Χρησιμοποιείται από το poll_acs_tracking_batch για κατανομή φορτίου και παράλειψη αποστολών που ελέγχθηκαν τα τελευταία 15 λεπτά.
+          description: Used by poll_acs_tracking_batch to spread load and skip shipments polled within the last 15 minutes.
         deliveryDate:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ημερομηνία παράδοσης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         stationDestinationExternalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID καταστήματος προορισμού
-          description: Μη κανονικοποιημένο ACS_SHOP_STATION_ID — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή AcsStation.
+          title: Destination station external ID
+          description: Denormalised ACS_SHOP_STATION_ID — preserved even if the AcsStation row is deleted.
         stationBranchDestination:
           type: string
           readOnly: true
-          title: Υποκατάστημα προορισμού
-          description: Τιμή Acs_Station_Branch_Destination.
+          title: Destination branch
+          description: Acs_Station_Branch_Destination value.
         station:
           allOf:
             - $ref: '#/components/schemas/AcsStation'
           nullable: true
           readOnly: true
-          description: Στοιχεία καταστήματος προορισμού ACS (παραλαβές Smartpoint).
+          description: Destination ACS station details (Smartpoint pickups).
         events:
           type: array
           items:
             $ref: '#/components/schemas/AcsTrackingEvent'
           readOnly: true
-          description: Τελευταία 50 συμβάντα παρακολούθησης ταξινομημένα κατά event_time φθίνουσα.
+          description: Last 50 tracking events ordered by event_time desc.
         labelUrl:
           type: string
           nullable: true
-          description: Σχετικό URL για λήψη του PDF voucher μέσω του proxy Django.
+          description: Relative URL to download the voucher PDF via the Django proxy.
           readOnly: true
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Αίτημα ακύρωσης στις
       required:
         - cancelRequestedAt
         - chargeType
@@ -28542,50 +28545,42 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
-          description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το ''ATH'')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.'
+          description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under ''ATH''); the (external_id, branch_code) pair is the locker''s identity.'
         branchCode:
           type: string
           readOnly: true
           default: ''
-          title: Κωδικός υποκαταστήματος
-          description: ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+          description: ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
         shopKind:
           allOf:
             - $ref: '#/components/schemas/ShopKindEnum'
           readOnly: true
-          title: Είδος καταστήματος
           description: |-
-            ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
+            ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
 
-            * `1` - Κατάστημα
-            * `2` - Συνεργαζόμενο κατάστημα (2)
-            * `3` - Συνεργαζόμενο κατάστημα (3)
+            * `1` - Shop
+            * `2` - Partner shop (2)
+            * `3` - Partner shop (3)
             * `4` - Xpress Point
             * `5` - Kiosk
-            * `7` - Smartpoint (χωρίς locker)
+            * `7` - Smartpoint (no locker)
             * `8` - Smartpoint locker
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         city:
           type: string
           readOnly: true
-          title: Πόλη
         postalCode:
           type: string
           readOnly: true
-          title: Ταχυδρομικός κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας.
+          description: ISO 3166-1 alpha-2 country code.
         lat:
           type: string
           nullable: true
@@ -28600,27 +28595,22 @@ components:
         workingHours:
           type: string
           readOnly: true
-          title: Ωράριο λειτουργίας
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - addressLine1
         - branchCode
@@ -28658,50 +28648,42 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
-          description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το ''ATH'')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.'
+          description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under ''ATH''); the (external_id, branch_code) pair is the locker''s identity.'
         branchCode:
           type: string
           readOnly: true
           default: ''
-          title: Κωδικός υποκαταστήματος
-          description: ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+          description: ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
         shopKind:
           allOf:
             - $ref: '#/components/schemas/ShopKindEnum'
           readOnly: true
-          title: Είδος καταστήματος
           description: |-
-            ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
+            ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
 
-            * `1` - Κατάστημα
-            * `2` - Συνεργαζόμενο κατάστημα (2)
-            * `3` - Συνεργαζόμενο κατάστημα (3)
+            * `1` - Shop
+            * `2` - Partner shop (2)
+            * `3` - Partner shop (3)
             * `4` - Xpress Point
             * `5` - Kiosk
-            * `7` - Smartpoint (χωρίς locker)
+            * `7` - Smartpoint (no locker)
             * `8` - Smartpoint locker
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         city:
           type: string
           readOnly: true
-          title: Πόλη
         postalCode:
           type: string
           readOnly: true
-          title: Ταχυδρομικός κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας.
+          description: ISO 3166-1 alpha-2 country code.
         lat:
           type: string
           nullable: true
@@ -28716,35 +28698,28 @@ components:
         workingHours:
           type: string
           readOnly: true
-          title: Ωράριο λειτουργίας
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         region:
           type: string
           readOnly: true
-          title: Περιοχή
         phone:
           type: string
           readOnly: true
@@ -28781,29 +28756,24 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ώρα συμβάντος
-          description: Checkpoint_Date_Time από το ACS_TrackingDetails.
+          description: Checkpoint_Date_Time from ACS_TrackingDetails.
         checkpointAction:
           type: string
           readOnly: true
-          title: Ενέργεια σημείου ελέγχου
-          description: Checkpoint_Action_Description — κείμενο στα ελληνικά σε αναγνώσιμη μορφή που περιγράφει το συμβάν.
+          description: Checkpoint_Action_Description — human-readable Greek text describing the event.
         checkpointLocation:
           type: string
           readOnly: true
-          title: Σημείο ελέγχου
           description: Checkpoint_Location_Description.
         notes:
           type: string
           readOnly: true
-          title: Σημειώσεις
-          description: Πεδίο σχολίων ACS.
+          description: ACS Comments field.
         receivedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Παραλήφθηκε στις
-          description: Πραγματικός χρόνος κατά τον οποίο η εργασία παρακολούθησης παρατήρησε αυτό το συμβάν.
+          description: Wall-clock time when the polling task observed this event.
       required:
         - checkpointAction
         - checkpointLocation
@@ -28918,12 +28888,10 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         valuesCount:
           type: integer
           readOnly: true
@@ -28934,12 +28902,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -28986,12 +28952,10 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: integer
           readOnly: true
@@ -28999,12 +28963,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - attribute
         - attributeName
@@ -29054,18 +29016,16 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         numberOfPosts:
           type: integer
           readOnly: true
@@ -29123,18 +29083,16 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         numberOfPosts:
           type: integer
           readOnly: true
@@ -29192,7 +29150,6 @@ components:
         user:
           type: integer
         website:
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -29247,7 +29204,6 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postCount:
           type: integer
           description: |-
@@ -29269,12 +29225,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - hasChildren
@@ -29331,7 +29285,6 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postCount:
           type: integer
           description: |-
@@ -29353,12 +29306,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         children:
           type: array
           items:
@@ -29412,10 +29363,10 @@ components:
       properties:
         id:
           type: integer
-          description: ID κατηγορίας
+          description: Category ID
         sortOrder:
           type: integer
-          description: Νέα τιμή σειράς ταξινόμησης
+          description: New sort order value
       required:
         - id
         - sortOrder
@@ -29426,7 +29377,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BlogCategoryReorderItemRequest'
-          description: Λίστα κατηγοριών με νέες σειρές ταξινόμησης
+          description: List of categories with new sort orders
       required:
         - categories
     BlogCategoryReorderResponse:
@@ -29434,10 +29385,10 @@ components:
       properties:
         updatedCount:
           type: integer
-          description: Αριθμός ενημερωμένων κατηγοριών
+          description: Number of categories updated
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
       required:
         - message
         - updatedCount
@@ -29518,11 +29469,11 @@ components:
           type: string
           nullable: true
           readOnly: true
-          description: Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+          description: First 150 characters of the comment content
         isReply:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+          description: Whether this comment is a reply to another comment
         parent:
           type: integer
           readOnly: true
@@ -29530,15 +29481,14 @@ components:
         hasReplies:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+          description: Whether this comment has approved replies
         approved:
           type: boolean
           readOnly: true
-          title: Εγκεκριμένο
         isEdited:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει επεξεργαστεί
+          description: Whether this comment has been edited
         likesCount:
           type: integer
           readOnly: true
@@ -29548,17 +29498,15 @@ components:
         userHasLiked:
           type: boolean
           readOnly: true
-          description: Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+          description: Whether the current user has liked this comment
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -29612,11 +29560,11 @@ components:
           type: string
           nullable: true
           readOnly: true
-          description: Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+          description: First 150 characters of the comment content
         isReply:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+          description: Whether this comment is a reply to another comment
         parent:
           type: integer
           readOnly: true
@@ -29624,15 +29572,14 @@ components:
         hasReplies:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+          description: Whether this comment has approved replies
         approved:
           type: boolean
           readOnly: true
-          title: Εγκεκριμένο
         isEdited:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει επεξεργαστεί
+          description: Whether this comment has been edited
         likesCount:
           type: integer
           readOnly: true
@@ -29642,17 +29589,15 @@ components:
         userHasLiked:
           type: boolean
           readOnly: true
-          description: Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+          description: Whether the current user has liked this comment
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -29661,7 +29606,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/BlogPost'
           readOnly: true
-          description: Βασικές πληροφορίες για το άρθρο
+          description: Basic information about the blog post
         parentComment:
           type: object
           nullable: true
@@ -29681,13 +29626,13 @@ components:
             - user
             - createdAt
           readOnly: true
-          description: Γονικό σχόλιο, αν πρόκειται για απάντηση
+          description: Parent comment if this is a reply
         childrenComments:
           type: array
           items:
             $ref: '#/components/schemas/BlogComment'
           readOnly: true
-          description: Άμεσα εγκεκριμένα θυγατρικά σχόλια (απαντήσεις)
+          description: Direct approved child comments (replies)
         ancestorsPath:
           type: array
           items:
@@ -29704,7 +29649,7 @@ components:
               - contentPreview
               - user
           readOnly: true
-          description: Διαδρομή από το ριζικό σχόλιο έως αυτό
+          description: Path from root comment to this comment
         treePosition:
           type: object
           properties:
@@ -29722,7 +29667,7 @@ components:
             - approvedDescendantsCount
             - siblingsCount
           readOnly: true
-          description: Πληροφορίες θέσης στο δέντρο σχολίων
+          description: Position information in the comment tree
       required:
         - ancestorsPath
         - approved
@@ -29751,7 +29696,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID σχολίων για έλεγχο κατάστασης επισήμανσης
+          description: List of comment IDs to check like status for
       required:
         - commentIds
     BlogCommentLikedCommentsResponse:
@@ -29761,7 +29706,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID σχολίων που έχει επισημάνει ο τρέχων χρήστης
+          description: List of comment IDs that are liked by the current user
       required:
         - likedCommentIds
     BlogCommentWriteRequest:
@@ -29853,11 +29798,9 @@ components:
             type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         likesCount:
           type: integer
           description: Return likes count from annotation or query database.
@@ -29872,23 +29815,19 @@ components:
           readOnly: true
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         mainImagePath:
           type: string
           readOnly: true
@@ -29982,11 +29921,9 @@ components:
           readOnly: true
         featured:
           type: boolean
-          title: Προβεβλημένο
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         likesCount:
           type: integer
           description: Return likes count from annotation or query database.
@@ -30001,23 +29938,19 @@ components:
           readOnly: true
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         mainImagePath:
           type: string
           readOnly: true
@@ -30032,15 +29965,12 @@ components:
           readOnly: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - author
@@ -30069,7 +29999,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID άρθρων για έλεγχο επισημάνσεων
+          description: List of post IDs to check for likes
       required:
         - postIds
     BlogPostLikedPostsResponse:
@@ -30079,12 +30009,27 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID άρθρων με επισήμανση
+          description: List of liked post IDs
       required:
         - postIds
     BlogPostMeiliSearchResponse:
       type: object
+      description: |-
+        Common disclosure fields every search response carries.
+
+        ``query_id`` attributes later clicks to this query (see the
+        ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+        query the zero-result fallback actually matched, so clients can
+        disclose "showing results for …" instead of silently swapping.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
         offset:
@@ -30099,6 +30044,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     BlogPostMeiliSearchResult:
       type: object
@@ -30189,21 +30136,16 @@ components:
           type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - author
@@ -30237,26 +30179,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postsCount:
           type: string
           readOnly: true
-          description: Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+          description: Number of blog posts using this tag
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30296,26 +30234,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postsCount:
           type: string
           readOnly: true
-          description: Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+          description: Number of blog posts using this tag
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30352,7 +30286,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
       required:
         - translations
     BoxNowCustomerRequest:
@@ -30361,23 +30294,23 @@ components:
       properties:
         name:
           type: string
-          description: Πλήρες όνομα πελάτη
+          description: Customer full name
         email:
           type: string
-          description: Email πελάτη
+          description: Customer email address
         phoneNumber:
           type: string
-          description: Τηλέφωνο πελάτη
+          description: Customer phone number
     BoxNowEventLocationRequest:
       type: object
       description: Nested ``eventLocation`` object within a BoxNow webhook payload.
       properties:
         displayName:
           type: string
-          description: Όνομα locker ή hub σε αναγνώσιμη μορφή
+          description: Human-readable locker or hub name
         postalCode:
           type: string
-          description: Ταχυδρομικός κώδικας της τοποθεσίας του συμβάντος
+          description: Postal code of the event location
     BoxNowLocker:
       type: object
       description: |-
@@ -30392,19 +30325,16 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
           description: BoxNow APM identifier (string)
         type:
           allOf:
             - $ref: '#/components/schemas/TypeEnum'
           readOnly: true
-          title: Τύπος
         imageUrl:
           type: string
           format: uri
           readOnly: true
           nullable: true
-          title: URL εικόνας
         lat:
           type: number
           format: double
@@ -30413,7 +30343,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό πλάτος
+          title: Latitude
         lng:
           type: number
           format: double
@@ -30422,32 +30352,26 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό μήκος
+          title: Longitude
         title:
           type: string
           readOnly: true
-          title: Τίτλος
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
@@ -30455,24 +30379,20 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
-          description: Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+          description: Timestamp of the most recent sync from BoxNow API
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30510,19 +30430,16 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
           description: BoxNow APM identifier (string)
         type:
           allOf:
             - $ref: '#/components/schemas/TypeEnum'
           readOnly: true
-          title: Τύπος
         imageUrl:
           type: string
           format: uri
           readOnly: true
           nullable: true
-          title: URL εικόνας
         lat:
           type: number
           format: double
@@ -30531,7 +30448,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό πλάτος
+          title: Latitude
         lng:
           type: number
           format: double
@@ -30540,32 +30457,26 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό μήκος
+          title: Longitude
         title:
           type: string
           readOnly: true
-          title: Τίτλος
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
@@ -30573,24 +30484,20 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
-          description: Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+          description: Timestamp of the most recent sync from BoxNow API
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30625,30 +30532,30 @@ components:
         city:
           type: string
           minLength: 1
-          description: Όνομα πόλης για αναζήτηση πλησιέστερου locker
+          description: City name for nearest-locker lookup
           maxLength: 128
         street:
           type: string
           minLength: 1
-          description: Οδός και αριθμός
+          description: Street name and number
           maxLength: 255
         postalCode:
           type: string
           minLength: 1
-          description: Ταχυδρομικός κώδικας
+          description: Postal / ZIP code
           maxLength: 16
         region:
           type: string
           minLength: 1
           default: el-GR
-          description: 'Ετικέτα γλώσσας IETF / κωδικός περιφέρειας (προεπιλογή: el-GR)'
+          description: 'IETF language tag / region code (default: el-GR)'
           maxLength: 8
         compartmentSize:
           type: integer
           maximum: 3
           minimum: 1
           default: 1
-          description: 'Απαιτούμενο μέγεθος θυρίδας: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο'
+          description: 'Required compartment size: 1=Small, 2=Medium, 3=Large'
       required:
         - city
         - postalCode
@@ -30666,60 +30573,60 @@ components:
         id:
           type: string
           readOnly: true
-          description: Αναγνωριστικό APM BoxNow
+          description: BoxNow APM identifier
         type:
           type: string
           readOnly: true
-          description: Τύπος locker (π.χ. apm, warehouse)
+          description: Locker type (e.g. apm, warehouse)
         image:
           type: string
           readOnly: true
-          description: URL εικόνας locker
+          description: URL of locker image
         lat:
           type: string
           readOnly: true
-          description: Γεωγραφικό πλάτος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+          description: Latitude (string as returned by BoxNow)
         lng:
           type: string
           readOnly: true
-          description: Γεωγραφικό μήκος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+          description: Longitude (string as returned by BoxNow)
         title:
           type: string
           readOnly: true
-          description: Σύντομος τίτλος εμφάνισης
+          description: Short display title
         name:
           type: string
           readOnly: true
-          description: Πλήρες όνομα locker
+          description: Full locker name
         postalCode:
           type: string
           readOnly: true
-          description: Ταχ. κώδικας του locker
+          description: Postal code of the locker
         country:
           type: string
           readOnly: true
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
-          description: Λειτουργική σημείωση από BoxNow
+          description: Operational note from BoxNow
         addressLine1:
           type: string
           readOnly: true
-          description: Κύρια γραμμή διεύθυνσης
+          description: Primary address line
         addressLine2:
           type: string
           readOnly: true
-          description: Δευτερεύουσα γραμμή διεύθυνσης
+          description: Secondary address line
         region:
           type: string
           readOnly: true
-          description: Ετικέτα περιφέρειας IETF που επιστρέφεται από το BoxNow
+          description: IETF region tag returned by BoxNow
         distance:
           type: number
           format: double
           readOnly: true
-          description: Απόσταση από τη δεδομένη διεύθυνση σε χιλιόμετρα
+          description: Distance from the supplied address in kilometres
       required:
         - addressLine1
         - addressLine2
@@ -30749,68 +30656,59 @@ components:
         webhookMessageId:
           type: string
           readOnly: true
-          title: ID μηνύματος webhook
-          description: Πεδίο 'id' του CloudEvents — κλειδί ιδεμποτεντίας
+          description: CloudEvents 'id' field — idempotency key
         eventType:
           allOf:
             - $ref: '#/components/schemas/BoxNowParcelState'
           readOnly: true
-          title: Τύπος συμβάντος
           description: |-
-            Συμβάν BoxNow αντιστοιχισμένο από το πεδίο 'event' του webhook
+            BoxNow event mapped from the webhook 'event' field
 
-            * `pending_creation` - Εκκρεμής δημιουργία
-            * `new` - Νέο
-            * `in_depot` - Σε αποθήκη
-            * `final_destination` - Στο locker
-            * `delivered` - Παραδόθηκε
-            * `returned` - Επιστράφηκε
-            * `expired` - Έληξε
-            * `canceled` - Ακυρώθηκε
-            * `accepted_for_return` - Αποδεκτό για επιστροφή
-            * `accepted_to_locker` - Αποδεκτό σε locker
-            * `missing` - Λείπει
-            * `lost` - Χάθηκε
+            * `pending_creation` - Pending creation
+            * `new` - New
+            * `in_depot` - In depot
+            * `final_destination` - At locker
+            * `delivered` - Delivered
+            * `returned` - Returned
+            * `expired` - Expired
+            * `canceled` - Canceled
+            * `accepted_for_return` - Accepted for return
+            * `accepted_to_locker` - Accepted to locker
+            * `missing` - Missing
+            * `lost` - Lost
         eventTypeDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή event_type
+          description: Human-readable label for the event_type choice
         parcelState:
           type: string
           readOnly: true
-          title: Κατάσταση Δέματος
-          description: Ακατέργαστη τιμή 'data.parcelState' από το payload του webhook BoxNow
+          description: Raw 'data.parcelState' value from BoxNow webhook payload
         eventTime:
           type: string
           format: date-time
           readOnly: true
-          title: Ώρα συμβάντος
-          description: Χρονοσήμανση από το 'data.time' στο payload του webhook
+          description: Timestamp from 'data.time' in the webhook payload
         displayName:
           type: string
           readOnly: true
-          title: Εμφανιζόμενο όνομα
           description: data.eventLocation.displayName
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
           description: data.eventLocation.postalCode
         additionalInformation:
           type: string
           readOnly: true
-          title: Πρόσθετες Πληροφορίες
         receivedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Παραλήφθηκε στις
-          description: Χρονοσήμανση λήψης του webhook από το GrooveShop (διαφορετική από το event_time)
+          description: Timestamp when GrooveShop received the webhook (separate from event_time)
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - additionalInformation
         - createdAt
@@ -30839,18 +30737,18 @@ components:
         - lost
       type: string
       description: |-
-        * `pending_creation` - Εκκρεμής δημιουργία
-        * `new` - Νέο
-        * `in_depot` - Σε αποθήκη
-        * `final_destination` - Στο locker
-        * `delivered` - Παραδόθηκε
-        * `returned` - Επιστράφηκε
-        * `expired` - Έληξε
-        * `canceled` - Ακυρώθηκε
-        * `accepted_for_return` - Αποδεκτό για επιστροφή
-        * `accepted_to_locker` - Αποδεκτό σε locker
-        * `missing` - Λείπει
-        * `lost` - Χάθηκε
+        * `pending_creation` - Pending creation
+        * `new` - New
+        * `in_depot` - In depot
+        * `final_destination` - At locker
+        * `delivered` - Delivered
+        * `returned` - Returned
+        * `expired` - Expired
+        * `canceled` - Canceled
+        * `accepted_for_return` - Accepted for return
+        * `accepted_to_locker` - Accepted to locker
+        * `missing` - Missing
+        * `lost` - Lost
     BoxNowShipmentDetail:
       type: object
       description: |-
@@ -30878,75 +30776,66 @@ components:
           type: string
           readOnly: true
           nullable: true
-          title: Αναγνωριστικό αιτήματος παράδοσης
-          description: ID αιτήματος παράδοσης BoxNow που επιστρέφεται από το POST /api/v1/delivery-requests
+          description: BoxNow delivery-request ID returned from POST /api/v1/delivery-requests
         parcelId:
           type: string
           readOnly: true
           nullable: true
-          title: ID δέματος
-          description: 10ψήφιος αριθμός BoxNow voucher
+          description: 10-digit BoxNow voucher number
         lockerExternalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID locker
-          description: Μη κανονικοποιημένο ID APM BoxNow — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή BoxNowLocker
+          description: Denormalised BoxNow APM ID — preserved even if the BoxNowLocker row is deleted
         parcelState:
           allOf:
             - $ref: '#/components/schemas/BoxNowParcelState'
           readOnly: true
-          title: Κατάσταση Δέματος
         parcelStateDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή parcel_state
+          description: Human-readable label for the parcel_state choice
         compartmentSize:
           allOf:
             - $ref: '#/components/schemas/CompartmentSizeEnum'
           readOnly: true
-          title: Μέγεθος θυρίδας
         paymentMode:
           allOf:
             - $ref: '#/components/schemas/PaymentModeEnum'
           readOnly: true
-          title: Τρόπος πληρωμής
         lastEventAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίο συμβάν
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         locker:
           allOf:
             - $ref: '#/components/schemas/BoxNowLocker'
           nullable: true
           readOnly: true
-          description: Ενσωματωμένα στοιχεία locker BoxNow
+          description: Nested BoxNow locker details
         events:
           type: array
           items:
             $ref: '#/components/schemas/BoxNowParcelEvent'
           readOnly: true
-          description: Τελευταία 20 συμβάντα δέματος ταξινομημένα κατά event_time φθίνουσα
+          description: Last 20 parcel events ordered by event_time desc
         labelUrl:
           type: string
           nullable: true
-          description: Σχετικό URL για λήψη του PDF ετικέτας δέματος μέσω του endpoint proxy Django
+          description: Relative URL to download the parcel label PDF via the Django proxy endpoint
           readOnly: true
         weightGrams:
           type: integer
           readOnly: true
-          title: Βάρος (γραμμάρια)
+          title: Weight (grams)
         amountToBeCollected:
           type: number
           format: double
@@ -30955,18 +30844,15 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Ποσό προς Είσπραξη
-          description: Ποσό που εισπράττεται κατά την παράδοση (PoG / COD). Πάντα 0 στη Φάση 1.
+          description: Amount collected at delivery (PoG / COD). Always 0 in Phase 1.
         allowReturn:
           type: boolean
           readOnly: true
-          title: Επιτρέπεται επιστροφή
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ημερομηνία αιτήματος ακύρωσης
       required:
         - allowReturn
         - amountToBeCollected
@@ -31000,40 +30886,40 @@ components:
         parcelId:
           type: string
           minLength: 1
-          description: 10ψήφιος αριθμός voucher/δέματος BoxNow
+          description: 10-digit BoxNow voucher/parcel number
         parcelState:
           type: string
           minLength: 1
-          description: Λεξιλόγιο κατάστασης δέματος BoxNow (data.parcelState)
+          description: BoxNow parcel state vocabulary (data.parcelState)
         parcelReferenceNumber:
           type: string
-          description: Προαιρετικός αριθμός αναφοράς εμπόρου
+          description: Optional merchant reference number
         parcelName:
           type: string
-          description: Προαιρετικό όνομα δέματος
+          description: Optional descriptive parcel name
         orderNumber:
           type: string
           minLength: 1
-          description: Αριθμός παραγγελίας εμπόρου που αποστέλλεται κατά τη δημιουργία αιτήματος παράδοσης
+          description: Merchant order number sent during delivery-request creation
         event:
           type: string
           minLength: 1
-          description: Συμβολοσειρά τύπου συμβάντος BoxNow (π.χ. 'in-depot', 'final-destination', 'delivered')
+          description: BoxNow event type string (e.g. 'in-depot', 'final-destination', 'delivered')
         eventLocation:
           allOf:
             - $ref: '#/components/schemas/BoxNowEventLocationRequest'
-          description: Πλαίσιο τοποθεσίας συμβάντος
+          description: Location context for this event
         customer:
           allOf:
             - $ref: '#/components/schemas/BoxNowCustomerRequest'
-          description: Στοιχεία πελάτη που σχετίζονται με το δέμα
+          description: Customer details associated with the parcel
         additionalInformation:
           type: string
-          description: Ελεύθερο κείμενο με επιπλέον πληροφορίες από το BoxNow
+          description: Free-text additional information from BoxNow
         time:
           type: string
           format: date-time
-          description: Χρονοσήμανση όταν συνέβη το συμβάν στο BoxNow
+          description: Timestamp when the event occurred at BoxNow
       required:
         - event
         - orderNumber
@@ -31053,40 +30939,40 @@ components:
         specversion:
           type: string
           minLength: 1
-          description: 'Έκδοση προδιαγραφής CloudEvents (αναμενόμενη: ''1.0'')'
+          description: 'CloudEvents specification version (expected: ''1.0'')'
         type:
           type: string
           minLength: 1
-          description: 'Τύπος συμβάντος (αναμενόμενος: ''gr.boxnow.parcel_event_change'')'
+          description: 'Event type (expected: ''gr.boxnow.parcel_event_change'')'
         source:
           type: string
           format: uri
           minLength: 1
-          description: URL προέλευσης πηγής συμβάντος
+          description: Origin URL of the event source
         subject:
           type: string
           minLength: 1
-          description: Θέμα του συμβάντος (συνήθως το ID δέματος)
+          description: Subject of the event (typically the parcel ID)
         id:
           type: string
           minLength: 1
-          description: Μοναδικό ID CloudEvents· χρησιμοποιείται ως κλειδί ιδεμποτεντίας (αποθηκεύεται ως webhook_message_id)
+          description: Unique CloudEvents ID; used as idempotency key (stored as webhook_message_id)
         time:
           type: string
           format: date-time
-          description: Χρονοσήμανση δημιουργίας του φακέλου
+          description: Timestamp the envelope was generated
         datacontenttype:
           type: string
           minLength: 1
-          description: 'Τύπος MIME του πεδίου data (αναμενόμενος: ''application/json'')'
+          description: 'MIME type of the data field (expected: ''application/json'')'
         datasignature:
           type: string
           minLength: 1
-          description: Δεκαεξαδικό digest HMAC-SHA256 του ακατέργαστου JSON αντικειμένου 'data'· χρησιμοποιείται για επαλήθευση υπογραφής
+          description: HMAC-SHA256 hex digest of the raw 'data' JSON object; used for signature verification
         data:
           allOf:
             - $ref: '#/components/schemas/BoxNowWebhookDataRequest'
-          description: Payload συμβάντος δέματος
+          description: Parcel event payload
       required:
         - data
         - datacontenttype
@@ -31116,12 +31002,12 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID θεμάτων για εγγραφή/διαγραφή
+          description: List of topic IDs to subscribe/unsubscribe
         action:
           allOf:
             - $ref: '#/components/schemas/ActionEnum'
           description: |-
-            Ενέργεια προς εκτέλεση σε θέματα
+            Action to perform on the topics
 
             * `subscribe` - subscribe
             * `unsubscribe` - unsubscribe
@@ -31226,26 +31112,23 @@ components:
         totalWeightGrams:
           type: integer
           readOnly: true
-          description: Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+          description: Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
         currency:
           type: string
           readOnly: true
-          description: Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+          description: ISO 4217 currency code for all monetary values in this cart
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         lastActivity:
           type: string
           format: date-time
           readOnly: true
-          title: Τελευταία δραστηριότητα
       required:
         - createdAt
         - currency
@@ -31279,26 +31162,26 @@ components:
         payWayId:
           type: integer
           minimum: 1
-          description: ID της επιλεγμένης μεθόδου πληρωμής (πρέπει να είναι online Stripe).
+          description: ID of the selected PayWay (must be online Stripe).
         shippingKind:
           allOf:
             - $ref: '#/components/schemas/CartCreatePaymentIntentRequestShippingKindEnum'
           description: |-
-            Τύπος εκπλήρωσης για τον μεταφορέα (home_delivery ή pickup_point). Απαιτείται ώστε να τηρούνται οι επιμέρους σημαίες λειτουργίας (π.χ. ACS_SMARTPOINT_ENABLED) και ο έλεγχος PICKUP_POINT του BoxNow.
+            Fulfilment kind for the carrier (home_delivery or pickup_point). Required so the per-kind feature flags (e.g. ACS_SMARTPOINT_ENABLED) and BoxNow's PICKUP_POINT gate are honoured.
 
             * `home_delivery` - home_delivery
             * `pickup_point` - pickup_point
         shippingProviderCode:
           type: string
-          description: Κωδικός μεταφορέα που αντιστοιχεί σε καταχωρημένο προσαρμογέα αποστολής (π.χ. 'acs', 'boxnow'). Απαιτείται για ``pickup_point``· παραλείψτε/αφήστε κενό για ``home_delivery`` (το backend χρησιμοποιεί τη γενική πάγια χρέωση, αντίστοιχη με αυτή που θα υπολογίσει η επαλήθευση δημιουργίας παραγγελίας για το ίδιο αίτημα).
+          description: Carrier code matching a registered shipping adapter (e.g. 'acs', 'boxnow'). Required for ``pickup_point``; omit/empty for ``home_delivery`` (the backend uses the generic flat rate, matching what the order-create verification will compute for the same body).
           maxLength: 32
         countryId:
           type: string
-          description: Προαιρετικός κωδικός χώρας ISO 3166-1 alpha-2 — καθορίζει τον συντελεστή αποστολής σε επίπεδο χώρας. Πρέπει να ταιριάζει με αυτόν που θα φέρει το αίτημα δημιουργίας παραγγελίας.
+          description: Optional ISO 3166-1 alpha-2 country code — drives the country-level shipping multiplier. Match what the order-create body will carry.
           maxLength: 2
         regionId:
           type: string
-          description: Προαιρετικός κωδικός περιφέρειας — καθορίζει την προσαρμογή αποστολής σε επίπεδο περιφέρειας.
+          description: Optional region code — drives the region-level shipping adjustment.
           maxLength: 16
       required:
         - payWayId
@@ -31376,32 +31259,29 @@ components:
         totalWeightGrams:
           type: integer
           readOnly: true
-          description: Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+          description: Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
         currency:
           type: string
           readOnly: true
-          description: Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+          description: ISO 4217 currency code for all monetary values in this cart
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         lastActivity:
           type: string
           format: date-time
           readOnly: true
-          title: Τελευταία δραστηριότητα
         recommendations:
           type: array
           items:
             $ref: '#/components/schemas/Product'
           readOnly: true
-          description: Προτάσεις προϊόντων βάσει περιεχομένου καλαθιού
+          description: Product recommendations based on cart contents
       required:
         - createdAt
         - currency
@@ -31434,7 +31314,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
         weightInfo:
           type: object
           properties:
@@ -31449,7 +31328,7 @@ components:
             - totalWeight
             - weightUnit
           readOnly: true
-          description: Πληροφορίες βάρους για υπολογισμούς αποστολής
+          description: Weight information for shipping calculations
         price:
           type: number
           format: double
@@ -31514,12 +31393,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31550,7 +31427,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
       required:
         - product
     CartItemDetail:
@@ -31570,7 +31446,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
         weightInfo:
           type: object
           properties:
@@ -31585,7 +31460,7 @@ components:
             - totalWeight
             - weightUnit
           readOnly: true
-          description: Πληροφορίες βάρους για υπολογισμούς αποστολής
+          description: Weight information for shipping calculations
         price:
           type: number
           format: double
@@ -31650,12 +31525,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31665,7 +31538,7 @@ components:
           items:
             $ref: '#/components/schemas/Product'
           readOnly: true
-          description: Σχετικά προϊόντα που ίσως ενδιαφέρουν τον πελάτη
+          description: Related products that might interest the customer
       required:
         - cartId
         - createdAt
@@ -31691,17 +31564,16 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
     CartPaymentIntentResponse:
       type: object
       description: Response body returned by the create-payment-intent cart action.
       properties:
         clientSecret:
           type: string
-          description: Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+          description: Stripe PaymentIntent client secret for frontend confirmation
         paymentIntentId:
           type: string
-          description: ID του Stripe PaymentIntent προς αποθήκευση στην παραγγελία
+          description: Stripe PaymentIntent ID to be stored on the order
         amount:
           type: number
           format: double
@@ -31709,10 +31581,10 @@ components:
           minimum: -10000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          description: Συνολικό ποσό χρέωσης (καλάθι + αποστολή + έξοδα πληρωμής)
+          description: Total charge amount (cart + shipping + payment fee)
         currency:
           type: string
-          description: Κωδικός νομίσματος ISO 4217 (π.χ. EUR)
+          description: ISO 4217 currency code (e.g. EUR)
           maxLength: 3
       required:
         - amount
@@ -31747,16 +31619,16 @@ components:
           description: Stripe PaymentIntent ID that charged the token
         status:
           type: string
-          description: Κατάσταση πληρωμής
+          description: Payment status
         amount:
           type: string
-          description: Ποσό πληρωμής
+          description: Payment amount
         currency:
           type: string
-          description: Νόμισμα πληρωμής
+          description: Payment currency
         provider:
           type: string
-          description: Όνομα παρόχου πληρωμών
+          description: Payment provider name
       required:
         - amount
         - currency
@@ -31791,7 +31663,6 @@ components:
           readOnly: true
         name:
           type: string
-          title: Όνομα
           maxLength: 100
         email:
           type: string
@@ -31799,17 +31670,14 @@ components:
           maxLength: 254
         message:
           type: string
-          title: Μήνυμα
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31828,7 +31696,6 @@ components:
         name:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 100
         email:
           type: string
@@ -31838,7 +31705,6 @@ components:
         message:
           type: string
           minLength: 1
-          title: Μήνυμα
       required:
         - email
         - message
@@ -31867,12 +31733,12 @@ components:
                   type: string
         alpha2:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -31880,28 +31746,24 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31942,12 +31804,12 @@ components:
                   type: string
         alpha2:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -31955,28 +31817,24 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31988,7 +31846,7 @@ components:
           type: array
           items:
             type: string
-            title: Κωδικός περιφέρειας
+            title: Region Code
           readOnly: true
       required:
         - alpha2
@@ -32025,13 +31883,13 @@ components:
         alpha2:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -32039,13 +31897,12 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
       required:
         - alpha2
         - alpha3
@@ -32107,37 +31964,37 @@ components:
             type: string
             minLength: 1
             maxLength: 500
-          description: Επιπλέον δεδομένα πληρωμής που απαιτούνται από τον πάροχο πληρωμών
+          description: Additional payment data required by the payment provider
     CreatePaymentIntentResponse:
       type: object
       properties:
         paymentId:
           type: string
-          description: ID payment intent από τον πάροχο πληρωμών
+          description: Payment intent ID from the payment provider
         status:
           type: string
-          description: Κατάσταση πληρωμής
+          description: Payment status
         amount:
           type: string
-          description: Ποσό πληρωμής
+          description: Payment amount
         currency:
           type: string
-          description: Νόμισμα πληρωμής
+          description: Payment currency
         provider:
           type: string
-          description: Όνομα παρόχου πληρωμών
+          description: Payment provider name
         clientSecret:
           type: string
-          description: Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+          description: Stripe PaymentIntent client secret for frontend confirmation
         requiresAction:
           type: boolean
           default: false
-          description: Αν η πληρωμή απαιτεί επιπλέον ενέργεια (3D Secure κ.λπ.)
+          description: Whether the payment requires additional action (3D Secure, etc.)
         nextAction:
           type: object
           additionalProperties: {}
           nullable: true
-          description: Επόμενη ενέργεια που απαιτείται για την ολοκλήρωση της πληρωμής
+          description: Next action required for payment completion
       required:
         - amount
         - currency
@@ -32177,7 +32034,7 @@ components:
         confirmation:
           type: string
           minLength: 1
-          description: Πρέπει να ισούται ακριβώς με τη συμβολοσειρά "DELETE".
+          description: Must equal the literal string "DELETE".
       required:
         - confirmation
     DeleteAccountResponse:
@@ -32230,6 +32087,14 @@ components:
       type: object
       description: Serializer for federated search response.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
           description: Maximum number of results requested
@@ -32248,6 +32113,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     FederatedSearchResult:
       type: object
@@ -32354,14 +32221,14 @@ components:
         - SIXTH_FLOOR_PLUS
       type: string
       description: |-
-        * `BASEMENT` - Υπόγειο
-        * `GROUND_FLOOR` - Ισόγειο
-        * `FIRST_FLOOR` - 1ος όροφος
-        * `SECOND_FLOOR` - 2ος όροφος
-        * `THIRD_FLOOR` - 3ος όροφος
-        * `FOURTH_FLOOR` - 4ος όροφος
-        * `FIFTH_FLOOR` - 5ος όροφος
-        * `SIXTH_FLOOR_PLUS` - 6ος όροφος +
+        * `BASEMENT` - Basement
+        * `GROUND_FLOOR` - Ground Floor
+        * `FIRST_FLOOR` - First Floor
+        * `SECOND_FLOOR` - Second Floor
+        * `THIRD_FLOOR` - Third Floor
+        * `FOURTH_FLOOR` - Fourth Floor
+        * `FIFTH_FLOOR` - Fifth Floor
+        * `SIXTH_FLOOR_PLUS` - Sixth Floor Plus
     FreeShippingInfo:
       type: object
       description: Response payload for the free-shipping-info endpoint.
@@ -32378,7 +32245,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Χαμηλότερο όριο μεταξύ των ενεργών παρόχων — ο κύριος αριθμός 'δωρεάν αποστολή από X €'. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+          description: Lowest threshold across active providers — the headline 'free shipping from X €' number. Null when no active provider advertises a threshold.
         maxThreshold:
           type: number
           format: double
@@ -32387,7 +32254,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Υψηλότερο όριο μεταξύ των ενεργών παρόχων — το υποσύνολο στο οποίο κάθε μεταφορέας αποστέλλει δωρεάν. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+          description: Highest threshold across active providers — the subtotal at which every carrier ships free. Null when no active provider advertises a threshold.
         currency:
           type: string
           maxLength: 3
@@ -32413,7 +32280,7 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          description: Υποσύνολο καλαθιού στο νόμισμα της απόκρισης πάνω από το οποίο αυτός ο συνδυασμός (πάροχος, τύπος) αποστέλλει δωρεάν.
+          description: Cart subtotal in the response's currency above which this (provider, kind) ships free.
         priority:
           type: integer
       required:
@@ -32449,16 +32316,16 @@ components:
         - SEASONAL
       type: string
       description: |-
-        * `MAIN` - Κύρια εικόνα
-        * `BANNER` - Banner
-        * `ICON` - Εικονίδιο
-        * `THUMBNAIL` - Μικρογραφία
-        * `GALLERY` - Εικόνα συλλογής
-        * `BACKGROUND` - Εικόνα φόντου
-        * `HERO` - Κεντρική εικόνα
-        * `FEATURE` - Κεντρική Εικόνα
-        * `PROMOTIONAL` - Προωθητική εικόνα
-        * `SEASONAL` - Εποχιακή εικόνα
+        * `MAIN` - Main Image
+        * `BANNER` - Banner Image
+        * `ICON` - Icon Image
+        * `THUMBNAIL` - Thumbnail Image
+        * `GALLERY` - Gallery Image
+        * `BACKGROUND` - Background Image
+        * `HERO` - Hero Image
+        * `FEATURE` - Feature Image
+        * `PROMOTIONAL` - Promotional Image
+        * `SEASONAL` - Seasonal Image
     InvoiceDownloadResponse:
       type: object
       description: Invoice metadata plus an absolute URL to the streaming endpoint.
@@ -32466,14 +32333,12 @@ components:
         invoiceNumber:
           type: string
           readOnly: true
-          title: Αριθμός τιμολογίου
-          description: Διαδοχικό αναγνωριστικό στη μορφή ``INV-{YEAR}-{NNNNNN}``. Δεν επιτρέπονται κενά βάσει της ελληνικής φορολογικής νομοθεσίας.
+          description: Sequential identifier in the form ``INV-{YEAR}-{NNNNNN}``. Gaps are not allowed by Greek tax law.
         issueDate:
           type: string
           format: date
           readOnly: true
-          title: Ημερομηνία έκδοσης
-          description: Φορολογική ημερομηνία έκδοσης. Αμετάβλητη μόλις εκδοθεί το τιμολόγιο — χρησιμοποιείται για διαδοχική αρίθμηση και αναφορές.
+          description: Fiscal date of issue. Immutable once the invoice is rendered — used for sequential numbering and reporting.
         downloadUrl:
           type: string
           nullable: true
@@ -32502,11 +32367,9 @@ components:
         currency:
           type: string
           readOnly: true
-          title: Νόμισμα
         vatBreakdown:
           readOnly: true
-          title: Ανάλυση ΦΠΑ
-          description: Λίστα σε cache από γραμμές ``{rate, subtotal, vat, gross}`` — παγιωμένη τη στιγμή της έκδοσης, ώστε η εκ νέου απόδοση του τιμολογίου να δίνει πάντα τον ίδιο πίνακα ΦΠΑ ακόμη κι αν αλλάξουν οι συντελεστές των προϊόντων.
+          description: Cached list of ``{rate, subtotal, vat, gross}`` rows — frozen at issue time so re-rendering the invoice always yields the same VAT table even if product rates change.
       required:
         - currency
         - downloadUrl
@@ -32523,9 +32386,9 @@ components:
         - OTHER
       type: string
       description: |-
-        * `HOME` - Σπίτι
-        * `OFFICE` - Γραφείο
-        * `OTHER` - Άλλο
+        * `HOME` - Αρχική
+        * `OFFICE` - Office
+        * `OTHER` - Other
     LoyaltySummary:
       type: object
       description: |-
@@ -32596,8 +32459,7 @@ components:
         requiredLevel:
           type: integer
           readOnly: true
-          title: Απαιτούμενο επίπεδο
-          description: Ελάχιστο επίπεδο για την επίτευξη αυτού του tier
+          description: Minimum level to achieve this tier
         pointsMultiplier:
           type: number
           format: double
@@ -32606,13 +32468,11 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Πολλαπλασιαστής πόντων
-          description: Πολλαπλασιαστής που εφαρμόζεται στους πόντους που κερδίζουν οι χρήστες σε αυτό το tier
+          description: Multiplier applied to earned points for users in this tier
         icon:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         mainImagePath:
           type: string
           readOnly: true
@@ -32661,42 +32521,35 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         kind:
-          allOf:
-            - $ref: '#/components/schemas/NotificationKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/NotificationKindEnum'
         category:
-          allOf:
-            - $ref: '#/components/schemas/NotificationCategory'
-          title: Κατηγορία
+          $ref: '#/components/schemas/NotificationCategory'
         priority:
-          allOf:
-            - $ref: '#/components/schemas/PriorityEnum'
-          title: Προτεραιότητα
+          $ref: '#/components/schemas/PriorityEnum'
         notificationType:
-          title: Τύπος ειδοποίησης
           description: |-
-            Λεπτομερές αναγνωριστικό συμβάντος. Δείτε ``notification.enum.NotificationTypeEnum`` για τον πλήρη κατάλογο. Αφήνεται κενό για περιστασιακές ανακοινώσεις διαχειριστή.
+            Fine-grained event identifier. See ``notification.enum.NotificationTypeEnum`` for the full catalogue. Left blank for ad-hoc admin broadcasts.
 
-            * `order_created` - Η παραγγελία δημιουργήθηκε
-            * `order_processing` - Επεξεργασία παραγγελίας
-            * `order_shipped` - Η παραγγελία απεστάλη
-            * `order_delivered` - Η παραγγελία παραδόθηκε
-            * `order_completed` - Η παραγγελία ολοκληρώθηκε
-            * `order_canceled` - Η παραγγελία ακυρώθηκε
-            * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-            * `shipment_dispatched` - Αποστολή απεστάλη
-            * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-            * `payment_failed` - Η πληρωμή απέτυχε
-            * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-            * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-            * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-            * `comment_liked` - Επισήμανση σχολίου blog
-            * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-            * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-            * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+            * `order_created` - Order created
+            * `order_processing` - Order processing
+            * `order_shipped` - Order shipped
+            * `order_delivered` - Order delivered
+            * `order_completed` - Order completed
+            * `order_canceled` - Order canceled
+            * `order_refunded` - Order refunded
+            * `shipment_dispatched` - Shipment dispatched
+            * `payment_confirmed` - Payment confirmed
+            * `payment_failed` - Payment failed
+            * `price_drop_favourite` - Price drop (favourited product)
+            * `restock_favourite` - Back in stock (favourited product)
+            * `loyalty_tier_up` - Loyalty tier promotion
+            * `comment_liked` - Blog comment liked
+            * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+            * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+            * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
           oneOf:
             - $ref: '#/components/schemas/NotificationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -32704,17 +32557,14 @@ components:
           type: string
           format: date-time
           nullable: true
-          title: Ημερομηνία Λήξης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32744,26 +32594,26 @@ components:
         - RECOMMENDATION
       type: string
       description: |-
-        * `ORDER` - Παραγγελία
-        * `PAYMENT` - Πληρωμή
-        * `SHIPPING` - Μεταφορικά
-        * `CART` - Καλάθι
-        * `PRODUCT` - Προϊόν
-        * `ACCOUNT` - Λογαριασμός Ανενεργός
-        * `SECURITY` - Ασφάλεια
-        * `PROMOTION` - Προσφορά
-        * `SYSTEM` - Σύστημα
-        * `REVIEW` - Εξέταση
-        * `WISHLIST` - Λίστα επιθυμιών
-        * `SUPPORT` - Υποστήριξη
+        * `ORDER` - Ταξινόμηση
+        * `PAYMENT` - Payment
+        * `SHIPPING` - Shipping
+        * `CART` - Cart
+        * `PRODUCT` - Product
+        * `ACCOUNT` - Account
+        * `SECURITY` - Security
+        * `PROMOTION` - Promotion
+        * `SYSTEM` - System
+        * `REVIEW` - Review
+        * `WISHLIST` - Wishlist
+        * `SUPPORT` - Support
         * `NEWSLETTER` - Newsletter
-        * `RECOMMENDATION` - Σύσταση
+        * `RECOMMENDATION` - Recommendation
     NotificationCountResponse:
       type: object
       properties:
         count:
           type: integer
-          description: Αριθμός μη ορατών ειδοποιήσεων
+          description: Number of unseen notifications
       required:
         - count
     NotificationIdsRequest:
@@ -32785,16 +32635,16 @@ components:
       type: string
       description: |-
         * `ERROR` - Σφάλμα
-        * `SUCCESS` - Επιτυχία
-        * `INFO` - Πληροφορία
-        * `WARNING` - Προειδοποίηση
-        * `DANGER` - Κίνδυνος
+        * `SUCCESS` - Success
+        * `INFO` - Info
+        * `WARNING` - Warning
+        * `DANGER` - Danger
     NotificationSuccessResponse:
       type: object
       properties:
         success:
           type: boolean
-          description: Αν η λειτουργία ήταν επιτυχής
+          description: Whether the operation was successful
     NotificationTypeEnum:
       enum:
         - order_created
@@ -32816,23 +32666,23 @@ components:
         - ACS_OUT_FOR_DELIVERY
       type: string
       description: |-
-        * `order_created` - Η παραγγελία δημιουργήθηκε
-        * `order_processing` - Επεξεργασία παραγγελίας
-        * `order_shipped` - Η παραγγελία απεστάλη
-        * `order_delivered` - Η παραγγελία παραδόθηκε
-        * `order_completed` - Η παραγγελία ολοκληρώθηκε
-        * `order_canceled` - Η παραγγελία ακυρώθηκε
-        * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-        * `shipment_dispatched` - Αποστολή απεστάλη
-        * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-        * `payment_failed` - Η πληρωμή απέτυχε
-        * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-        * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-        * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-        * `comment_liked` - Επισήμανση σχολίου blog
-        * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-        * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-        * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+        * `order_created` - Order created
+        * `order_processing` - Order processing
+        * `order_shipped` - Order shipped
+        * `order_delivered` - Order delivered
+        * `order_completed` - Order completed
+        * `order_canceled` - Order canceled
+        * `order_refunded` - Order refunded
+        * `shipment_dispatched` - Shipment dispatched
+        * `payment_confirmed` - Payment confirmed
+        * `payment_failed` - Payment failed
+        * `price_drop_favourite` - Price drop (favourited product)
+        * `restock_favourite` - Back in stock (favourited product)
+        * `loyalty_tier_up` - Loyalty tier promotion
+        * `comment_liked` - Blog comment liked
+        * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+        * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+        * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
     NotificationUser:
       type: object
       properties:
@@ -32847,22 +32697,18 @@ components:
           readOnly: true
         seen:
           type: boolean
-          title: Ορατό
         seenAt:
           type: string
           format: date-time
           nullable: true
-          title: Ορατό στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32881,7 +32727,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID χρηστών ειδοποίησης προς σήμανση ως ορατά/μη ορατά
+          description: List of notification user IDs to mark as seen/unseen
       required:
         - notificationUserIds
     NotificationUserDetail:
@@ -32900,22 +32746,18 @@ components:
           readOnly: true
         seen:
           type: boolean
-          title: Ορατό
         seenAt:
           type: string
           format: date-time
           nullable: true
-          title: Ορατό στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32932,7 +32774,6 @@ components:
       properties:
         seen:
           type: boolean
-          title: Ορατό
     Order:
       type: object
       properties:
@@ -32944,37 +32785,31 @@ components:
           nullable: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         payWay:
           type: integer
           nullable: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/OrderStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/OrderStatus'
         statusDisplay:
           type: string
           readOnly: true
@@ -32983,14 +32818,11 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-          title: Κατάσταση ενημερώθηκε στις
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -32998,21 +32830,17 @@ components:
           maxLength: 255
         zipcode:
           type: string
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         paidAmount:
           type: number
           format: double
@@ -33042,19 +32870,15 @@ components:
           exclusiveMinimum: true
           readOnly: true
         documentType:
-          allOf:
-            - $ref: '#/components/schemas/OrderDocumentType'
-          title: Τύπος Εγγράφου
+          $ref: '#/components/schemas/OrderDocumentType'
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -33081,10 +32905,8 @@ components:
         paymentId:
           type: string
           nullable: true
-          title: ID πληρωμής
           maxLength: 255
         paymentStatus:
-          title: Κατάσταση πληρωμής
           oneOf:
             - $ref: '#/components/schemas/PaymentStatusEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -33094,7 +32916,6 @@ components:
           description: Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
         paymentMethod:
           type: string
-          title: Μέθοδος πληρωμής
           maxLength: 50
         isOnlinePayment:
           type: boolean
@@ -33141,8 +32962,8 @@ components:
         - INVOICE
       type: string
       description: |-
-        * `RECEIPT` - Απόδειξη
-        * `INVOICE` - Τιμολόγιο
+        * `RECEIPT` - Receipt
+        * `INVOICE` - Invoice
     OrderCreateFromCartRequest:
       type: object
       description: |-
@@ -33157,103 +32978,103 @@ components:
       properties:
         payWayId:
           type: integer
-          description: ID μεθόδου πληρωμής
+          description: Payment method ID
         paymentIntentId:
           type: string
           nullable: true
-          description: ID payment intent από τον πάροχο πληρωμών (υποχρεωτικό για online πληρωμές)
+          description: Payment intent ID from payment provider (required for online payments)
         firstName:
           type: string
           minLength: 1
-          description: Όνομα πελάτη
+          description: Customer first name
           maxLength: 150
         lastName:
           type: string
           minLength: 1
-          description: Επώνυμο πελάτη
+          description: Customer last name
           maxLength: 150
         email:
           type: string
           format: email
           minLength: 1
-          description: Email πελάτη
+          description: Customer email address
         street:
           type: string
           minLength: 1
-          description: Όνομα οδού
+          description: Street name
           maxLength: 255
         streetNumber:
           type: string
-          description: Αριθμός οδού
+          description: Street number
           maxLength: 50
         city:
           type: string
           minLength: 1
-          description: Όνομα πόλης
+          description: City name
           maxLength: 100
         zipcode:
           type: string
           minLength: 1
-          description: Ταχυδρομικός κώδικας
+          description: Postal/ZIP code
           maxLength: 20
         countryId:
           type: string
           minLength: 1
-          description: Κωδικός χώρας alpha-2 (π.χ. 'GR', 'US')
+          description: Country alpha-2 code (e.g., 'GR', 'US')
         regionId:
           type: string
           nullable: true
-          description: Αλφαριθμητικός κωδικός περιφέρειας
+          description: Region alpha code
         phone:
           type: string
           minLength: 1
-          description: Τηλέφωνο πελάτη
+          description: Customer phone number
         customerNotes:
           type: string
-          description: Σημειώσεις πελάτη ή ειδικές οδηγίες
+          description: Customer notes or special instructions
           maxLength: 500
         floor:
           type: string
-          description: Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)
+          description: Floor number or label (e.g. FIRST_FLOOR)
           maxLength: 50
         locationType:
           type: string
-          description: Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)
+          description: Location type, e.g. HOME or OFFICE (optional)
           maxLength: 100
         billingVatId:
           type: string
-          description: ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.
+          description: Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.
           maxLength: 12
         billingCountry:
           type: string
-          description: Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.
+          description: ISO 3166-1 alpha-2 country code for the buyer's tax identity. Defaults to the order country when blank.
           maxLength: 2
         documentType:
           allOf:
             - $ref: '#/components/schemas/OrderCreateDocumentType'
           default: RECEIPT
           description: |-
-            RECEIPT (Α.Λ.Π., Tier A — λιανική) ή INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Η επιλογή INVOICE απαιτεί έγκυρο ``billing_vat_id``.
+            RECEIPT (Α.Λ.Π., Tier A — retail) or INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Selecting INVOICE requires a valid ``billing_vat_id``.
 
-            * `RECEIPT` - Απόδειξη
-            * `INVOICE` - Τιμολόγιο
+            * `RECEIPT` - Receipt
+            * `INVOICE` - Invoice
         loyaltyPointsToRedeem:
           type: integer
           minimum: 0
           nullable: true
-          description: Αριθμός πόντων πιστότητας προς εξαργύρωση για έκπτωση σε αυτή την παραγγελία
+          description: Number of loyalty points to redeem for discount on this order
         boxnowLockerId:
           type: string
-          description: ID locker APM BoxNow από το widget
+          description: BoxNow APM locker ID from the widget
           maxLength: 64
         boxnowCompartmentSize:
           type: integer
           maximum: 3
           minimum: 1
           default: 1
-          description: 'Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο'
+          description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large'
         shippingProviderCode:
-          description: Κωδικός μεταφορέα από /api/v1/shipping/options (π.χ. 'acs').
+          description: Carrier code from /api/v1/shipping/options (e.g. 'acs').
           oneOf:
             - type: string
               maxLength: 32
@@ -33264,37 +33085,37 @@ components:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
           description: |-
-            Γενικός τύπος εκπλήρωσης, ανεξάρτητος από τον πάροχο.
+            Generic fulfilment kind, independent of provider.
 
-            * `home_delivery` - Κατ' οίκον παράδοση
-            * `pickup_point` - Σημείο παραλαβής / locker
+            * `home_delivery` - Home delivery
+            * `pickup_point` - Pickup point / locker
         acsStationExternalId:
           type: string
-          description: Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).
+          description: ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).
           maxLength: 32
         acsStationBranch:
           type: string
-          description: Τιμή ACS_Station_Branch_Destination.
+          description: ACS_Station_Branch_Destination value.
           maxLength: 32
         acsChargeType:
           allOf:
             - $ref: '#/components/schemas/AcsChargeType'
           description: |-
-            Προαιρετική παράκαμψη του ACS Charge_Type ανά παραγγελία. Αφήστε το κενό για χρήση της προεπιλογής σε επίπεδο μεταφορέα (COD σε σύμβαση μόνο-COD). Ο ορισμός εδώ έχει νόημα μόνο αν η εμπορική σύμβαση με την ACS επιτρέπει την επιλεγμένη τιμή — μη έγκυροι συνδυασμοί απορρίπτονται από το ACS_Create_Voucher.
+            Optional per-order ACS Charge_Type override. Leave unset to use the carrier-level default (COD on a COD-only contract). Setting this here only makes sense if the ACS commercial contract permits the chosen value — invalid combinations are rejected by ACS_Create_Voucher.
 
-            * `1` - Προπληρωμένο
-            * `2` - Αντικαταβολή
+            * `1` - Prepaid
+            * `2` - Cash on delivery
         acsItemQuantity:
           type: integer
           maximum: 20
           minimum: 1
-          description: Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.
+          description: Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.
         meta:
           type: object
           additionalProperties: {}
           writeOnly: true
           nullable: true
-          description: 'Πλαίσιο Meta Pixel: κλειδιά ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict με {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict με boolean ``ads``). Κενό dict / null όταν ο πελάτης αρνήθηκε τα cookies μάρκετινγκ· ο αποστολέας CAPI τότε παραλείπει την αποστολή.'
+          description: 'Meta Pixel context: keys ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict of {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict with ``ads`` boolean). Empty dict / null when the customer declined marketing cookies; the CAPI dispatcher then skips the send.'
       required:
         - city
         - countryId
@@ -33316,37 +33137,31 @@ components:
           nullable: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         payWay:
           type: integer
           nullable: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/OrderStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/OrderStatus'
         statusDisplay:
           type: string
           readOnly: true
@@ -33355,14 +33170,11 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-          title: Κατάσταση ενημερώθηκε στις
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -33370,22 +33182,18 @@ components:
           maxLength: 255
         zipcode:
           type: string
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           readOnly: true
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         paidAmount:
           type: number
           format: double
@@ -33415,19 +33223,15 @@ components:
           exclusiveMinimum: true
           readOnly: true
         documentType:
-          allOf:
-            - $ref: '#/components/schemas/OrderDocumentType'
-          title: Τύπος Εγγράφου
+          $ref: '#/components/schemas/OrderDocumentType'
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -33454,10 +33258,8 @@ components:
         paymentId:
           type: string
           nullable: true
-          title: ID πληρωμής
           maxLength: 255
         paymentStatus:
-          title: Κατάσταση πληρωμής
           oneOf:
             - $ref: '#/components/schemas/PaymentStatusEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -33467,7 +33269,6 @@ components:
           description: Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
         paymentMethod:
           type: string
-          title: Μέθοδος πληρωμής
           maxLength: 50
         isOnlinePayment:
           type: boolean
@@ -33595,11 +33396,9 @@ components:
           description: Cancellation context for CANCELED orders — exposes the operator-supplied reason, timestamp, and shipment-cancel outcome from ``order.metadata['cancellation']``. Returns null when the order was not canceled. Internal flags from the metadata bag (webhook idempotency markers, mint tickets) are intentionally not surfaced.
         trackingNumber:
           type: string
-          title: Αριθμός Παρακολούθησης
           maxLength: 255
         shippingCarrier:
           type: string
-          title: Εταιρεία μεταφοράς
           maxLength: 255
         customerFullName:
           type: string
@@ -33674,12 +33473,12 @@ components:
         - CREDIT_NOTE
       type: string
       description: |-
-        * `RECEIPT` - Απόδειξη
-        * `INVOICE` - Τιμολόγιο
-        * `PROFORMA` - Προτιμολόγιο
-        * `SHIPPING_LABEL` - Ετικέτα αποστολής
-        * `RETURN_LABEL` - Ετικέτα επιστροφής
-        * `CREDIT_NOTE` - Πιστωτικό
+        * `RECEIPT` - Receipt
+        * `INVOICE` - Invoice
+        * `PROFORMA` - Proforma Invoice
+        * `SHIPPING_LABEL` - Shipping Label
+        * `RETURN_LABEL` - Return Label
+        * `CREDIT_NOTE` - Credit Note
     OrderItem:
       type: object
       properties:
@@ -33706,15 +33505,12 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         isRefunded:
           type: boolean
           readOnly: true
-          title: Έχει επιστραφεί
         refundedQuantity:
           type: integer
           readOnly: true
-          title: Επιστραφείσα ποσότητα
         netQuantity:
           type: integer
           readOnly: true
@@ -33730,12 +33526,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -33757,10 +33551,8 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - product
     OrderItemDetail:
@@ -33791,15 +33583,12 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         isRefunded:
           type: boolean
           readOnly: true
-          title: Έχει επιστραφεί
         refundedQuantity:
           type: integer
           readOnly: true
-          title: Επιστραφείσα ποσότητα
         netQuantity:
           type: integer
           readOnly: true
@@ -33815,17 +33604,14 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         originalQuantity:
           type: integer
           readOnly: true
           nullable: true
-          title: Αρχική ποσότητα
         refundedAmount:
           type: number
           format: double
@@ -33846,10 +33632,8 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - createdAt
         - id
@@ -33872,10 +33656,10 @@ components:
         quantity:
           type: integer
           minimum: 1
-          description: Ποσότητα προς επιστροφή. Αν δεν δοθεί, επιστρέφονται όλα.
+          description: Quantity to refund. If not provided, refunds all.
         reason:
           type: string
-          description: Προαιρετική αιτία επιστροφής
+          description: Optional reason for the refund
           maxLength: 255
     OrderItemRefundResponse:
       type: object
@@ -33906,10 +33690,8 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - order
         - product
@@ -33925,56 +33707,50 @@ components:
         - REFUNDED
       type: string
       description: |-
-        * `PENDING` - Εκκρεμεί
-        * `PROCESSING` - Σε επεξεργασία
-        * `SHIPPED` - Απεστάλη
-        * `DELIVERED` - Παραδόθηκε
-        * `COMPLETED` - Ολοκληρώθηκε
-        * `CANCELED` - Ακυρώθηκε
-        * `RETURNED` - Επιστράφηκε
-        * `REFUNDED` - Επιστροφή Χρημάτων
+        * `PENDING` - Pending
+        * `PROCESSING` - Processing
+        * `SHIPPED` - Shipped
+        * `DELIVERED` - Delivered
+        * `COMPLETED` - Completed
+        * `CANCELED` - Canceled
+        * `RETURNED` - Returned
+        * `REFUNDED` - Refunded
     OrderWriteRequest:
       type: object
       properties:
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -33984,23 +33760,19 @@ components:
         zipcode:
           type: string
           minLength: 1
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           minLength: 1
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         items:
           type: array
           items:
@@ -35332,7 +35104,6 @@ components:
         user:
           type: integer
         website:
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -35456,21 +35227,16 @@ components:
           type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
     PatchedBlogTagWriteRequest:
       type: object
@@ -35496,7 +35262,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
     PatchedCartItemUpdateRequest:
       type: object
       properties:
@@ -35504,7 +35269,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
     PatchedCountryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35530,13 +35294,13 @@ components:
         alpha2:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -35544,19 +35308,17 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
     PatchedNotificationUserWriteRequest:
       type: object
       properties:
         seen:
           type: boolean
-          title: Ορατό
     PatchedOrderItemWriteRequest:
       type: object
       properties:
@@ -35568,52 +35330,44 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
     PatchedOrderWriteRequest:
       type: object
       properties:
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -35623,23 +35377,19 @@ components:
         zipcode:
           type: string
           minLength: 1
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           minLength: 1
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         items:
           type: array
           items:
@@ -35680,7 +35430,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -35699,24 +35448,20 @@ components:
           type: string
           format: binary
           nullable: true
-          title: Εικονίδιο
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           nullable: true
-          title: Διαμόρφωση Παρόχου
-          description: Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+          title: Provider Configuration
+          description: Provider-specific configuration (API keys, webhooks, etc.)
     PatchedProductCategoryImageBulkUpdateRequest:
       type: object
       properties:
@@ -35742,10 +35487,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         translations:
           type: object
           properties:
@@ -35805,21 +35548,17 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
     PatchedProductFavouriteWriteRequest:
       type: object
@@ -35838,7 +35577,6 @@ components:
           title: Εικόνα
         isMain:
           type: boolean
-          title: Κύριο
         translations:
           type: object
           properties:
@@ -35866,7 +35604,6 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         translations:
@@ -35938,7 +35675,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         weight:
           type: object
           properties:
@@ -35957,22 +35693,17 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         active:
           type: boolean
-          title: Ενεργή
     PatchedRegionWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35998,12 +35729,12 @@ components:
         alpha:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
     PatchedSubscriptionTopicWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36035,35 +35766,33 @@ components:
         slug:
           type: string
           minLength: 1
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
     PatchedTagWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36088,14 +35817,13 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
     PatchedTaggedItemWriteRequest:
       type: object
       properties:
         tagId:
           type: integer
           writeOnly: true
-          description: ID ετικέτας προς ανάθεση
+          description: ID of the tag to assign
         contentType:
           type: integer
         objectId:
@@ -36108,45 +35836,37 @@ components:
         title:
           type: string
           minLength: 1
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
           minLength: 1
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -36155,28 +35875,25 @@ components:
           minLength: 1
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
     PatchedUserSubscriptionWriteRequest:
       type: object
       properties:
         topic:
           type: integer
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
     PatchedUserWriteRequest:
       type: object
       properties:
@@ -36184,15 +35901,13 @@ components:
           type: string
           format: email
           minLength: 1
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         username:
           nullable: true
@@ -36214,38 +35929,34 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           nullable: true
-          title: Προφίλ Twitter
+          title: Twitter Profile
           oneOf:
             - type: string
               format: uri
@@ -36254,7 +35965,7 @@ components:
               maxLength: 0
         linkedin:
           nullable: true
-          title: Προφίλ LinkedIn
+          title: LinkedIn Profile
           oneOf:
             - type: string
               format: uri
@@ -36263,7 +35974,7 @@ components:
               maxLength: 0
         facebook:
           nullable: true
-          title: Προφίλ Facebook
+          title: Facebook Profile
           oneOf:
             - type: string
               format: uri
@@ -36272,7 +35983,7 @@ components:
               maxLength: 0
         instagram:
           nullable: true
-          title: Προφίλ Instagram
+          title: Instagram Profile
           oneOf:
             - type: string
               format: uri
@@ -36281,7 +35992,6 @@ components:
               maxLength: 0
         website:
           nullable: true
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -36290,7 +36000,7 @@ components:
               maxLength: 0
         youtube:
           nullable: true
-          title: Προφίλ Youtube
+          title: Youtube Profile
           oneOf:
             - type: string
               format: uri
@@ -36299,7 +36009,7 @@ components:
               maxLength: 0
         github:
           nullable: true
-          title: Προφίλ Github
+          title: Github Profile
           oneOf:
             - type: string
               format: uri
@@ -36308,12 +36018,11 @@ components:
               maxLength: 0
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
           minLength: 1
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
     PayWay:
       type: object
@@ -36354,7 +36063,6 @@ components:
           readOnly: true
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36373,12 +36081,10 @@ components:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         mainImagePath:
           type: string
           readOnly: true
@@ -36386,12 +36092,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36401,17 +36105,14 @@ components:
           readOnly: true
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
       required:
         - cost
         - createdAt
@@ -36462,7 +36163,6 @@ components:
           readOnly: true
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36481,12 +36181,10 @@ components:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         mainImagePath:
           type: string
           readOnly: true
@@ -36494,12 +36192,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36509,17 +36205,14 @@ components:
           readOnly: true
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           readOnly: true
       required:
@@ -36570,7 +36263,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36589,24 +36281,20 @@ components:
           type: string
           format: binary
           nullable: true
-          title: Εικονίδιο
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           nullable: true
-          title: Διαμόρφωση Παρόχου
-          description: Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+          title: Provider Configuration
+          description: Provider-specific configuration (API keys, webhooks, etc.)
       required:
         - cost
         - translations
@@ -36616,8 +36304,8 @@ components:
         - cod
       type: string
       description: |-
-        * `prepaid` - Προπληρωμένο
-        * `cod` - Αντικαταβολή
+        * `prepaid` - Prepaid
+        * `cod` - Cash on delivery
     PaymentStatusEnum:
       enum:
         - PENDING
@@ -36629,13 +36317,13 @@ components:
         - CANCELED
       type: string
       description: |-
-        * `PENDING` - Εκκρεμεί
-        * `PROCESSING` - Σε επεξεργασία
-        * `COMPLETED` - Ολοκληρώθηκε
-        * `FAILED` - Απέτυχε
-        * `REFUNDED` - Επιστροφή Χρημάτων
-        * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-        * `CANCELED` - Ακυρώθηκε
+        * `PENDING` - Pending
+        * `PROCESSING` - Processing
+        * `COMPLETED` - Completed
+        * `FAILED` - Failed
+        * `REFUNDED` - Refunded
+        * `PARTIALLY_REFUNDED` - Partially Refunded
+        * `CANCELED` - Canceled
     PaymentStatusResponse:
       type: object
       properties:
@@ -36693,13 +36381,11 @@ components:
         points:
           type: integer
           readOnly: true
-          title: Πόντοι
-          description: Θετικό για κέρδος/μπόνους, αρνητικό για εξαργύρωση/λήξη/προσαρμογή
+          description: Positive for earn/bonus, negative for redeem/expire/adjust
         transactionType:
           allOf:
             - $ref: '#/components/schemas/TransactionTypeEnum'
           readOnly: true
-          title: Τύπος συναλλαγής
         referenceOrder:
           type: integer
           readOnly: true
@@ -36707,12 +36393,10 @@ components:
         description:
           type: string
           readOnly: true
-          title: Περιγραφή
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - createdAt
         - description
@@ -36729,11 +36413,11 @@ components:
         - CRITICAL
       type: string
       description: |-
-        * `LOW` - Χαμηλή προτεραιότητα
-        * `NORMAL` - Κανονική προτεραιότητα
-        * `HIGH` - Υψηλή προτεραιότητα
-        * `URGENT` - Επείγουσα προτεραιότητα
-        * `CRITICAL` - Κρίσιμη προτεραιότητα
+        * `LOW` - Low Priority
+        * `NORMAL` - Normal Priority
+        * `HIGH` - High Priority
+        * `URGENT` - Urgent Priority
+        * `CRITICAL` - Critical Priority
     Product:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36775,7 +36459,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -36796,20 +36480,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -36823,15 +36503,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -36840,7 +36517,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -36893,12 +36569,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36944,9 +36618,7 @@ components:
           format: uuid
           readOnly: true
         kind:
-          allOf:
-            - $ref: '#/components/schemas/ProductAlertKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/ProductAlertKindEnum'
         product:
           type: integer
         user:
@@ -36969,23 +36641,19 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         notifiedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ειδοποιήθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -37002,15 +36670,13 @@ components:
         - price_drop
       type: string
       description: |-
-        * `restock` - Αναπλήρωση
-        * `price_drop` - Πτώση τιμής
+        * `restock` - Restock
+        * `price_drop` - Price drop
     ProductAlertRequest:
       type: object
       properties:
         kind:
-          allOf:
-            - $ref: '#/components/schemas/ProductAlertKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/ProductAlertKindEnum'
         product:
           type: integer
         email:
@@ -37054,7 +36720,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - attributeId
         - attributeName
@@ -37122,7 +36787,6 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
@@ -37136,12 +36800,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37192,7 +36854,6 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
@@ -37206,12 +36867,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37226,15 +36885,12 @@ components:
           readOnly: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - children
@@ -37267,15 +36923,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -37310,12 +36963,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37365,15 +37016,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -37408,12 +37056,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37444,10 +37090,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         translations:
           type: object
           properties:
@@ -37511,21 +37155,17 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - slug
@@ -37571,7 +37211,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -37592,20 +37232,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -37619,15 +37255,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -37636,7 +37269,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -37689,12 +37321,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37707,8 +37337,7 @@ components:
         priceDropAlertsEnabled:
           type: boolean
           readOnly: true
-          title: Ειδοποιήσεις πτώσης τιμής
-          description: Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+          description: When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
       required:
         - attributes
         - brand
@@ -37776,7 +37405,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -37797,20 +37426,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -37824,15 +37449,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -37841,7 +37463,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -37894,12 +37515,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37912,8 +37531,7 @@ components:
         priceDropAlertsEnabled:
           type: boolean
           readOnly: true
-          title: Ειδοποιήσεις πτώσης τιμής
-          description: Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+          description: When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
       required:
         - attributes
         - brand
@@ -37960,7 +37578,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37979,7 +37596,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID προϊόντων για έλεγχο αγαπημένων
+          description: List of product IDs to check for favorites
           maxItems: 100
       required:
         - productIds
@@ -38020,7 +37637,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38032,7 +37648,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -38090,12 +37705,10 @@ components:
           readOnly: true
         isMain:
           type: boolean
-          title: Κύριο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -38121,7 +37734,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - altText
         - createdAt
@@ -38165,12 +37777,10 @@ components:
           readOnly: true
         isMain:
           type: boolean
-          title: Κύριο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -38196,7 +37806,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         imageDimensions:
           type: object
           properties:
@@ -38226,7 +37835,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - altText
         - createdAt
@@ -38255,7 +37863,6 @@ components:
           title: Εικόνα
         isMain:
           type: boolean
-          title: Κύριο
         translations:
           type: object
           properties:
@@ -38280,7 +37887,22 @@ components:
         - translations
     ProductMeiliSearchResponse:
       type: object
+      description: |-
+        Common disclosure fields every search response carries.
+
+        ``query_id`` attributes later clicks to this query (see the
+        ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+        query the zero-result fallback actually matched, so clients can
+        disclose "showing results for …" instead of silently swapping.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
         offset:
@@ -38306,6 +37928,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     ProductMeiliSearchResult:
       type: object
@@ -38415,32 +38039,25 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         status:
-          allOf:
-            - $ref: '#/components/schemas/ReviewStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/ReviewStatus'
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38491,32 +38108,25 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         status:
-          allOf:
-            - $ref: '#/components/schemas/ReviewStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/ReviewStatus'
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38558,7 +38168,6 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         translations:
@@ -38624,11 +38233,9 @@ components:
         active:
           type: boolean
           readOnly: true
-          title: Ενεργή
         stock:
           type: integer
           readOnly: true
-          title: Απόθεμα
         price:
           type: number
           format: double
@@ -38653,7 +38260,6 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Ποσοστό Έκπτωσης
         mainImagePath:
           type: string
           readOnly: true
@@ -38741,7 +38347,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         weight:
           type: object
           properties:
@@ -38760,22 +38365,17 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         active:
           type: boolean
-          title: Ενεργή
       required:
         - category
         - price
@@ -38796,16 +38396,16 @@ components:
         - 10
       type: integer
       description: |-
-        * `1` - Ένα
-        * `2` - Δύο
-        * `3` - Τρία
-        * `4` - Τέσσερα
-        * `5` - Πέντε
-        * `6` - Έξι
-        * `7` - Επτά
-        * `8` - Οκτώ
-        * `9` - Εννέα
-        * `10` - Δέκα
+        * `1` - One
+        * `2` - Two
+        * `3` - Three
+        * `4` - Four
+        * `5` - Five
+        * `6` - Six
+        * `7` - Seven
+        * `8` - Eight
+        * `9` - Nine
+        * `10` - Ten
     RedeemPointsRequestRequest:
       type: object
       description: Serializer for validating a points redemption request.
@@ -38884,26 +38484,23 @@ components:
                   type: string
         alpha:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38940,26 +38537,23 @@ components:
                   type: string
         alpha:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38997,12 +38591,12 @@ components:
         alpha:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
       required:
         - alpha
         - country
@@ -39015,7 +38609,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID δεσμεύσεων προς απελευθέρωση
+          description: List of reservation IDs to release
       required:
         - reservationIds
     ReleaseReservationsResponse:
@@ -39024,16 +38618,16 @@ components:
       properties:
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
         releasedCount:
           type: integer
-          description: Αριθμός αποδεσμευμένων κρατήσεων
+          description: Number of reservations released
         failedReleases:
           type: array
           items:
             type: object
             additionalProperties: {}
-          description: Λίστα αποτυχημένων απελευθερώσεων με λεπτομέρειες σφάλματος
+          description: List of failed releases with error details
       required:
         - message
         - releasedCount
@@ -39079,13 +38673,21 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID δημιουργημένων δεσμεύσεων αποθέματος
+          description: List of created stock reservation IDs
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
       required:
         - message
         - reservationIds
+    ResultTypeEnum:
+      enum:
+        - product
+        - blog_post
+      type: string
+      description: |-
+        * `product` - product
+        * `blog_post` - blog_post
     ReviewStatus:
       enum:
         - NEW
@@ -39093,9 +38695,9 @@ components:
         - 'FALSE'
       type: string
       description: |-
-        * `NEW` - Νέο
-        * `TRUE` - Ναι
-        * `FALSE` - Όχι
+        * `NEW` - New
+        * `TRUE` - True
+        * `FALSE` - False
     SearchAnalyticsResponse:
       type: object
       description: Serializer for search analytics response.
@@ -39133,6 +38735,43 @@ components:
         - searchVolume
         - topQueries
         - zeroResultQueries
+    SearchClickRequestRequest:
+      type: object
+      description: Payload for attributing a result click to a search query.
+      properties:
+        queryId:
+          type: string
+          format: uuid
+          description: The query_id returned by the search response
+        resultId:
+          type: string
+          minLength: 1
+          description: ID of the clicked result (Product or BlogPost ID)
+          maxLength: 100
+        resultType:
+          allOf:
+            - $ref: '#/components/schemas/ResultTypeEnum'
+          description: |-
+            Type of the clicked result
+
+            * `product` - product
+            * `blog_post` - blog_post
+        position:
+          type: integer
+          minimum: 0
+          description: 0-indexed position of the result in the result list
+      required:
+        - position
+        - queryId
+        - resultId
+        - resultType
+    SearchClickResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+        - detail
     SearchVolume:
       type: object
       description: Serializer for search volume metrics.
@@ -39191,24 +38830,24 @@ components:
         - lost
       type: string
       description: |-
-        * `pending_creation` - Εκκρεμής δημιουργία
-        * `new` - Νέο
-        * `in_transit` - Σε μεταφορά
-        * `at_destination` - Στο κατάστημα παράδοσης
-        * `out_for_delivery` - Σε διανομή
-        * `delivered` - Παραδόθηκε
-        * `attempted` - Απόπειρα παράδοσης
-        * `returned` - Επιστράφηκε
-        * `canceled` - Ακυρώθηκε
-        * `lost` - Χάθηκε
+        * `pending_creation` - Pending creation
+        * `new` - New
+        * `in_transit` - In transit
+        * `at_destination` - At destination station
+        * `out_for_delivery` - Out for delivery
+        * `delivered` - Delivered
+        * `attempted` - Delivery attempted
+        * `returned` - Returned
+        * `canceled` - Canceled
+        * `lost` - Lost
     ShippingKind:
       enum:
         - home_delivery
         - pickup_point
       type: string
       description: |-
-        * `home_delivery` - Κατ' οίκον παράδοση
-        * `pickup_point` - Σημείο παραλαβής / locker
+        * `home_delivery` - Home delivery
+        * `pickup_point` - Pickup point / locker
     ShippingOption:
       type: object
       description: |-
@@ -39233,7 +38872,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Null όταν ο πάροχος παραπέμπει στη γενική πάγια χρέωση.
+          description: Null when the provider defers to the global flat rate.
         currency:
           type: string
           maxLength: 3
@@ -39245,7 +38884,7 @@ components:
           type: string
           format: uri
           nullable: true
-          description: Απόλυτο URL για το λογότυπο μάρκας που ανέβασε ο χειριστής, υπολογισμένο ανά (πάροχο, τύπο) ώστε η γραμμή κατ' οίκον παράδοσης και η γραμμή σημείου παραλαβής του ίδιου μεταφορέα να μπορούν να εμφανίζουν διαφορετικές εικόνες. Null όταν δεν έχει μεταφορτωθεί λογότυπο — το κατάστημα τότε επιστρέφει στην ενσωματωμένη προεπιλογή του. Το ``settings.MEDIA_URL`` είναι απόλυτο σε κάθε περιβάλλον, οπότε αυτό είναι πάντα πλήρες URL όταν υπάρχει.
+          description: Absolute URL for the operator-uploaded brand logo, resolved per (provider, kind) so the home-delivery row and the pickup-point row of the same carrier can show different images. Null when no logo is uploaded — the storefront then falls back to its bundled default. ``settings.MEDIA_URL`` is absolute in every environment so this is always a full URL when present.
         metadata:
           type: object
           additionalProperties: {}
@@ -39268,35 +38907,30 @@ components:
           type: string
           readOnly: true
           title: Κωδικός
-          description: Σταθερό αναγνωριστικό που αντιστοιχεί στον καταχωρημένο προσαρμογέα μεταφορέα (π.χ. 'acs', 'boxnow').
+          description: Stable identifier matching the registered carrier adapter (e.g. 'acs', 'boxnow').
           pattern: ^[-a-zA-Z0-9_]+$
         name:
           type: string
           readOnly: true
-          title: Όνομα
-          description: Όνομα εμφάνισης προς τους πελάτες (π.χ. 'ACS Courier').
+          description: Display name shown to customers (e.g. 'ACS Courier').
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
-          description: Κύριος διακόπτης — όταν είναι False, ο πάροχος αποκρύπτεται από το checkout ανεξάρτητα από τις σημαίες δυνατοτήτων.
+          description: Master switch — when False the provider is hidden from checkout regardless of capability flags.
         supportsHomeDelivery:
           type: boolean
           readOnly: true
-          title: Υποστηρίζει Κατ' Οίκον Παράδοση
         supportsPickupPoint:
           type: boolean
           readOnly: true
-          title: Υποστηρίζει σημείο παραλαβής
         liveMode:
           type: boolean
           readOnly: true
-          description: False = διαπιστευτήρια sandbox / δοκιμής. Χρησιμοποιείται από το UI διαχείρισης για να προειδοποιεί τους χειριστές ότι τα vouchers δεν θα αποσταλούν πραγματικά.
+          description: False = sandbox / test credentials. Used by the admin UI to warn operators that vouchers won't actually ship.
         priority:
           type: integer
           readOnly: true
-          title: Προτεραιότητα
-          description: Σειρά ταξινόμησης στο checkout — οι μικρότεροι αριθμοί εμφανίζονται πρώτοι.
+          description: Sort order in checkout — lower numbers appear first.
         logo:
           type: string
           format: uri
@@ -39323,18 +38957,15 @@ components:
           description: Filename of the pickup-point logo (or empty).
         metadata:
           readOnly: true
-          title: Μεταδεδομένα
-          description: Διαμόρφωση ειδική για τον πάροχο (υποστηριζόμενες χώρες, σημαίες λειτουργιών, υποδείξεις branding).
+          description: Provider-specific configuration (supported countries, feature flags, branding hints).
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - code
         - createdAt
@@ -39363,12 +38994,12 @@ components:
         - 8
       type: integer
       description: |-
-        * `1` - Κατάστημα
-        * `2` - Συνεργαζόμενο κατάστημα (2)
-        * `3` - Συνεργαζόμενο κατάστημα (3)
+        * `1` - Shop
+        * `2` - Partner shop (2)
+        * `3` - Partner shop (3)
         * `4` - Xpress Point
         * `5` - Kiosk
-        * `7` - Smartpoint (χωρίς locker)
+        * `7` - Smartpoint (no locker)
         * `8` - Smartpoint locker
     SubscriptionStatus:
       enum:
@@ -39378,10 +39009,10 @@ components:
         - BOUNCED
       type: string
       description: |-
-        * `ACTIVE` - Ενεργή
-        * `PENDING` - Εκκρεμεί Επιβεβαίωση
-        * `UNSUBSCRIBED` - Διαγραφή
-        * `BOUNCED` - Επιστράφηκε
+        * `ACTIVE` - Active
+        * `PENDING` - Pending Confirmation
+        * `UNSUBSCRIBED` - Unsubscribed
+        * `BOUNCED` - Bounced
     SubscriptionTopic:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -39419,35 +39050,33 @@ components:
           readOnly: true
         slug:
           type: string
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
         subscriberCount:
           type: integer
           readOnly: true
@@ -39494,35 +39123,33 @@ components:
           readOnly: true
         slug:
           type: string
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
         subscriberCount:
           type: integer
           readOnly: true
@@ -39530,12 +39157,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -39575,35 +39200,33 @@ components:
         slug:
           type: string
           minLength: 1
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
       required:
         - slug
         - translations
@@ -39634,26 +39257,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: string
           readOnly: true
-          description: Πόσες φορές χρησιμοποιείται η ετικέτα
+          description: Number of times this tag is used
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39693,26 +39312,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: string
           readOnly: true
-          description: Πόσες φορές χρησιμοποιείται η ετικέτα
+          description: Number of times this tag is used
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39720,7 +39335,7 @@ components:
         contentTypes:
           type: string
           readOnly: true
-          description: Τύποι περιεχομένου με τους οποίους χρησιμοποιείται αυτή η ετικέτα
+          description: Content types this tag is used with
       required:
         - contentTypes
         - createdAt
@@ -39754,7 +39369,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
       required:
         - translations
     TaggedItem:
@@ -39772,14 +39386,14 @@ components:
         contentTypeName:
           type: string
           readOnly: true
-          description: Όνομα τύπου περιεχομένου
+          description: Name of the content type
         objectId:
           type: integer
           maximum: 2147483647
           minimum: 0
         contentObject:
           type: object
-          description: Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+          description: Serialized representation of the related content object
           properties:
             id:
               type: integer
@@ -39802,12 +39416,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39837,14 +39449,14 @@ components:
         contentTypeName:
           type: string
           readOnly: true
-          description: Όνομα τύπου περιεχομένου
+          description: Name of the content type
         objectId:
           type: integer
           maximum: 2147483647
           minimum: 0
         contentObject:
           type: object
-          description: Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+          description: Serialized representation of the related content object
           properties:
             id:
               type: integer
@@ -39867,12 +39479,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39893,7 +39503,7 @@ components:
         tagId:
           type: integer
           writeOnly: true
-          description: ID ετικέτας προς ανάθεση
+          description: ID of the tag to assign
         contentType:
           type: integer
         objectId:
@@ -40098,13 +39708,13 @@ components:
         - OTHER
       type: string
       description: |-
-        * `MARKETING` - Καμπάνιες marketing
-        * `PRODUCT` - Ενημερώσεις προϊόντων
-        * `ACCOUNT` - Λογαριασμός Ανενεργός
-        * `SYSTEM` - Ειδοποιήσεις Συστήματος
+        * `MARKETING` - Marketing Campaigns
+        * `PRODUCT` - Product Updates
+        * `ACCOUNT` - Account Updates
+        * `SYSTEM` - System Notifications
         * `NEWSLETTER` - Newsletter
-        * `PROMOTIONAL` - Προωθητικό
-        * `OTHER` - Άλλο
+        * `PROMOTIONAL` - Promotional
+        * `OTHER` - Other
     TransactionTypeEnum:
       enum:
         - EARN
@@ -40114,10 +39724,10 @@ components:
         - BONUS
       type: string
       description: |-
-        * `EARN` - Κερδίστε
-        * `REDEEM` - Εξαργύρωση
-        * `EXPIRE` - Λήξη
-        * `ADJUST` - Προσαρμογή
+        * `EARN` - Earn
+        * `REDEEM` - Redeem
+        * `EXPIRE` - Expire
+        * `ADJUST` - Adjust
         * `BONUS` - Bonus
     TrendingSearchItem:
       type: object
@@ -40168,9 +39778,9 @@ components:
       type: string
       description: |-
         * `apm` - APM
-        * `any_apm` - Οποιοδήποτε APM
-        * `warehouse` - Αποθήκη
-        * `depot` - Αποθήκη
+        * `any_apm` - Any APM
+        * `warehouse` - Warehouse
+        * `depot` - Depot
     UnsubscribeResponse:
       type: object
       properties:
@@ -40204,39 +39814,31 @@ components:
           readOnly: true
         title:
           type: string
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40244,31 +39846,27 @@ components:
           type: string
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         user:
           type: integer
           readOnly: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40297,39 +39895,31 @@ components:
           readOnly: true
         title:
           type: string
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40337,31 +39927,27 @@ components:
           type: string
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         user:
           type: integer
           readOnly: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40388,45 +39974,37 @@ components:
         title:
           type: string
           minLength: 1
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
           minLength: 1
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40435,20 +40013,18 @@ components:
           minLength: 1
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
       required:
         - city
         - country
@@ -40508,15 +40084,13 @@ components:
         email:
           type: string
           format: email
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         id:
           type: integer
@@ -40536,91 +40110,86 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         linkedin:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         facebook:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         instagram:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         website:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         youtube:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         github:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργή
+          title: Active
         isStaff:
           type: boolean
           readOnly: true
-          title: Προσωπικό
+          title: Staff
         isSuperuser:
           type: boolean
           readOnly: true
@@ -40630,12 +40199,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40678,33 +40245,26 @@ components:
             - $ref: '#/components/schemas/SubscriptionTopic'
           readOnly: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/SubscriptionStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/SubscriptionStatus'
         subscribedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εγγραφή στις
         unsubscribedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Διαγραφή στις
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -40731,33 +40291,26 @@ components:
             - $ref: '#/components/schemas/SubscriptionTopic'
           readOnly: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/SubscriptionStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/SubscriptionStatus'
         subscribedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εγγραφή στις
         unsubscribedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Διαγραφή στις
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -40773,8 +40326,7 @@ components:
         topic:
           type: integer
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
       required:
         - topic
     UserWriteRequest:
@@ -40784,15 +40336,13 @@ components:
           type: string
           format: email
           minLength: 1
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         username:
           nullable: true
@@ -40814,38 +40364,34 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           nullable: true
-          title: Προφίλ Twitter
+          title: Twitter Profile
           oneOf:
             - type: string
               format: uri
@@ -40854,7 +40400,7 @@ components:
               maxLength: 0
         linkedin:
           nullable: true
-          title: Προφίλ LinkedIn
+          title: LinkedIn Profile
           oneOf:
             - type: string
               format: uri
@@ -40863,7 +40409,7 @@ components:
               maxLength: 0
         facebook:
           nullable: true
-          title: Προφίλ Facebook
+          title: Facebook Profile
           oneOf:
             - type: string
               format: uri
@@ -40872,7 +40418,7 @@ components:
               maxLength: 0
         instagram:
           nullable: true
-          title: Προφίλ Instagram
+          title: Instagram Profile
           oneOf:
             - type: string
               format: uri
@@ -40881,7 +40427,6 @@ components:
               maxLength: 0
         website:
           nullable: true
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -40890,7 +40435,7 @@ components:
               maxLength: 0
         youtube:
           nullable: true
-          title: Προφίλ Youtube
+          title: Youtube Profile
           oneOf:
             - type: string
               format: uri
@@ -40899,7 +40444,7 @@ components:
               maxLength: 0
         github:
           nullable: true
-          title: Προφίλ Github
+          title: Github Profile
           oneOf:
             - type: string
               format: uri
@@ -40908,12 +40453,11 @@ components:
               maxLength: 0
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
           minLength: 1
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
       required:
         - email
@@ -40923,7 +40467,7 @@ components:
         username:
           type: string
           minLength: 1
-          description: Νέο όνομα χρήστη
+          description: New username
           maxLength: 150
       required:
         - username
@@ -40932,7 +40476,7 @@ components:
       properties:
         detail:
           type: string
-          description: Μήνυμα επιτυχίας για ενημέρωση ονόματος χρήστη
+          description: Success message for username update
       required:
         - detail
     VariantAxis:

--- a/schema.yml
+++ b/schema.yml
@@ -67,14 +67,14 @@ paths:
   /api/v1/blog/author:
     get:
       operationId: listBlogAuthor
-      description: 'Ανάκτηση λίστας Συντάκτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Συντάκτες Blog
+      description: 'Retrieve a list of Blog Authors with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Authors
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -84,7 +84,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -108,7 +108,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -117,7 +117,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -127,7 +127,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -178,8 +178,8 @@ paths:
           description: ''
     post:
       operationId: createBlogAuthor
-      description: Δημιουργία νέου Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Συντάκτης Blog
+      description: Create a new Blog Author. Requires authentication.
+      summary: Create a Blog Author
       parameters:
         - in: query
           name: languageCode
@@ -190,7 +190,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -247,8 +247,8 @@ paths:
   /api/v1/blog/author/{id}:
     get:
       operationId: retrieveBlogAuthor
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συντάκτης Blog.
-      summary: Ανάκτηση Συντάκτης Blog
+      description: Get detailed information about a specific Blog Author.
+      summary: Retrieve a Blog Author
       parameters:
         - in: path
           name: id
@@ -267,7 +267,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       security:
@@ -306,8 +306,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogAuthor
-      description: Ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Συντάκτης Blog
+      description: Update Blog Author information. Requires authentication.
+      summary: Update a Blog Author
       parameters:
         - in: path
           name: id
@@ -326,7 +326,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -382,8 +382,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogAuthor
-      description: Μερική ενημέρωση πληροφοριών Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Συντάκτης Blog
+      description: Partially update Blog Author information. Requires authentication.
+      summary: Partially update a Blog Author
       parameters:
         - in: path
           name: id
@@ -402,7 +402,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Authors
       requestBody:
@@ -457,8 +457,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogAuthor
-      description: Διαγραφή Συντάκτης Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Συντάκτης Blog
+      description: Delete a Blog Author. Requires authentication.
+      summary: Delete a Blog Author
       parameters:
         - in: path
           name: id
@@ -496,8 +496,8 @@ paths:
   /api/v1/blog/author/{id}/posts:
     get:
       operationId: getBlogAuthorPosts
-      description: Ανάκτηση όλων των άρθρων που έχει γράψει αυτός ο συντάκτης, με σελιδοποίηση.
-      summary: Λήψη άρθρων συντάκτη
+      description: Retrieve all blog posts written by this author with proper pagination.
+      summary: Get author's blog posts
       parameters:
         - in: path
           name: id
@@ -583,8 +583,8 @@ paths:
   /api/v1/blog/category:
     get:
       operationId: listBlogCategory
-      description: 'Ανάκτηση λίστας Κατηγορίες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κατηγορίες Blog
+      description: 'Retrieve a list of Blog Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Categories
       parameters:
         - in: query
           name: languageCode
@@ -595,7 +595,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -619,7 +619,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -628,7 +628,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -638,7 +638,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -689,8 +689,8 @@ paths:
           description: ''
     post:
       operationId: createBlogCategory
-      description: Δημιουργία νέου Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κατηγορία Blog
+      description: Create a new Blog Category. Requires authentication.
+      summary: Create a Blog Category
       parameters:
         - in: query
           name: languageCode
@@ -701,7 +701,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -758,8 +758,8 @@ paths:
   /api/v1/blog/category/{id}:
     get:
       operationId: retrieveBlogCategory
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Blog.
-      summary: Ανάκτηση Κατηγορία Blog
+      description: Get detailed information about a specific Blog Category.
+      summary: Retrieve a Blog Category
       parameters:
         - in: path
           name: id
@@ -778,7 +778,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       security:
@@ -817,8 +817,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogCategory
-      description: Ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κατηγορία Blog
+      description: Update Blog Category information. Requires authentication.
+      summary: Update a Blog Category
       parameters:
         - in: path
           name: id
@@ -837,7 +837,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -893,8 +893,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogCategory
-      description: Μερική ενημέρωση πληροφοριών Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κατηγορία Blog
+      description: Partially update Blog Category information. Requires authentication.
+      summary: Partially update a Blog Category
       parameters:
         - in: path
           name: id
@@ -913,7 +913,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Categories
       requestBody:
@@ -968,8 +968,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogCategory
-      description: Διαγραφή Κατηγορία Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κατηγορία Blog
+      description: Delete a Blog Category. Requires authentication.
+      summary: Delete a Blog Category
       parameters:
         - in: path
           name: id
@@ -1007,8 +1007,8 @@ paths:
   /api/v1/blog/category/{id}/ancestors:
     get:
       operationId: listBlogCategoryAncestors
-      description: Λήψη όλων των προγόνων (γονέας, παππούς κ.λπ.) αυτής της κατηγορίας.
-      summary: Λήψη προγόνων κατηγορίας
+      description: Get all ancestors (parent, grandparent, etc.) of this category.
+      summary: Get category ancestors
       parameters:
         - in: path
           name: id
@@ -1094,8 +1094,8 @@ paths:
   /api/v1/blog/category/{id}/children:
     get:
       operationId: listBlogCategoryChildren
-      description: Λήψη άμεσων θυγατρικών κατηγοριών αυτής της κατηγορίας.
-      summary: Λήψη θυγατρικών κατηγοριών
+      description: Get direct children of this category.
+      summary: Get category children
       parameters:
         - in: path
           name: id
@@ -1181,8 +1181,8 @@ paths:
   /api/v1/blog/category/{id}/descendants:
     get:
       operationId: listBlogCategoryDescendants
-      description: Λήψη όλων των απογόνων (θυγατρικές, εγγόνια κ.λπ.) αυτής της κατηγορίας.
-      summary: Λήψη απογόνων κατηγορίας
+      description: Get all descendants (children, grandchildren, etc.) of this category.
+      summary: Get category descendants
       parameters:
         - in: path
           name: id
@@ -1268,8 +1268,8 @@ paths:
   /api/v1/blog/category/{id}/posts:
     get:
       operationId: listBlogCategoryPosts
-      description: Ανάκτηση όλων των άρθρων σε αυτή την κατηγορία και τις υποκατηγορίες της. Χρησιμοποιήστε 'recursive=true' για να συμπεριληφθούν άρθρα από όλες τις κατηγορίες-απογόνους.
-      summary: Λήψη άρθρων κατηγορίας
+      description: Retrieve all blog posts in this category and its subcategories. Use 'recursive=true' to include posts from all descendant categories.
+      summary: Get category's blog posts
       parameters:
         - in: path
           name: id
@@ -1367,8 +1367,8 @@ paths:
   /api/v1/blog/category/{id}/siblings:
     get:
       operationId: listBlogCategorySiblings
-      description: Λήψη κατηγοριών-αδερφών (ίδιο επίπεδο γονέα).
-      summary: Λήψη αδερφών κατηγοριών
+      description: Get sibling categories (same parent level).
+      summary: Get category siblings
       parameters:
         - in: path
           name: id
@@ -1454,8 +1454,8 @@ paths:
   /api/v1/blog/category/reorder:
     post:
       operationId: reorderBlogCategories
-      description: Μαζική αναδιάταξη κατηγοριών με ενημέρωση των τιμών sort_order.
-      summary: Αναδιάταξη κατηγοριών
+      description: Batch reorder categories by updating their sort_order values.
+      summary: Reorder categories
       tags:
         - Blog Categories
       requestBody:
@@ -1512,8 +1512,8 @@ paths:
   /api/v1/blog/category/tree:
     get:
       operationId: getBlogCategoryTree
-      description: Λήψη της πλήρους δενδρικής δομής κατηγοριών με ένθετες σχέσεις. Είναι πιο αποδοτικό από τη χρήση list?tree=true για την εμφάνιση μενού πλοήγησης ή ιεραρχιών κατηγοριών.
-      summary: Λήψη πλήρους δέντρου κατηγοριών
+      description: Get the complete category tree structure with nested relationships. This is more efficient than using list?tree=true for displaying navigation menus or category hierarchies.
+      summary: Get complete category tree
       parameters:
         - name: ordering
           in: query
@@ -1591,8 +1591,8 @@ paths:
   /api/v1/blog/comment:
     get:
       operationId: listBlogComment
-      description: 'Ανάκτηση λίστας Σχόλια Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Σχόλια Blog
+      description: 'Retrieve a list of Blog Comments with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Comments
       parameters:
         - in: query
           name: ancestorOf
@@ -1601,7 +1601,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -1613,12 +1613,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -1626,7 +1626,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -1658,7 +1658,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: descendantOf
           schema:
@@ -1666,7 +1666,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -1678,7 +1678,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -1690,7 +1690,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -1702,7 +1702,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: query
           name: id
           schema:
@@ -1715,7 +1715,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -1733,7 +1733,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -1745,7 +1745,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: languageCode
           schema:
@@ -1755,7 +1755,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: level
           schema:
@@ -1763,7 +1763,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -1771,7 +1771,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -1779,7 +1779,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -1787,7 +1787,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -1809,7 +1809,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -1817,7 +1817,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -1825,7 +1825,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -1833,7 +1833,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -1841,7 +1841,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -1849,7 +1849,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -1857,7 +1857,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -1869,7 +1869,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -1881,7 +1881,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -1905,7 +1905,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -1914,7 +1914,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -1924,7 +1924,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: parent
           schema:
@@ -1932,7 +1932,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -1944,7 +1944,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -1952,7 +1952,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -1960,7 +1960,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -1968,12 +1968,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -1985,17 +1985,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -2003,7 +2003,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -2031,7 +2031,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -2066,12 +2066,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -2083,7 +2083,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -2095,7 +2095,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -2144,8 +2144,8 @@ paths:
           description: ''
     post:
       operationId: createBlogComment
-      description: Δημιουργία νέου Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Σχόλιο Blog
+      description: Create a new Blog Comment. Requires authentication.
+      summary: Create a Blog Comment
       parameters:
         - in: query
           name: languageCode
@@ -2156,7 +2156,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2213,8 +2213,8 @@ paths:
   /api/v1/blog/comment/{id}:
     get:
       operationId: retrieveBlogComment
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχόλιο Blog.
-      summary: Ανάκτηση Σχόλιο Blog
+      description: Get detailed information about a specific Blog Comment.
+      summary: Retrieve a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2233,7 +2233,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       security:
@@ -2271,8 +2271,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogComment
-      description: Ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Σχόλιο Blog
+      description: Update Blog Comment information. Requires authentication.
+      summary: Update a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2291,7 +2291,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2347,8 +2347,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogComment
-      description: Μερική ενημέρωση πληροφοριών Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Σχόλιο Blog
+      description: Partially update Blog Comment information. Requires authentication.
+      summary: Partially update a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2367,7 +2367,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Comments
       requestBody:
@@ -2422,8 +2422,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogComment
-      description: Διαγραφή Σχόλιο Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Σχόλιο Blog
+      description: Delete a Blog Comment. Requires authentication.
+      summary: Delete a Blog Comment
       parameters:
         - in: path
           name: id
@@ -2461,8 +2461,8 @@ paths:
   /api/v1/blog/comment/{id}/post:
     get:
       operationId: getBlogCommentPost
-      description: Λήψη του άρθρου στο οποίο ανήκει αυτό το σχόλιο.
-      summary: Λήψη άρθρου σχολίου
+      description: Get the blog post that this comment belongs to.
+      summary: Get comment's blog post
       parameters:
         - in: path
           name: id
@@ -2516,8 +2516,8 @@ paths:
   /api/v1/blog/comment/{id}/replies:
     get:
       operationId: listBlogCommentReplies
-      description: Λήψη όλων των απαντήσεων (θυγατρικά) αυτού του σχολίου σε δομή νήματος.
-      summary: Λήψη απαντήσεων σχολίου
+      description: Get all replies (children) of this comment in threaded structure.
+      summary: Get comment replies
       parameters:
         - in: query
           name: ancestorOf
@@ -2526,7 +2526,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -2538,12 +2538,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -2551,7 +2551,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -2586,7 +2586,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -2598,7 +2598,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -2610,7 +2610,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -2622,7 +2622,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: path
           name: id
           schema:
@@ -2643,7 +2643,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -2661,7 +2661,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -2673,7 +2673,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -2681,7 +2681,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -2689,7 +2689,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -2697,7 +2697,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -2705,7 +2705,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -2727,7 +2727,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -2735,7 +2735,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -2743,7 +2743,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -2751,7 +2751,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -2759,7 +2759,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -2767,7 +2767,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -2775,7 +2775,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -2787,7 +2787,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -2799,7 +2799,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -2832,7 +2832,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -2844,7 +2844,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -2852,7 +2852,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -2860,7 +2860,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -2868,12 +2868,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -2885,17 +2885,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -2903,7 +2903,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -2931,7 +2931,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -2966,12 +2966,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -2983,7 +2983,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -2995,7 +2995,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -3045,8 +3045,8 @@ paths:
   /api/v1/blog/comment/{id}/thread:
     get:
       operationId: getBlogCommentThread
-      description: Λήψη ολόκληρου του νήματος (όλοι οι πρόγονοι και απόγονοι) αυτού του σχολίου.
-      summary: Λήψη νήματος σχολίων
+      description: Get the complete thread (all ancestors and descendants) of this comment.
+      summary: Get comment thread
       parameters:
         - in: query
           name: ancestorOf
@@ -3055,7 +3055,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -3067,12 +3067,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -3080,7 +3080,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -3115,7 +3115,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -3127,7 +3127,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -3139,7 +3139,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -3151,7 +3151,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: path
           name: id
           schema:
@@ -3172,7 +3172,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -3190,7 +3190,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -3202,7 +3202,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -3210,7 +3210,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -3218,7 +3218,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -3226,7 +3226,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -3234,7 +3234,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -3256,7 +3256,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -3264,7 +3264,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -3272,7 +3272,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -3280,7 +3280,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -3288,7 +3288,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -3296,7 +3296,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -3304,7 +3304,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -3316,7 +3316,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -3328,7 +3328,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -3361,7 +3361,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -3373,7 +3373,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -3381,7 +3381,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -3389,7 +3389,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -3397,12 +3397,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -3414,17 +3414,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -3432,7 +3432,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -3460,7 +3460,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -3495,12 +3495,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -3512,7 +3512,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -3524,7 +3524,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -3574,8 +3574,8 @@ paths:
   /api/v1/blog/comment/{id}/update_likes:
     post:
       operationId: toggleBlogCommentLike
-      description: Επισήμανση ή αναίρεση επισήμανσης σχολίου. Εναλλάσσει την κατάσταση επισήμανσης.
-      summary: Εναλλαγή επισήμανσης σχολίου
+      description: Like or unlike a comment. Toggles the like status.
+      summary: Toggle comment like
       parameters:
         - in: path
           name: id
@@ -3629,8 +3629,8 @@ paths:
   /api/v1/blog/comment/liked_comments:
     post:
       operationId: checkBlogCommentLikes
-      description: Έλεγχος ποια σχόλια από μια λίστα έχει επισημάνει ο τρέχων χρήστης.
-      summary: Έλεγχος μαζικής κατάστασης επισήμανσης
+      description: Check which comments from a list are liked by the current user.
+      summary: Check bulk like status
       tags:
         - Blog Comments
       requestBody:
@@ -3687,8 +3687,8 @@ paths:
   /api/v1/blog/comment/my_comments:
     get:
       operationId: listMyBlogComments
-      description: Λήψη όλων των σχολίων που έχει κάνει ο συνδεδεμένος χρήστης.
-      summary: Λήψη σχολίων τρέχοντος χρήστη
+      description: Get all comments made by the currently authenticated user.
+      summary: Get current user's comments
       parameters:
         - in: query
           name: ancestorOf
@@ -3697,7 +3697,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+          description: Filter comments that are ancestors of the given comment ID
         - in: query
           name: approved
           schema:
@@ -3709,12 +3709,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση έγκρισης
+          description: Filter by approval status
         - in: query
           name: content
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by comment content (case-insensitive)
         - in: query
           name: contentLength
           schema:
@@ -3722,7 +3722,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβές μήκος περιεχομένου
+          description: Filter by exact content length
         - in: query
           name: createdAfter
           schema:
@@ -3757,7 +3757,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+          description: Filter comments that are descendants of the given comment ID
         - in: query
           name: hasContent
           schema:
@@ -3769,7 +3769,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+          description: Filter comments that have content (true) or are empty (false)
         - in: query
           name: hasLikes
           schema:
@@ -3781,7 +3781,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+          description: Filter comments that have likes (true) or no likes (false)
         - in: query
           name: hasReplies
           schema:
@@ -3793,7 +3793,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+          description: Filter comments that have approved replies (true) or no replies (false)
         - in: query
           name: id
           schema:
@@ -3806,7 +3806,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -3824,7 +3824,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+          description: Filter anonymous comments (no user)
         - in: query
           name: isLeaf
           schema:
@@ -3836,7 +3836,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+          description: Filter leaf comments (no approved replies)
         - in: query
           name: level
           schema:
@@ -3844,7 +3844,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+          description: Filter by comment nesting level (0 for top-level)
         - in: query
           name: level_Gte
           schema:
@@ -3852,7 +3852,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+          description: Filter comments at or below this nesting level
         - in: query
           name: level_Lte
           schema:
@@ -3860,7 +3860,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+          description: Filter comments at or above this nesting level
         - in: query
           name: lft
           schema:
@@ -3868,7 +3868,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by left tree value (MPTT internal)
         - in: query
           name: lft_Gte
           schema:
@@ -3890,7 +3890,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+          description: Filter comments liked by specific user ID
         - in: query
           name: maxContentLength
           schema:
@@ -3898,7 +3898,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+          description: Filter comments with at most this content length
         - in: query
           name: maxLikes
           schema:
@@ -3906,7 +3906,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες επισημάνσεις
+          description: Filter comments with at most this many likes
         - in: query
           name: maxReplies
           schema:
@@ -3914,7 +3914,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at most this many approved replies
         - in: query
           name: minContentLength
           schema:
@@ -3922,7 +3922,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+          description: Filter comments with at least this content length
         - in: query
           name: minLikes
           schema:
@@ -3930,7 +3930,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+          description: Filter comments with at least this many likes
         - in: query
           name: minReplies
           schema:
@@ -3938,7 +3938,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+          description: Filter comments with at least this many approved replies
         - in: query
           name: mostLiked
           schema:
@@ -3950,7 +3950,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+          description: Order comments by most likes first
         - in: query
           name: mostReplied
           schema:
@@ -3962,7 +3962,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+          description: Order comments by most approved replies first
         - name: ordering
           in: query
           required: false
@@ -3995,7 +3995,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID γονικού σχολίου
+          description: Filter by parent comment ID
         - in: query
           name: parent_Isnull
           schema:
@@ -4007,7 +4007,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+          description: Filter top-level comments (true) or replies (false)
         - in: query
           name: post
           schema:
@@ -4015,7 +4015,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID άρθρου
+          description: Filter by blog post ID
         - in: query
           name: post_Author
           schema:
@@ -4023,7 +4023,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη άρθρου
+          description: Filter by blog post author ID
         - in: query
           name: post_Category
           schema:
@@ -4031,12 +4031,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας άρθρου
+          description: Filter by blog post category ID
         - in: query
           name: post_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας άρθρου
+          description: Filter by blog post category slug
         - in: query
           name: post_IsPublished
           schema:
@@ -4048,17 +4048,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+          description: Filter by blog post published status
         - in: query
           name: post_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug άρθρου
+          description: Filter by blog post slug
         - in: query
           name: post_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο άρθρου
+          description: Filter by blog post title
         - in: query
           name: rght
           schema:
@@ -4066,7 +4066,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+          description: Filter by right tree value (MPTT internal)
         - in: query
           name: rght_Gte
           schema:
@@ -4094,7 +4094,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+          description: Filter by tree ID (MPTT internal)
         - in: query
           name: updatedAfter
           schema:
@@ -4129,12 +4129,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη
+          description: Filter by user email
         - in: query
           name: user_IsActive
           schema:
@@ -4146,7 +4146,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από ενεργούς χρήστες
+          description: Filter comments by active users
         - in: query
           name: user_IsStaff
           schema:
@@ -4158,7 +4158,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο σχολίων από staff
+          description: Filter comments by staff users
         - in: query
           name: uuid
           schema:
@@ -4208,8 +4208,8 @@ paths:
   /api/v1/blog/post:
     get:
       operationId: listBlogPost
-      description: 'Ανάκτηση λίστας Άρθρα Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Άρθρα Blog
+      description: 'Retrieve a list of Blog Posts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Posts
       parameters:
         - in: query
           name: author
@@ -4218,17 +4218,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -4236,18 +4236,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -4268,7 +4268,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -4280,12 +4280,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: featured
           schema:
@@ -4297,7 +4297,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -4310,7 +4310,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -4328,7 +4328,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: languageCode
           schema:
@@ -4338,7 +4338,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: minComments
           schema:
@@ -4346,7 +4346,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -4354,7 +4354,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -4362,7 +4362,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -4370,7 +4370,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -4394,7 +4394,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -4403,7 +4403,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -4413,13 +4413,13 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: publishedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -4440,7 +4440,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -4459,30 +4459,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -4503,7 +4503,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -4574,8 +4574,8 @@ paths:
           description: ''
     post:
       operationId: createBlogPost
-      description: Δημιουργία νέου Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Άρθρο Blog
+      description: Create a new Blog Post. Requires authentication.
+      summary: Create a Blog Post
       parameters:
         - in: query
           name: languageCode
@@ -4586,7 +4586,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4643,8 +4643,8 @@ paths:
   /api/v1/blog/post/{id}:
     get:
       operationId: retrieveBlogPost
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Άρθρο Blog.
-      summary: Ανάκτηση Άρθρο Blog
+      description: Get detailed information about a specific Blog Post.
+      summary: Retrieve a Blog Post
       parameters:
         - in: path
           name: id
@@ -4663,7 +4663,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       security:
@@ -4702,8 +4702,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogPost
-      description: Ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Άρθρο Blog
+      description: Update Blog Post information. Requires authentication.
+      summary: Update a Blog Post
       parameters:
         - in: path
           name: id
@@ -4722,7 +4722,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4778,8 +4778,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogPost
-      description: Μερική ενημέρωση πληροφοριών Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Άρθρο Blog
+      description: Partially update Blog Post information. Requires authentication.
+      summary: Partially update a Blog Post
       parameters:
         - in: path
           name: id
@@ -4798,7 +4798,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Post
       requestBody:
@@ -4853,8 +4853,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogPost
-      description: Διαγραφή Άρθρο Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Άρθρο Blog
+      description: Delete a Blog Post. Requires authentication.
+      summary: Delete a Blog Post
       parameters:
         - in: path
           name: id
@@ -4892,8 +4892,8 @@ paths:
   /api/v1/blog/post/{id}/comments:
     get:
       operationId: listBlogPostComments
-      description: Λήψη όλων των σχολίων ενός άρθρου.
-      summary: Λήψη σχολίων άρθρου
+      description: Get all comments for a blog post.
+      summary: Get post comments
       parameters:
         - in: path
           name: id
@@ -4996,8 +4996,8 @@ paths:
   /api/v1/blog/post/{id}/related_posts:
     get:
       operationId: listBlogPostRelated
-      description: Λήψη σχετικών άρθρων για ένα άρθρο.
-      summary: Λήψη σχετικών άρθρων
+      description: Get related posts for a blog post.
+      summary: Get related posts
       parameters:
         - in: query
           name: author
@@ -5006,17 +5006,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5024,18 +5024,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5056,7 +5056,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5068,7 +5068,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5080,7 +5080,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5102,7 +5102,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5120,7 +5120,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5128,7 +5128,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5136,7 +5136,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5144,7 +5144,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5152,7 +5152,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -5165,7 +5165,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -5186,7 +5186,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -5205,30 +5205,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -5249,7 +5249,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -5323,8 +5323,8 @@ paths:
   /api/v1/blog/post/{id}/update_likes:
     post:
       operationId: toggleBlogPostLike
-      description: Επισήμανση ή αναίρεση επισήμανσης άρθρου. Εναλλάσσει την κατάσταση επισήμανσης.
-      summary: Εναλλαγή επισήμανσης άρθρου
+      description: Like or unlike a blog post. Toggles the like status.
+      summary: Toggle post like
       parameters:
         - in: path
           name: id
@@ -5379,8 +5379,8 @@ paths:
   /api/v1/blog/post/{id}/update_view_count:
     post:
       operationId: incrementBlogPostViews
-      description: Αύξηση του μετρητή προβολών ενός άρθρου.
-      summary: Αύξηση προβολών άρθρου
+      description: Increment the view count for a blog post.
+      summary: Increment post view count
       parameters:
         - in: path
           name: id
@@ -5435,8 +5435,8 @@ paths:
   /api/v1/blog/post/featured:
     get:
       operationId: listFeaturedBlogPosts
-      description: Λήψη άρθρων που έχουν επισημανθεί ως προτεινόμενα, ταξινομημένα κατά ημερομηνία δημοσίευσης.
-      summary: Λήψη προτεινόμενων άρθρων
+      description: Get posts marked as featured, ordered by publication date.
+      summary: Get featured posts
       parameters:
         - in: query
           name: author
@@ -5445,17 +5445,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5463,18 +5463,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5495,7 +5495,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5507,7 +5507,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5519,7 +5519,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5532,7 +5532,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5550,7 +5550,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5558,7 +5558,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5566,7 +5566,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5574,7 +5574,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5582,7 +5582,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -5613,7 +5613,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -5634,7 +5634,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -5653,30 +5653,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -5697,7 +5697,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -5769,8 +5769,8 @@ paths:
   /api/v1/blog/post/liked_posts:
     post:
       operationId: checkBlogPostLikes
-      description: Λήψη όλων των άρθρων που έχει επισημάνει ο συνδεδεμένος χρήστης.
-      summary: Λήψη άρθρων με επισήμανση
+      description: Get all posts that the authenticated user has liked.
+      summary: Get liked posts
       tags:
         - Blog Posts
       requestBody:
@@ -5828,8 +5828,8 @@ paths:
   /api/v1/blog/post/popular:
     get:
       operationId: listPopularBlogPosts
-      description: Λήψη των πιο δημοφιλών άρθρων βάσει δεικτών αλληλεπίδρασης όλων των εποχών.
-      summary: Λήψη δημοφιλών άρθρων
+      description: Get most popular blog posts based on all-time engagement metrics.
+      summary: Get popular posts
       parameters:
         - in: query
           name: author
@@ -5838,17 +5838,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -5856,18 +5856,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -5888,7 +5888,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -5900,7 +5900,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: featured
           schema:
@@ -5912,7 +5912,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -5925,7 +5925,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -5943,7 +5943,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -5951,7 +5951,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -5959,7 +5959,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -5967,7 +5967,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -5975,7 +5975,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -6006,7 +6006,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -6027,7 +6027,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -6046,30 +6046,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -6090,7 +6090,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -6162,8 +6162,8 @@ paths:
   /api/v1/blog/post/trending:
     get:
       operationId: listTrendingBlogPosts
-      description: Λήψη δημοφιλών άρθρων βάσει πρόσφατων δεικτών αλληλεπίδρασης. Συνδυάζει προβολές, επισημάνσεις και σχόλια πρόσφατης περιόδου.
-      summary: Λήψη trending άρθρων
+      description: Get trending blog posts based on recent engagement metrics. Combines views, likes, and comments from recent time period.
+      summary: Get trending posts
       parameters:
         - in: query
           name: author
@@ -6172,17 +6172,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID συντάκτη
+          description: Filter by author ID
         - in: query
           name: authorEmail
           schema:
             type: string
-          description: Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author email (case-insensitive)
         - in: query
           name: authorName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by author full name (case-insensitive)
         - in: query
           name: category
           schema:
@@ -6190,18 +6190,18 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας
+          description: Filter by category ID
         - in: query
           name: categoryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by category name (case-insensitive)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -6222,7 +6222,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -6234,7 +6234,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: days
           schema:
@@ -6254,7 +6254,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προτεινόμενου
+          description: Filter by featured status
         - in: query
           name: id
           schema:
@@ -6267,7 +6267,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -6285,7 +6285,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: minComments
           schema:
@@ -6293,7 +6293,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+          description: Filter by minimum number of approved comments
         - in: query
           name: minLikes
           schema:
@@ -6301,7 +6301,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+          description: Filter by minimum number of likes
         - in: query
           name: minTags
           schema:
@@ -6309,7 +6309,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+          description: Filter by minimum number of active tags
         - in: query
           name: minViewCount
           schema:
@@ -6317,7 +6317,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστο αριθμό προβολών
+          description: Filter by minimum number of views
         - name: ordering
           in: query
           required: false
@@ -6348,7 +6348,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -6369,7 +6369,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - name: search
           required: false
           in: query
@@ -6388,30 +6388,30 @@ paths:
           name: tagName
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by tag label (case-insensitive)
         - in: query
           name: tags
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
-          description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+          description: Filter by tag IDs (comma-separated)
           explode: true
           style: form
         - in: query
           name: title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by title (case-insensitive)
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -6432,7 +6432,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: uuid
           schema:
@@ -6504,8 +6504,8 @@ paths:
   /api/v1/blog/tag:
     get:
       operationId: listBlogTag
-      description: 'Ανάκτηση λίστας Ετικέτες Blog με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ετικέτες Blog
+      description: 'Retrieve a list of Blog Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Blog Tags
       parameters:
         - in: query
           name: active
@@ -6518,7 +6518,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: createdAfter
           schema:
@@ -6550,7 +6550,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasLikedPosts
           schema:
@@ -6562,7 +6562,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα με/χωρίς επισημάνσεις
+          description: Filter tags used in posts that have/don't have likes
         - in: query
           name: hasName
           schema:
@@ -6574,7 +6574,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς όνομα
+          description: Filter tags that have/don't have a name
         - in: query
           name: hasPosts
           schema:
@@ -6586,7 +6586,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς άρθρα
+          description: Filter tags that have/don't have posts
         - in: query
           name: id
           schema:
@@ -6599,7 +6599,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -6615,7 +6615,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxPosts
           schema:
@@ -6623,7 +6623,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με έως X άρθρα
+          description: Filter tags with at most X posts
         - in: query
           name: minPosts
           schema:
@@ -6631,7 +6631,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με τουλάχιστον X άρθρα
+          description: Filter tags with at least X posts
         - in: query
           name: minTotalLikes
           schema:
@@ -6639,7 +6639,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών με άρθρα που έχουν τουλάχιστον X συνολικές επισημάνσεις
+          description: Filter tags with posts having at least X total likes
         - in: query
           name: mostLiked
           schema:
@@ -6651,7 +6651,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά συνολικές επισημάνσεις στα άρθρα που τις χρησιμοποιούν
+          description: Order tags by total likes on posts using them
         - in: query
           name: mostUsed
           schema:
@@ -6663,22 +6663,22 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+          description: Order tags by usage count (most used first)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα ετικέτας (μερική αντιστοίχιση)
+          description: Filter by tag name (partial match)
         - in: query
           name: name_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές όνομα ετικέτας
+          description: Filter by exact tag name
         - in: query
           name: name_Startswith
           schema:
             type: string
-          description: Φίλτρο ετικετών με όνομα που ξεκινά με
+          description: Filter tags with names starting with
         - name: ordering
           in: query
           required: false
@@ -6702,7 +6702,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -6711,7 +6711,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -6721,7 +6721,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: post
           schema:
@@ -6729,7 +6729,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται από συγκεκριμένο άρθρο
+          description: Filter tags used by specific post ID
         - in: query
           name: post_Author
           schema:
@@ -6737,7 +6737,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένου συντάκτη
+          description: Filter tags used in posts by specific author
         - in: query
           name: post_Category
           schema:
@@ -6745,7 +6745,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένης κατηγορίας
+          description: Filter tags used in posts from specific category
         - in: query
           name: post_IsPublished
           schema:
@@ -6757,7 +6757,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που χρησιμοποιούνται σε δημοσιευμένα/μη δημοσιευμένα άρθρα
+          description: Filter tags used in published/unpublished posts
         - name: search
           required: false
           in: query
@@ -6808,7 +6808,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που δεν χρησιμοποιούνται σε κανένα άρθρο
+          description: Filter tags not used in any posts
         - in: query
           name: updatedAfter
           schema:
@@ -6885,8 +6885,8 @@ paths:
           description: ''
     post:
       operationId: createBlogTag
-      description: Δημιουργία νέου Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ετικέτα Blog
+      description: Create a new Blog Tag. Requires authentication.
+      summary: Create a Blog Tag
       parameters:
         - in: query
           name: languageCode
@@ -6897,7 +6897,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -6954,8 +6954,8 @@ paths:
   /api/v1/blog/tag/{id}:
     get:
       operationId: retrieveBlogTag
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα Blog.
-      summary: Ανάκτηση Ετικέτα Blog
+      description: Get detailed information about a specific Blog Tag.
+      summary: Retrieve a Blog Tag
       parameters:
         - in: path
           name: id
@@ -6974,7 +6974,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       security:
@@ -7013,8 +7013,8 @@ paths:
           description: ''
     put:
       operationId: updateBlogTag
-      description: Ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Ετικέτα Blog
+      description: Update Blog Tag information. Requires authentication.
+      summary: Update a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7033,7 +7033,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -7089,8 +7089,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateBlogTag
-      description: Μερική ενημέρωση πληροφοριών Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Ετικέτα Blog
+      description: Partially update Blog Tag information. Requires authentication.
+      summary: Partially update a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7109,7 +7109,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Blog Tags
       requestBody:
@@ -7164,8 +7164,8 @@ paths:
           description: ''
     delete:
       operationId: destroyBlogTag
-      description: Διαγραφή Ετικέτα Blog. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ετικέτα Blog
+      description: Delete a Blog Tag. Requires authentication.
+      summary: Delete a Blog Tag
       parameters:
         - in: path
           name: id
@@ -7203,8 +7203,8 @@ paths:
   /api/v1/cart:
     get:
       operationId: retrieveCart
-      description: Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λήψη καλαθιού
+      description: Get a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Get cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7250,8 +7250,8 @@ paths:
           description: ''
     put:
       operationId: updateCart
-      description: Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση καλαθιού
+      description: Update a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7303,8 +7303,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCart
-      description: Ενημέρωση καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση καλαθιού
+      description: Update a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7356,8 +7356,8 @@ paths:
           description: ''
     delete:
       operationId: destroyCart
-      description: Διαγραφή καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Διαγραφή καλαθιού
+      description: Delete a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Delete cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7392,8 +7392,8 @@ paths:
   /api/v1/cart/create-payment-intent:
     post:
       operationId: createCartPaymentIntent
-      description: Δημιουργία Stripe payment intent βάσει του συνόλου του καλαθιού πριν τη δημιουργία παραγγελίας. Απαιτείται για μεθόδους online πληρωμής (Stripe) στη ροή πληρωμής πριν την παραγγελία. Επιστρέφει client_secret για επιβεβαίωση πληρωμής στο frontend και payment_intent_id προς συμπερίληψη στο αίτημα δημιουργίας παραγγελίας.
-      summary: Δημιουργία payment intent από καλάθι
+      description: Create a Stripe payment intent based on cart total before order creation. This is required for online payment methods (Stripe) in the payment-first flow. Returns client_secret for frontend payment confirmation and payment_intent_id to be included in order creation request.
+      summary: Create payment intent from cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7458,8 +7458,8 @@ paths:
   /api/v1/cart/item:
     get:
       operationId: listCartItem
-      description: Ανάκτηση λίστας ειδών καλαθιού με δυνατότητες φιλτραρίσματος και αναζήτησης. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λίστα αντικειμένων καλαθιού
+      description: Retrieve a list of cart items with filtering and search capabilities. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: List cart items
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7474,7 +7474,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID καλαθιού
+          description: Filter by cart ID
         - in: query
           name: cart_IsGuest
           schema:
@@ -7486,7 +7486,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων σε καλάθια επισκεπτών
+          description: Filter items in guest carts
         - in: query
           name: cart_User
           schema:
@@ -7494,35 +7494,35 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη καλαθιού
+          description: Filter by cart user ID
         - in: query
           name: cart_User_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη καλαθιού (μερική αντιστοίχιση)
+          description: Filter by cart user email (partial match)
         - in: query
           name: cart_User_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη καλαθιού (όνομα ή επώνυμο)
+          description: Filter by cart user name (first or last)
         - in: query
           name: cart_Uuid
           schema:
             type: string
             format: uuid
-          description: Φίλτρο ανά UUID καλαθιού
+          description: Filter by cart UUID
         - in: query
           name: cartLastActivityAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά τελευταία δραστηριότητα καλαθιού μετά από ημερομηνία
+          description: Filter by cart last activity after date
         - in: query
           name: cartLastActivityBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά τελευταία δραστηριότητα καλαθιού πριν από ημερομηνία
+          description: Filter by cart last activity before date
         - in: query
           name: createdAfter
           schema:
@@ -7554,7 +7554,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -7567,7 +7567,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -7585,7 +7585,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών σε εγκαταλελειμμένα καλάθια (30+ ημέρες)
+          description: Filter items in abandoned carts (30+ days)
         - in: query
           name: inActiveCarts
           schema:
@@ -7597,7 +7597,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών σε ενεργά καλάθια (24ωρο)
+          description: Filter items in active carts (24hr)
         - in: query
           name: languageCode
           schema:
@@ -7607,7 +7607,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxDiscountPercent
           schema:
@@ -7615,7 +7615,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο ποσοστό έκπτωσης
+          description: Filter by maximum discount percentage
         - in: query
           name: maxPrice
           schema:
@@ -7623,7 +7623,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη τιμή προϊόντος
+          description: Filter by maximum product price
         - in: query
           name: maxQuantity
           schema:
@@ -7631,7 +7631,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα
+          description: Filter by maximum quantity
         - in: query
           name: maxTotalPrice
           schema:
@@ -7639,7 +7639,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη συνολική τιμή (ποσότητα * τιμή)
+          description: Filter by maximum total price (quantity * price)
         - in: query
           name: minDiscountPercent
           schema:
@@ -7647,7 +7647,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο ποσοστό έκπτωσης
+          description: Filter by minimum discount percentage
         - in: query
           name: minPrice
           schema:
@@ -7655,7 +7655,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη τιμή προϊόντος
+          description: Filter by minimum product price
         - in: query
           name: minQuantity
           schema:
@@ -7663,7 +7663,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα
+          description: Filter by minimum quantity
         - in: query
           name: minTotalPrice
           schema:
@@ -7671,7 +7671,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη συνολική τιμή (ποσότητα * τιμή)
+          description: Filter by minimum total price (quantity * price)
         - name: ordering
           in: query
           required: false
@@ -7695,7 +7695,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -7704,7 +7704,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -7714,7 +7714,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -7722,7 +7722,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: product_Active
           schema:
@@ -7734,7 +7734,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: product_Category
           schema:
@@ -7742,28 +7742,28 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: product_Category_Slug
           schema:
             type: string
-          description: Φίλτρο ανά slug κατηγορίας προϊόντος
+          description: Filter by product category slug
         - in: query
           name: product_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+          description: Filter by product name (partial match)
         - in: query
           name: product_Sku
           schema:
             type: string
-          description: Φίλτρο ανά sku προϊόντος (ακριβής αντιστοίχιση)
+          description: Filter by product sku (exact match)
         - in: query
           name: product_Uuid
           schema:
             type: string
             format: uuid
-          description: Φίλτρο ανά UUID προϊόντος
+          description: Filter by product UUID
         - in: query
           name: quantity
           schema:
@@ -7771,7 +7771,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ποσότητα
+          description: Filter by exact quantity
         - in: query
           name: quantity_Gte
           schema:
@@ -7835,7 +7835,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με εκπτώσεις προϊόντος
+          description: Filter items with product discounts
       tags:
         - Cart Items
       security:
@@ -7880,8 +7880,8 @@ paths:
           description: ''
     post:
       operationId: createCartItem
-      description: Δημιουργία νέου είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Δημιουργία αντικειμένου καλαθιού
+      description: Create a new cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Create a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7946,8 +7946,8 @@ paths:
   /api/v1/cart/item/{id}:
     get:
       operationId: retrieveCartItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο είδος καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ανάκτηση είδους καλαθιού
+      description: Get detailed information about a specific cart item. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Retrieve a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -7972,7 +7972,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Cart Items
       security:
@@ -8011,8 +8011,8 @@ paths:
           description: ''
     put:
       operationId: updateCartItem
-      description: Ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Ενημέρωση αντικειμένου καλαθιού
+      description: Update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Update a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8083,8 +8083,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCartItem
-      description: Μερική ενημέρωση πληροφοριών είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Μερική ενημέρωση είδους καλαθιού
+      description: Partially update cart item information. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Partially update a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8109,7 +8109,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Cart Items
       requestBody:
@@ -8165,8 +8165,8 @@ paths:
           description: ''
     delete:
       operationId: destroyCartItem
-      description: Διαγραφή είδους καλαθιού. Απαιτεί ταυτοποίηση. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Διαγραφή αντικειμένου καλαθιού
+      description: Delete a cart item. Requires authentication. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Delete a cart item
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8209,8 +8209,8 @@ paths:
   /api/v1/cart/list:
     get:
       operationId: listCart
-      description: Λήψη καλαθιού. Για επισκέπτες, συμπεριλάβετε την κεφαλίδα X-Cart-Id για διατήρηση της συνεδρίας καλαθιού.
-      summary: Λήψη καλαθιού
+      description: Get a cart. For guest users, include X-Cart-Id header to maintain cart session.
+      summary: Get cart
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8227,7 +8227,7 @@ paths:
               - guest
               - user
           description: |-
-            Φίλτρο ανά τύπο καλαθιού
+            Filter by cart type
 
             * `user` - User Cart
             * `guest` - Guest Cart
@@ -8263,7 +8263,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: daysInactive
           schema:
@@ -8271,7 +8271,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών αδρανών για τουλάχιστον X ημέρες
+          description: Filter carts inactive for at least X days
         - in: query
           name: hasDiscounts
           schema:
@@ -8283,7 +8283,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς είδη σε έκπτωση
+          description: Filter carts with/without discounted items
         - in: query
           name: hasItems
           schema:
@@ -8295,7 +8295,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς είδη
+          description: Filter carts that have/don't have items
         - in: query
           name: id
           schema:
@@ -8308,7 +8308,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -8326,7 +8326,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο εγκαταλελειμμένων καλαθιών (αδρανή για 30+ ημέρες)
+          description: Filter abandoned carts (inactive for 30+ days)
         - in: query
           name: isActive
           schema:
@@ -8338,7 +8338,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών/εγκαταλελειμμένων καλαθιών (βάσει 30 ημερών αδράνειας)
+          description: Filter active/abandoned carts (based on 30-day inactivity)
         - in: query
           name: isGuest
           schema:
@@ -8350,7 +8350,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών επισκεπτών (True) ή καλαθιών χρηστών (False)
+          description: Filter guest carts (True) or user carts (False)
         - in: query
           name: languageCode
           schema:
@@ -8360,13 +8360,13 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastActivity
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ανά ακριβή ημερομηνία τελευταίας δραστηριότητας
+          description: Filter by exact last activity date
         - in: query
           name: lastActivity_Date
           schema:
@@ -8387,13 +8387,13 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο καλαθιών με τελευταία δραστηριότητα μετά από αυτή την ημερομηνία
+          description: Filter carts with last activity after this date
         - in: query
           name: lastActivityBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο καλαθιών με τελευταία δραστηριότητα πριν από αυτή την ημερομηνία
+          description: Filter carts with last activity before this date
         - in: query
           name: maxItems
           schema:
@@ -8401,7 +8401,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με έως X συνολικά είδη (ποσότητα)
+          description: Filter carts with at most X total items (quantity)
         - in: query
           name: maxTotalValue
           schema:
@@ -8409,7 +8409,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με συνολική αξία έως X
+          description: Filter carts with total value at most X
         - in: query
           name: maxUniqueItems
           schema:
@@ -8417,7 +8417,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με έως X μοναδικά είδη
+          description: Filter carts with at most X unique items
         - in: query
           name: minItems
           schema:
@@ -8425,7 +8425,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με τουλάχιστον X συνολικά είδη (ποσότητα)
+          description: Filter carts with at least X total items (quantity)
         - in: query
           name: minTotalValue
           schema:
@@ -8433,7 +8433,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με συνολική αξία τουλάχιστον X
+          description: Filter carts with total value at least X
         - in: query
           name: minUniqueItems
           schema:
@@ -8441,7 +8441,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο καλαθιών με τουλάχιστον X μοναδικά είδη
+          description: Filter carts with at least X unique items
         - name: ordering
           in: query
           required: false
@@ -8465,7 +8465,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -8474,7 +8474,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -8484,7 +8484,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -8525,7 +8525,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_IsActive
           schema:
@@ -8537,7 +8537,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργούς χρήστες
+          description: Filter by active users
         - in: query
           name: user_Isnull
           schema:
@@ -8549,17 +8549,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο καλαθιών με/χωρίς χρήστες
+          description: Filter carts with/without users
         - in: query
           name: userEmail
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+          description: Filter by user email (partial match)
         - in: query
           name: userName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα χρήστη (όνομα ή επώνυμο)
+          description: Filter by user full name (first or last name)
         - in: query
           name: uuid
           schema:
@@ -8609,8 +8609,8 @@ paths:
   /api/v1/cart/release-reservations:
     post:
       operationId: releaseCartReservations
-      description: Απελευθέρωση δεσμεύσεων αποθέματος όταν το checkout εγκαταλείπεται ή η πληρωμή αποτυγχάνει. Αυτό καθιστά το δεσμευμένο απόθεμα διαθέσιμο για άλλους πελάτες.
-      summary: Αποδέσμευση δεσμεύσεων αποθέματος
+      description: Release stock reservations when checkout is abandoned or payment fails. This makes the reserved stock available for other customers.
+      summary: Release stock reservations
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8675,8 +8675,8 @@ paths:
   /api/v1/cart/reserve-stock:
     post:
       operationId: reserveCartStock
-      description: Δέσμευση αποθέματος για όλα τα είδη του καλαθιού κατά το checkout. Δημιουργεί προσωρινές δεσμεύσεις αποθέματος με διάρκεια ζωής 15 λεπτών. Επιστρέφει λίστα ID δεσμεύσεων για χρήση κατά τη δημιουργία της παραγγελίας.
-      summary: Δέσμευση αποθέματος για αντικείμενα καλαθιού
+      description: Reserve stock for all items in the cart during checkout. Creates temporary stock reservations with 15-minute TTL. Returns list of reservation IDs to be used during order creation.
+      summary: Reserve stock for cart items
       parameters:
         - in: header
           name: X-Cart-Id
@@ -8729,8 +8729,8 @@ paths:
   /api/v1/contact:
     post:
       operationId: createContact
-      description: Αποστολή μηνύματος επικοινωνίας στους διαχειριστές του ιστότοπου.
-      summary: Δημιουργία μηνύματος επικοινωνίας
+      description: Send a contact message to the site administrators.
+      summary: Create a contact message
       tags:
         - Contact
       requestBody:
@@ -8764,19 +8764,19 @@ paths:
   /api/v1/country:
     get:
       operationId: listCountry
-      description: 'Ανάκτηση λίστας Χώρες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χώρες
+      description: 'Retrieve a list of Countries with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Countries
       parameters:
         - in: query
           name: alpha2
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή διψήφιο κωδικό χώρας
+          description: Filter by exact 2-letter country code
         - in: query
           name: alpha2_Icontains
           schema:
             type: string
-          description: Φίλτρο ανά διψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+          description: Filter by 2-letter country code (partial match)
         - in: query
           name: alpha2_Iexact
           schema:
@@ -8786,7 +8786,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -8797,12 +8797,12 @@ paths:
           name: alpha3
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή τριψήφιο κωδικό χώρας
+          description: Filter by exact 3-letter country code
         - in: query
           name: alpha3_Icontains
           schema:
             type: string
-          description: Φίλτρο ανά τριψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+          description: Filter by 3-letter country code (partial match)
         - in: query
           name: alpha3_Iexact
           schema:
@@ -8812,7 +8812,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -8832,7 +8832,7 @@ paths:
               - OC
               - SA
           description: |-
-            Φίλτρο ανά ήπειρο (βάσει κωδικών ISO)
+            Filter by continent (based on ISO codes)
 
             * `AF` - Africa
             * `AS` - Asia
@@ -8872,7 +8872,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasAllData
           schema:
@@ -8884,7 +8884,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με πλήρη δεδομένα (ISO, κλήση, σημαία, όνομα)
+          description: Filter countries that have complete data (ISO, phone, flag, name)
         - in: query
           name: hasFlagImage
           schema:
@@ -8896,7 +8896,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς εικόνα σημαίας
+          description: Filter countries that have/don't have flag image
         - in: query
           name: hasIsoCc
           schema:
@@ -8908,7 +8908,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς κωδικό ISO
+          description: Filter countries that have/don't have ISO country code
         - in: query
           name: hasName
           schema:
@@ -8920,7 +8920,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς μετάφραση ονόματος
+          description: Filter countries that have/don't have name translation
         - in: query
           name: hasPhoneCode
           schema:
@@ -8932,7 +8932,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών με/χωρίς κωδικό κλήσης
+          description: Filter countries that have/don't have phone code
         - in: query
           name: isEu
           schema:
@@ -8944,7 +8944,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χωρών μελών ΕΕ
+          description: Filter EU member countries
         - in: query
           name: isoCc
           schema:
@@ -8952,7 +8952,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ISO κωδικό χώρας
+          description: Filter by exact ISO country code
         - in: query
           name: isoCc_Gte
           schema:
@@ -8965,7 +8965,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -8986,7 +8986,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό ISO μικρότερο ή ίσο με
+          description: Filter countries with ISO code less than or equal to
         - in: query
           name: isoCcMin
           schema:
@@ -8994,7 +8994,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό ISO μεγαλύτερο ή ίσο με
+          description: Filter countries with ISO code greater than or equal to
         - in: query
           name: languageCode
           schema:
@@ -9004,27 +9004,27 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: multipleCodes
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλούς κωδικούς χωρών (διαχωρισμένους με κόμμα, alpha-2 ή alpha-3)
+          description: Filter by multiple country codes (comma-separated, alpha-2 or alpha-3)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: name_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές όνομα χώρας
+          description: Filter by exact country name
         - in: query
           name: name_Startswith
           schema:
             type: string
-          description: Φίλτρο χωρών με όνομα που ξεκινά με
+          description: Filter countries with names starting with
         - name: ordering
           in: query
           required: false
@@ -9048,7 +9048,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -9057,7 +9057,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -9067,7 +9067,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: phoneCode
           schema:
@@ -9075,7 +9075,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή κωδικό κλήσης
+          description: Filter by exact phone code
         - in: query
           name: phoneCode_Gte
           schema:
@@ -9088,7 +9088,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -9109,7 +9109,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό κλήσης μικρότερο ή ίσο με
+          description: Filter countries with phone code less than or equal to
         - in: query
           name: phoneCodeMin
           schema:
@@ -9117,7 +9117,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο χωρών με κωδικό κλήσης μεγαλύτερο ή ίσο με
+          description: Filter countries with phone code greater than or equal to
         - name: search
           required: false
           in: query
@@ -9221,8 +9221,8 @@ paths:
           description: ''
     post:
       operationId: createCountry
-      description: Δημιουργία νέου Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Χώρα
+      description: Create a new Country. Requires authentication.
+      summary: Create a Country
       parameters:
         - in: query
           name: languageCode
@@ -9233,7 +9233,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9290,15 +9290,15 @@ paths:
   /api/v1/country/{alpha_2}:
     get:
       operationId: retrieveCountry
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χώρα.
-      summary: Ανάκτηση Χώρα
+      description: Get detailed information about a specific Country.
+      summary: Retrieve a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9309,7 +9309,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       security:
@@ -9348,15 +9348,15 @@ paths:
           description: ''
     put:
       operationId: updateCountry
-      description: Ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Χώρα
+      description: Update Country information. Requires authentication.
+      summary: Update a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9367,7 +9367,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9423,15 +9423,15 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateCountry
-      description: Μερική ενημέρωση πληροφοριών Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Χώρα
+      description: Partially update Country information. Requires authentication.
+      summary: Partially update a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
         - in: query
           name: languageCode
@@ -9442,7 +9442,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Countries
       requestBody:
@@ -9497,15 +9497,15 @@ paths:
           description: ''
     delete:
       operationId: destroyCountry
-      description: Διαγραφή Χώρα. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Χώρα
+      description: Delete a Country. Requires authentication.
+      summary: Delete a Country
       parameters:
         - in: path
           name: alpha2
           schema:
             type: string
-            title: Κωδικός Χώρας (Alpha 2)
-          description: A unique value identifying this Χώρα.
+            title: Country Code Alpha 2
+          description: A unique value identifying this Country.
           required: true
       tags:
         - Countries
@@ -9535,8 +9535,8 @@ paths:
   /api/v1/health:
     get:
       operationId: api_v1_health_retrieve
-      description: Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery
-      summary: Έλεγχος κατάστασης υγείας βάσης δεδομένων, Redis και Celery
+      description: Check the health status of database, Redis, and Celery
+      summary: Check the health status of database, Redis, and Celery
       tags:
         - Health
       security:
@@ -9552,8 +9552,8 @@ paths:
   /api/v1/loyalty/product/{id}/points:
     get:
       operationId: getProductLoyaltyPoints
-      description: Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος
-      summary: Λήψη προεπισκόπησης πόντων πιστότητας προϊόντος
+      description: Get product loyalty points preview
+      summary: Get product loyalty points preview
       parameters:
         - in: path
           name: id
@@ -9607,8 +9607,8 @@ paths:
   /api/v1/loyalty/redeem:
     post:
       operationId: redeemLoyaltyPoints
-      description: Εξαργύρωση πόντων πιστότητας
-      summary: Εξαργύρωση πόντων πιστότητας
+      description: Redeem loyalty points
+      summary: Redeem loyalty points
       tags:
         - Loyalty
       requestBody:
@@ -9665,8 +9665,8 @@ paths:
   /api/v1/loyalty/summary:
     get:
       operationId: getLoyaltySummary
-      description: Λήψη σύνοψης πιστότητας
-      summary: Λήψη σύνοψης πιστότητας
+      description: Get loyalty summary
+      summary: Get loyalty summary
       tags:
         - Loyalty
       security:
@@ -9711,8 +9711,8 @@ paths:
   /api/v1/loyalty/tiers:
     get:
       operationId: listLoyaltyTiers
-      description: Λίστα όλων των tier πιστότητας
-      summary: Λίστα όλων των tier πιστότητας
+      description: List all loyalty tiers
+      summary: List all loyalty tiers
       parameters:
         - name: page
           required: false
@@ -9782,8 +9782,8 @@ paths:
   /api/v1/loyalty/transactions:
     get:
       operationId: listLoyaltyTransactions
-      description: Λίστα συναλλαγών πιστότητας
-      summary: Λίστα συναλλαγών πιστότητας
+      description: List loyalty transactions
+      summary: List loyalty transactions
       parameters:
         - name: page
           required: false
@@ -9853,8 +9853,8 @@ paths:
   /api/v1/notification/ids:
     post:
       operationId: getNotificationsByIds
-      description: Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.
-      summary: Επιστρέφει τις ειδοποιήσεις για μια λίστα αναγνωριστικών.
+      description: Returns the notifications for a list of ids.
+      summary: Returns the notifications for a list of ids.
       parameters:
         - in: query
           name: seen
@@ -9867,7 +9867,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων κατά κατάσταση προβολής. Αν είναι false, επιστρέφει μόνο τις μη ορατές ειδοποιήσεις.
+          description: Filter notifications by seen status. If false, returns only unseen notifications.
       tags:
         - Notifications
       requestBody:
@@ -9896,8 +9896,8 @@ paths:
   /api/v1/notification/user:
     get:
       operationId: listNotificationUser
-      description: 'Ανάκτηση λίστας Χρήστες ειδοποίησης με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χρήστες ειδοποίησης
+      description: 'Retrieve a list of Notification Users with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Notification Users
       parameters:
         - in: query
           name: createdAfter
@@ -9930,7 +9930,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasSeenAt
           schema:
@@ -9942,7 +9942,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων που έχουν προβληθεί (true) ή όχι (false)
+          description: Filter notifications that have been seen (true) or not seen (false)
         - in: query
           name: highPriority
           schema:
@@ -9954,7 +9954,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων υψηλής προτεραιότητας
+          description: Filter high priority notifications
         - in: query
           name: id
           schema:
@@ -9967,7 +9967,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -9983,7 +9983,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: notification
           schema:
@@ -9991,24 +9991,24 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID ειδοποίησης
+          description: Filter by notification ID
         - in: query
           name: notification_Category
           schema:
             type: string
-          description: Φίλτρο ανά κατηγορία ειδοποίησης
+          description: Filter by notification category
         - in: query
           name: notification_ExpiresAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που λήγουν μετά από αυτή την ημερομηνία
+          description: Filter notifications expiring after this date
         - in: query
           name: notification_ExpiresBefore
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που λήγουν πριν από αυτή την ημερομηνία
+          description: Filter notifications expiring before this date
         - in: query
           name: notification_IsExpired
           schema:
@@ -10020,47 +10020,47 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση λήξης ειδοποίησης
+          description: Filter by notification expiry status
         - in: query
           name: notification_Kind
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης
+          description: Filter by notification kind
         - in: query
           name: notification_Link
           schema:
             type: string
-          description: Φίλτρο ανά σύνδεσμο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification link (case-insensitive)
         - in: query
           name: notification_Message
           schema:
             type: string
-          description: Φίλτρο ανά μήνυμα ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification message (case-insensitive)
         - in: query
           name: notification_Priority
           schema:
             type: string
-          description: Φίλτρο ανά προτεραιότητα ειδοποίησης
+          description: Filter by notification priority
         - in: query
           name: notification_Title
           schema:
             type: string
-          description: Φίλτρο ανά τίτλο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification title (case-insensitive)
         - in: query
           name: notification_Type
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notification type (case-insensitive)
         - in: query
           name: notificationIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID ειδοποιήσεων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple notification IDs (comma-separated)
         - in: query
           name: notificationKind
           schema:
             type: string
-          description: Φίλτρο ανά τύπο ειδοποίησης
+          description: Filter by notification kind
         - name: ordering
           in: query
           required: false
@@ -10084,7 +10084,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -10093,7 +10093,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -10103,7 +10103,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: recentNotifications
           schema:
@@ -10115,7 +10115,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων των τελευταίων 7 ημερών
+          description: Filter notifications from the last 7 days
         - name: search
           required: false
           in: query
@@ -10133,13 +10133,13 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση προβολής
+          description: Filter by seen status
         - in: query
           name: seenAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που προβλήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter notifications seen after this date
         - in: query
           name: seenAt_Date
           schema:
@@ -10160,7 +10160,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο ειδοποιήσεων που προβλήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter notifications seen before this date
         - in: query
           name: seenOnly
           schema:
@@ -10172,7 +10172,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μόνο ορατών ειδοποιήσεων
+          description: Filter only seen notifications
         - in: query
           name: unseenOnly
           schema:
@@ -10184,7 +10184,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μόνο μη ορατών ειδοποιήσεων
+          description: Filter only unseen notifications
         - in: query
           name: updatedAfter
           schema:
@@ -10219,17 +10219,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -10241,7 +10241,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_IsStaff
           schema:
@@ -10253,17 +10253,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά staff status χρήστη
+          description: Filter by user staff status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -10313,8 +10313,8 @@ paths:
   /api/v1/notification/user/{id}:
     get:
       operationId: retrieveNotificationUser
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραλήπτης Ειδοποίησης.
-      summary: Ανάκτηση Παραλήπτης Ειδοποίησης
+      description: Get detailed information about a specific Notification User.
+      summary: Retrieve a Notification User
       parameters:
         - in: path
           name: id
@@ -10330,7 +10330,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       security:
@@ -10368,8 +10368,8 @@ paths:
           description: ''
     put:
       operationId: updateNotificationUser
-      description: Ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Παραλήπτης Ειδοποίησης
+      description: Update Notification User information. Requires authentication.
+      summary: Update a Notification User
       parameters:
         - in: path
           name: id
@@ -10385,7 +10385,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       requestBody:
@@ -10440,8 +10440,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateNotificationUser
-      description: Μερική ενημέρωση πληροφοριών Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Παραλήπτης Ειδοποίησης
+      description: Partially update Notification User information. Requires authentication.
+      summary: Partially update a Notification User
       parameters:
         - in: path
           name: id
@@ -10457,7 +10457,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Notification Users
       requestBody:
@@ -10512,8 +10512,8 @@ paths:
           description: ''
     delete:
       operationId: destroyNotificationUser
-      description: Διαγραφή Παραλήπτης Ειδοποίησης. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Παραλήπτης Ειδοποίησης
+      description: Delete a Notification User. Requires authentication.
+      summary: Delete a Notification User
       parameters:
         - in: path
           name: id
@@ -10548,8 +10548,8 @@ paths:
   /api/v1/notification/user/mark_all_as_seen:
     post:
       operationId: markAllNotificationUsersAsSeen
-      description: Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως ορατών.
-      summary: Σήμανση όλων ως ορατές
+      description: Mark all of the authenticated user's notifications as seen.
+      summary: Mark all notifications as seen
       tags:
         - Notification Users
       security:
@@ -10594,8 +10594,8 @@ paths:
   /api/v1/notification/user/mark_all_as_unseen:
     post:
       operationId: markAllNotificationUsersAsUnseen
-      description: Σήμανση όλων των ειδοποιήσεων του συνδεδεμένου χρήστη ως μη ορατών.
-      summary: Σήμανση όλων ως μη ορατές
+      description: Mark all of the authenticated user's notifications as unseen.
+      summary: Mark all notifications as unseen
       tags:
         - Notification Users
       security:
@@ -10640,8 +10640,8 @@ paths:
   /api/v1/notification/user/mark_as_seen:
     post:
       operationId: markNotificationUsersAsSeen
-      description: Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών για τον συνδεδεμένο χρήστη.
-      summary: Σήμανση συγκεκριμένων ειδοποιήσεων ως ορατών
+      description: Mark specific notifications as seen for the authenticated user.
+      summary: Mark specific notifications as seen
       tags:
         - Notification Users
       requestBody:
@@ -10698,8 +10698,8 @@ paths:
   /api/v1/notification/user/mark_as_unseen:
     post:
       operationId: markNotificationUsersAsUnseen
-      description: Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών για τον συνδεδεμένο χρήστη.
-      summary: Σήμανση συγκεκριμένων ειδοποιήσεων ως μη ορατών
+      description: Mark specific notifications as unseen for the authenticated user.
+      summary: Mark specific notifications as unseen
       tags:
         - Notification Users
       requestBody:
@@ -10756,8 +10756,8 @@ paths:
   /api/v1/notification/user/unseen_count:
     get:
       operationId: getNotificationUserUnseenCount
-      description: Λήψη του πλήθους μη ορατών ειδοποιήσεων για τον συνδεδεμένο χρήστη.
-      summary: Λήψη πλήθους μη ορατών ειδοποιήσεων
+      description: Get the count of unseen notifications for the authenticated user.
+      summary: Get unseen notifications count
       tags:
         - Notification Users
       security:
@@ -10802,8 +10802,8 @@ paths:
   /api/v1/order:
     get:
       operationId: listOrder
-      description: 'Ανάκτηση λίστας Παραγγελίες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Παραγγελίες
+      description: 'Retrieve a list of Orders with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Orders
       parameters:
         - in: query
           name: activeOrders
@@ -10816,7 +10816,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+          description: Filter active orders (pending, processing, shipped, delivered)
         - in: query
           name: canBeCanceled
           schema:
@@ -10828,12 +10828,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+          description: Filter orders that can be canceled
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+          description: Filter by city (case-insensitive)
         - in: query
           name: city_Icontains
           schema:
@@ -10842,22 +10842,22 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας
+          description: Filter by country code
         - in: query
           name: country_Alpha2
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: country_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by country name (case-insensitive)
         - in: query
           name: countryIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple country IDs (comma-separated)
         - in: query
           name: createdAfter
           schema:
@@ -10889,7 +10889,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: customerNotes
           schema:
@@ -10902,12 +10902,12 @@ paths:
           name: documentType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο εγγράφου
+          description: Filter by document type
         - in: query
           name: email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer email (case-insensitive)
         - in: query
           name: email_Icontains
           schema:
@@ -10923,12 +10923,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+          description: Filter final orders (completed, canceled, refunded)
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer first name (case-insensitive)
         - in: query
           name: firstName_Icontains
           schema:
@@ -10937,7 +10937,7 @@ paths:
           name: floor
           schema:
             type: string
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: hasCustomerNotes
           schema:
@@ -10949,7 +10949,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+          description: Filter orders that have/don't have customer notes
         - in: query
           name: hasPaymentId
           schema:
@@ -10961,7 +10961,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+          description: Filter orders that have/don't have payment ID
         - in: query
           name: hasStatusUpdatedAt
           schema:
@@ -10973,7 +10973,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+          description: Filter orders that have status update timestamp
         - in: query
           name: hasTracking
           schema:
@@ -10985,7 +10985,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+          description: Filter orders that have/don't have tracking number
         - in: query
           name: hasUser
           schema:
@@ -10997,7 +10997,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς χρήστη
+          description: Filter orders that have/don't have a user
         - in: query
           name: id
           schema:
@@ -11010,7 +11010,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -11028,7 +11028,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ακυρωμένων παραγγελιών
+          description: Filter canceled orders
         - in: query
           name: isCompleted
           schema:
@@ -11040,7 +11040,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ολοκληρωμένων παραγγελιών
+          description: Filter completed orders
         - in: query
           name: isPaid
           schema:
@@ -11052,7 +11052,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+          description: Filter paid/unpaid orders
         - in: query
           name: languageCode
           schema:
@@ -11062,12 +11062,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer last name (case-insensitive)
         - in: query
           name: lastName_Icontains
           schema:
@@ -11076,7 +11076,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας
+          description: Filter by location type
         - in: query
           name: needsProcessing
           schema:
@@ -11088,7 +11088,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+          description: Filter orders that need processing
         - name: ordering
           in: query
           required: false
@@ -11112,7 +11112,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -11121,7 +11121,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -11131,7 +11131,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: paidAmount_Gte
           schema:
@@ -11153,7 +11153,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο πληρωμένο ποσό
+          description: Filter by maximum paid amount
         - in: query
           name: paidAmountMin
           schema:
@@ -11161,7 +11161,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+          description: Filter by minimum paid amount
         - in: query
           name: payWay
           schema:
@@ -11169,7 +11169,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: payWay_IsOnlinePayment
           schema:
@@ -11181,17 +11181,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά online μεθόδους πληρωμής
+          description: Filter by online payment methods
         - in: query
           name: payWay_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by payment method name (case-insensitive)
         - in: query
           name: paymentId
           schema:
             type: string
-          description: Φίλτρο ανά ID πληρωμής
+          description: Filter by payment ID
         - in: query
           name: paymentId_Icontains
           schema:
@@ -11200,7 +11200,7 @@ paths:
           name: paymentMethod
           schema:
             type: string
-          description: Φίλτρο ανά μέθοδο πληρωμής
+          description: Filter by payment method
         - in: query
           name: paymentMethod_Icontains
           schema:
@@ -11209,7 +11209,6 @@ paths:
           name: paymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -11219,21 +11218,21 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής
+            Filter by payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: paymentStatus_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -11244,7 +11243,7 @@ paths:
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου
+          description: Filter by phone number
         - in: query
           name: phone_Icontains
           schema:
@@ -11253,7 +11252,7 @@ paths:
           name: place
           schema:
             type: string
-          description: Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by place (case-insensitive)
         - in: query
           name: place_Icontains
           schema:
@@ -11269,17 +11268,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+          description: Filter orders from the last 30 days
         - in: query
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: region_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by region name (case-insensitive)
         - name: search
           required: false
           in: query
@@ -11290,7 +11289,7 @@ paths:
           name: shippingCarrier
           schema:
             type: string
-          description: Φίλτρο ανά εταιρεία μεταφοράς
+          description: Filter by shipping carrier
         - in: query
           name: shippingCarrier_Icontains
           schema:
@@ -11316,7 +11315,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστα έξοδα αποστολής
+          description: Filter by maximum shipping price
         - in: query
           name: shippingPriceMin
           schema:
@@ -11324,12 +11323,11 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστα έξοδα αποστολής
+          description: Filter by minimum shipping price
         - in: query
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -11340,22 +11338,22 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: status_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -11366,13 +11364,13 @@ paths:
           name: statusList
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+          description: Filter by multiple statuses (comma-separated)
         - in: query
           name: statusUpdatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+          description: Filter orders with status updated after this date
         - in: query
           name: statusUpdatedAt_Date
           schema:
@@ -11393,12 +11391,12 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+          description: Filter orders with status updated before this date
         - in: query
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by street (case-insensitive)
         - in: query
           name: street_Icontains
           schema:
@@ -11407,7 +11405,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -11416,7 +11414,7 @@ paths:
           name: trackingNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό παρακολούθησης
+          description: Filter by tracking number
         - in: query
           name: trackingNumber_Icontains
           schema:
@@ -11455,17 +11453,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -11477,17 +11475,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -11497,7 +11495,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά Τ.Κ.
+          description: Filter by zipcode
       tags:
         - Orders
       security:
@@ -11541,8 +11539,8 @@ paths:
           description: ''
     post:
       operationId: createOrder
-      description: Δημιουργία νέου Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Παραγγελία
+      description: Create a new Ταξινόμηση. Requires authentication.
+      summary: Create a Ταξινόμηση
       parameters:
         - in: query
           name: languageCode
@@ -11553,7 +11551,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -11610,8 +11608,8 @@ paths:
   /api/v1/order-items:
     get:
       operationId: listOrderItem
-      description: 'Ανάκτηση λίστας Προϊόντα Παραγγελίας με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Προϊόντα Παραγγελίας
+      description: 'Retrieve a list of Order Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Order Items
       parameters:
         - in: query
           name: bulkItems
@@ -11624,7 +11622,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο χονδρικής (ποσότητα > 5)
+          description: Filter bulk items (quantity > 5)
         - in: query
           name: createdAfter
           schema:
@@ -11656,7 +11654,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasNotes
           schema:
@@ -11668,7 +11666,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με/χωρίς σημειώσεις
+          description: Filter items that have/don't have notes
         - in: query
           name: hasRefundedQuantity
           schema:
@@ -11680,7 +11678,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών με/χωρίς ποσότητα επιστροφής
+          description: Filter items that have/don't have refunded quantity
         - in: query
           name: highValueItems
           schema:
@@ -11692,7 +11690,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών υψηλής αξίας (τιμή > 100)
+          description: Filter high value items (price > 100)
         - in: query
           name: id
           schema:
@@ -11705,7 +11703,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -11723,7 +11721,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πλήρως επιστραμμένων αντικειμένων
+          description: Filter fully refunded items
         - in: query
           name: isPartiallyRefunded
           schema:
@@ -11735,7 +11733,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μερικώς επιστραμμένων αντικειμένων
+          description: Filter partially refunded items
         - in: query
           name: isRefunded
           schema:
@@ -11747,7 +11745,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση επιστροφής χρημάτων
+          description: Filter by refund status
         - in: query
           name: languageCode
           schema:
@@ -11757,12 +11755,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: notes
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σημειώσεων (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by notes content (case-insensitive)
         - in: query
           name: notes_Icontains
           schema:
@@ -11774,32 +11772,31 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID παραγγελίας
+          description: Filter by order ID
         - in: query
           name: order_Country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας παραγγελίας
+          description: Filter by order country code
         - in: query
           name: order_Email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer email (case-insensitive)
         - in: query
           name: order_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer first name (case-insensitive)
         - in: query
           name: order_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order customer last name (case-insensitive)
         - in: query
           name: order_PaymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -11809,25 +11806,24 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής παραγγελίας
+            Filter by order payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: order_Region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας παραγγελίας
+          description: Filter by order region code
         - in: query
           name: order_Status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -11838,16 +11834,16 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: order_User
           schema:
@@ -11855,22 +11851,22 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη παραγγελίας
+          description: Filter by order user ID
         - in: query
           name: order_User_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by order user email (case-insensitive)
         - in: query
           name: orderIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID παραγγελιών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple order IDs (comma-separated)
         - in: query
           name: orderStatuses
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις παραγγελιών (διαχωρισμένες με κόμμα)
+          description: Filter by multiple order statuses (comma-separated)
         - name: ordering
           in: query
           required: false
@@ -11906,7 +11902,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη αρχική ποσότητα
+          description: Filter by maximum original quantity
         - in: query
           name: originalQuantityMin
           schema:
@@ -11914,7 +11910,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη αρχική ποσότητα
+          description: Filter by minimum original quantity
         - name: page
           required: false
           in: query
@@ -11931,7 +11927,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -11940,7 +11936,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -11950,7 +11946,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: price
           schema:
@@ -11979,7 +11975,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ακριβή τιμή
+          description: Filter by exact price
         - in: query
           name: priceMax
           schema:
@@ -11987,7 +11983,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστη τιμή
+          description: Filter by maximum price
         - in: query
           name: priceMin
           schema:
@@ -11995,7 +11991,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστη τιμή
+          description: Filter by minimum price
         - in: query
           name: product
           schema:
@@ -12003,7 +11999,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: product_Active
           schema:
@@ -12015,7 +12011,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: product_Category
           schema:
@@ -12023,27 +12019,27 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: product_Category_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα κατηγορίας προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by product category name (case-insensitive)
         - in: query
           name: product_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by product name (case-insensitive)
         - in: query
           name: product_Sku
           schema:
             type: string
-          description: Φίλτρο ανά SKU προϊόντος
+          description: Filter by product SKU
         - in: query
           name: productIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID προϊόντων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple product IDs (comma-separated)
         - in: query
           name: quantity
           schema:
@@ -12072,7 +12068,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ακριβή ποσότητα
+          description: Filter by exact quantity
         - in: query
           name: quantityMax
           schema:
@@ -12080,7 +12076,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα
+          description: Filter by maximum quantity
         - in: query
           name: quantityMin
           schema:
@@ -12088,7 +12084,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα
+          description: Filter by minimum quantity
         - in: query
           name: recentItems
           schema:
@@ -12100,7 +12096,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδών των τελευταίων 7 ημερών
+          description: Filter items from the last 7 days
         - in: query
           name: refundedQuantity
           schema:
@@ -12129,7 +12125,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη ποσότητα επιστροφής
+          description: Filter by maximum refunded quantity
         - in: query
           name: refundedQuantityMin
           schema:
@@ -12137,7 +12133,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη ποσότητα επιστροφής
+          description: Filter by minimum refunded quantity
         - name: search
           required: false
           in: query
@@ -12240,8 +12236,8 @@ paths:
           description: ''
     post:
       operationId: createOrderItem
-      description: Δημιουργία νέου Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Είδος Παραγγελίας
+      description: Create a new Order Item. Requires authentication.
+      summary: Create a Order Item
       parameters:
         - in: query
           name: languageCode
@@ -12252,7 +12248,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12309,8 +12305,8 @@ paths:
   /api/v1/order-items/{id}:
     get:
       operationId: retrieveOrderItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Είδος Παραγγελίας.
-      summary: Ανάκτηση Είδος Παραγγελίας
+      description: Get detailed information about a specific Order Item.
+      summary: Retrieve a Order Item
       parameters:
         - in: path
           name: id
@@ -12329,7 +12325,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       security:
@@ -12367,8 +12363,8 @@ paths:
           description: ''
     put:
       operationId: updateOrderItem
-      description: Ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Είδος Παραγγελίας
+      description: Update Order Item information. Requires authentication.
+      summary: Update a Order Item
       parameters:
         - in: path
           name: id
@@ -12387,7 +12383,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12443,8 +12439,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateOrderItem
-      description: Μερική ενημέρωση πληροφοριών Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Είδος Παραγγελίας
+      description: Partially update Order Item information. Requires authentication.
+      summary: Partially update a Order Item
       parameters:
         - in: path
           name: id
@@ -12463,7 +12459,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Order Items
       requestBody:
@@ -12518,8 +12514,8 @@ paths:
           description: ''
     delete:
       operationId: destroyOrderItem
-      description: Διαγραφή Είδος Παραγγελίας. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Είδος Παραγγελίας
+      description: Delete a Order Item. Requires authentication.
+      summary: Delete a Order Item
       parameters:
         - in: path
           name: id
@@ -12557,8 +12553,8 @@ paths:
   /api/v1/order-items/{id}/refund:
     post:
       operationId: refundOrderItem
-      description: Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας.
-      summary: Επεξεργασία επιστροφής χρημάτων για είδος παραγγελίας
+      description: Process a refund for an order item.
+      summary: Process a refund for an order item
       parameters:
         - in: path
           name: id
@@ -12623,8 +12619,8 @@ paths:
   /api/v1/order/{id}:
     get:
       operationId: retrieveOrder
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Παραγγελία.
-      summary: Ανάκτηση Παραγγελία
+      description: Get detailed information about a specific Ταξινόμηση.
+      summary: Retrieve a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12643,7 +12639,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       security:
@@ -12681,8 +12677,8 @@ paths:
           description: ''
     put:
       operationId: updateOrder
-      description: Ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Παραγγελία
+      description: Update Ταξινόμηση information. Requires authentication.
+      summary: Update a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12701,7 +12697,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -12757,8 +12753,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateOrder
-      description: Μερική ενημέρωση πληροφοριών Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Παραγγελία
+      description: Partially update Ταξινόμηση information. Requires authentication.
+      summary: Partially update a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12777,7 +12773,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Orders
       requestBody:
@@ -12832,8 +12828,8 @@ paths:
           description: ''
     delete:
       operationId: destroyOrder
-      description: Διαγραφή Παραγγελία. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Παραγγελία
+      description: Delete a Ταξινόμηση. Requires authentication.
+      summary: Delete a Ταξινόμηση
       parameters:
         - in: path
           name: id
@@ -12871,8 +12867,8 @@ paths:
   /api/v1/order/{id}/acs_cancel:
     post:
       operationId: cancelAcsShipmentForOrder
-      description: Μόνο για διαχειριστές. Καλεί το ACS_Delete_Voucher. Έγκυρο μόνο πριν το voucher οριστικοποιηθεί σε λίστα παραλαβής.
-      summary: Ακύρωση της αποστολής ACS για παραγγελία
+      description: Admin-only. Calls ACS_Delete_Voucher. Only valid before the voucher is finalised in a pickup list.
+      summary: Cancel the ACS shipment for an order
       parameters:
         - in: path
           name: id
@@ -12920,8 +12916,8 @@ paths:
   /api/v1/order/{id}/acs_label:
     get:
       operationId: getAcsLabelForOrder
-      description: Μεταδίδει το PDF ετικέτας ACS μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή ACS για την παραγγελία ή δεν έχει εκδοθεί ακόμα το voucher.
-      summary: Λήψη του PDF ετικέτας voucher ACS για παραγγελία
+      description: Streams the ACS label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no ACS shipment exists for the order or the voucher has not been minted yet.
+      summary: Download the ACS voucher label PDF for an order
       parameters:
         - in: path
           name: id
@@ -12969,8 +12965,8 @@ paths:
   /api/v1/order/{id}/add_tracking:
     post:
       operationId: addOrderTracking
-      description: Προσθήκη πληροφοριών παρακολούθησης σε υπάρχουσα παραγγελία
-      summary: Προσθήκη πληροφοριών παρακολούθησης σε παραγγελία
+      description: Add tracking information to an existing order
+      summary: Add tracking information to an order
       parameters:
         - in: path
           name: id
@@ -13036,8 +13032,8 @@ paths:
   /api/v1/order/{id}/boxnow_cancel:
     post:
       operationId: cancelBoxNowShipmentForOrder
-      description: Μόνο για διαχειριστές. Ζητά ακύρωση δέματος μέσω του API του BoxNow. Έγκυρο μόνο όταν η κατάσταση δέματος είναι NEW (διαφορετικά σφάλμα BoxNow P420). Δέχεται προαιρετικό πεδίο ``reason`` στο σώμα του αιτήματος.
-      summary: Ακύρωση της αποστολής BoxNow για παραγγελία
+      description: Admin-only. Requests parcel cancellation via the BoxNow API. Only valid when the parcel state is NEW (BoxNow error P420 otherwise). Accepts an optional ``reason`` field in the request body.
+      summary: Cancel the BoxNow shipment for an order
       parameters:
         - in: path
           name: id
@@ -13085,8 +13081,8 @@ paths:
   /api/v1/order/{id}/boxnow_label:
     get:
       operationId: getBoxNowLabelForOrder
-      description: Μεταδίδει το PDF ετικέτας BoxNow μέσω ταυτοποίησης Django. Προσβάσιμο από τον ιδιοκτήτη της παραγγελίας, το προσωπικό, ή έναν επισκέπτη με το UUID της παραγγελίας. Επιστρέφει 404 όταν δεν υπάρχει αποστολή BoxNow για την παραγγελία ή δεν έχει ακόμα ανατεθεί ID δέματος.
-      summary: Λήψη του PDF ετικέτας δέματος BoxNow για παραγγελία
+      description: Streams the BoxNow label PDF through Django auth. Accessible by the order owner, staff, or a guest with the order UUID. Returns 404 when no BoxNow shipment exists for the order or the parcel ID has not yet been assigned.
+      summary: Download the BoxNow parcel label PDF for an order
       parameters:
         - in: path
           name: id
@@ -13134,8 +13130,8 @@ paths:
   /api/v1/order/{id}/cancel:
     post:
       operationId: cancelOrder
-      description: Ακύρωση υπάρχουσας παραγγελίας και αποκατάσταση αποθέματος προϊόντων
-      summary: Ακύρωση παραγγελίας
+      description: Cancel an existing order and restore product stock
+      summary: Cancel an order
       parameters:
         - in: path
           name: id
@@ -13267,8 +13263,8 @@ paths:
   /api/v1/order/{id}/create_checkout_session:
     post:
       operationId: createOrderCheckoutSession
-      description: Δημιουργία φιλοξενούμενης συνεδρίας checkout (Stripe ή Viva Wallet). Ο πελάτης θα ανακατευθυνθεί στη σελίδα πληρωμής του παρόχου για να ολοκληρώσει την πληρωμή.
-      summary: Δημιουργία φιλοξενούμενης συνεδρίας checkout για παραγγελία
+      description: Create a hosted checkout session (Stripe or Viva Wallet). The customer will be redirected to the provider's checkout page to complete payment.
+      summary: Create a hosted checkout session for an order
       parameters:
         - in: path
           name: id
@@ -13334,8 +13330,8 @@ paths:
   /api/v1/order/{id}/create_payment_intent:
     post:
       operationId: createOrderPaymentIntent
-      description: Δημιουργία payment intent για πληρωμές Stripe σε υπάρχουσα παραγγελία
-      summary: Δημιουργία payment intent για παραγγελία
+      description: Create a payment intent for Stripe payments on an existing order
+      summary: Create a payment intent for an order
       parameters:
         - in: path
           name: id
@@ -13400,8 +13396,8 @@ paths:
   /api/v1/order/{id}/invoice:
     get:
       operationId: retrieveOrderInvoice
-      description: Επιστρέφει τα μεταδεδομένα τιμολογίου της παραγγελίας και ένα απόλυτο URL προς το endpoint λήψης μέσω ροής (``/order/{id}/invoice/download``). Το URL προστατεύεται από τον ίδιο έλεγχο δικαιώματος ιδιοκτήτη/διαχειριστή όπως και αυτό το endpoint μεταδεδομένων — δεν εκτίθενται ακατέργαστα URL αποθήκευσης στον client. 404 αν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα (π.χ. η παραγγελία δεν έχει ολοκληρωθεί).
-      summary: Λήψη μεταδεδομένων λήψης τιμολογίου για παραγγελία
+      description: Return the order's invoice metadata and an absolute URL to the streaming download endpoint (``/order/{id}/invoice/download``). The URL is gated by the same owner/admin permission check as this metadata endpoint — no raw storage URLs are exposed to the client. 404 if the invoice has not been generated yet (e.g. order not completed).
+      summary: Get invoice download metadata for an order
       parameters:
         - in: path
           name: id
@@ -13455,8 +13451,8 @@ paths:
   /api/v1/order/{id}/invoice/download:
     get:
       operationId: downloadOrderInvoice
-      description: Μεταδίδει το παραχθέν PDF μέσω ταυτοποίησης Django. 404 όταν το τιμολόγιο δεν έχει δημιουργηθεί ακόμα. Ίδιος έλεγχος ιδιοκτησίας όπως και το endpoint μεταδεδομένων — επιστρέφει υπογεγραμμένη ροή S3 σε παραγωγή και ροή αρχείου συστήματος σε ανάπτυξη, χωρίς να εκθέτει το URL αποθήκευσης στον client.
-      summary: Λήψη PDF τιμολογίου
+      description: Streams the rendered PDF through Django auth. 404 when the invoice has not been generated yet. Same ownership check as the metadata endpoint — returns a signed S3 stream on prod and a filesystem stream in dev without exposing the storage URL to the client.
+      summary: Download the invoice PDF
       parameters:
         - in: path
           name: id
@@ -13478,8 +13474,8 @@ paths:
   /api/v1/order/{id}/payment_status:
     get:
       operationId: getOrderPaymentStatus
-      description: Ανάκτηση της τρέχουσας κατάστασης πληρωμής από τον πάροχο πληρωμών. Αυτό λαμβάνει την πιο πρόσφατη κατάσταση απευθείας από το Stripe/PayPal.
-      summary: Λήψη κατάστασης πληρωμής παραγγελίας
+      description: Retrieve the current payment status from the payment provider. This fetches the latest status directly from Stripe/PayPal.
+      summary: Get payment status for an order
       parameters:
         - in: path
           name: id
@@ -13533,8 +13529,8 @@ paths:
   /api/v1/order/{id}/reorder:
     post:
       operationId: reorderOrder
-      description: Αντιγραφή κάθε είδους από προηγούμενη παραγγελία πίσω στο ενεργό καλάθι του συνδεδεμένου χρήστη. Τα είδη των οποίων τα προϊόντα είναι ανενεργά ή εξαντλημένα επιστρέφονται στο skipped_items· οι ποσότητες περιορίζονται στο τρέχον απόθεμα.
-      summary: Επανάληψη παραγγελίας των ειδών από προηγούμενη παραγγελία
+      description: Copy each item from a past order back into the authenticated user's active cart. Items whose products are inactive or out of stock are returned in skipped_items; quantities are capped at current stock.
+      summary: Reorder the items from a past order
       parameters:
         - in: path
           name: id
@@ -13588,8 +13584,8 @@ paths:
   /api/v1/order/{id}/retry-payment:
     post:
       operationId: retryOrderPayment
-      description: Δημιουργία νέου Stripe PaymentIntent για παραγγελία της οποίας η προηγούμενη πληρωμή απέτυχε ή δεν ολοκληρώθηκε ποτέ, ώστε ο πελάτης να μπορεί να δοκιμάσει ξανά χωρίς να ξεκινήσει νέα παραγγελία.
-      summary: Επανάληψη πληρωμής για αποτυχημένη ή εκκρεμή παραγγελία
+      description: Create a fresh Stripe PaymentIntent for an order whose previous payment failed or was never completed, so the customer can try again without starting a new order.
+      summary: Retry payment for a failed or pending order
       parameters:
         - in: path
           name: id
@@ -13654,8 +13650,8 @@ paths:
   /api/v1/order/{id}/shipment_cancel:
     post:
       operationId: cancelShipmentForOrder
-      description: 'Μόνο για διαχειριστές. Ακύρωση ανεξάρτητη παρόχου: αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον προσαρμογέα μεταφορέα. Ισχύουν οι κανόνες του κάθε παρόχου (το BoxNow ακυρώνει μόνο δέματα σε κατάσταση NEW· η ACS ακυρώνει μόνο vouchers που δεν έχουν οριστικοποιηθεί σε λίστα παραλαβής).'
-      summary: Ακύρωση της αποστολής μεταφορέα για παραγγελία
+      description: 'Admin-only. Provider-agnostic cancellation: looks up the order''s shipping provider and dispatches to the carrier adapter. The provider''s own rules apply (BoxNow only cancels parcels in NEW state; ACS only cancels vouchers not yet finalised in a pickup list).'
+      summary: Cancel the carrier shipment for an order
       parameters:
         - in: path
           name: id
@@ -13709,8 +13705,8 @@ paths:
   /api/v1/order/{id}/shipment_label:
     get:
       operationId: getShipmentLabelForOrder
-      description: Λήψη ετικέτας ανεξάρτητη παρόχου. Αναζητά τον πάροχο αποστολής της παραγγελίας και τη διαβιβάζει στον αντίστοιχο προσαρμογέα μεταφορέα μέσω του μητρώου αποστολών — τα frontends μπορούν να καλούν το ίδιο endpoint ανεξάρτητα από τον courier που εκτελεί την παραγγελία.
-      summary: Λήψη του PDF ετικέτας μεταφορέα για παραγγελία
+      description: Provider-agnostic label download. Looks up the order's shipping provider and dispatches to the matching carrier adapter via the shipping registry — frontends can call the same endpoint regardless of which courier is fulfilling the order.
+      summary: Download the carrier label PDF for an order
       parameters:
         - in: path
           name: id
@@ -13764,8 +13760,8 @@ paths:
   /api/v1/order/{id}/update_status:
     post:
       operationId: updateOrderStatus
-      description: Ενημέρωση της κατάστασης υπάρχουσας παραγγελίας
-      summary: Ενημέρωση κατάστασης παραγγελίας
+      description: Update the status of an existing order
+      summary: Update the status of an order
       parameters:
         - in: path
           name: id
@@ -13831,8 +13827,8 @@ paths:
   /api/v1/order/my_orders:
     get:
       operationId: listMyOrders
-      description: Επιστρέφει λίστα με τις παραγγελίες του συνδεδεμένου χρήστη
-      summary: Λίστα παραγγελιών τρέχοντος χρήστη
+      description: Returns a list of the authenticated user's orders
+      summary: List current user's orders
       parameters:
         - in: query
           name: activeOrders
@@ -13845,7 +13841,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+          description: Filter active orders (pending, processing, shipped, delivered)
         - in: query
           name: canBeCanceled
           schema:
@@ -13857,12 +13853,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+          description: Filter orders that can be canceled
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+          description: Filter by city (case-insensitive)
         - in: query
           name: city_Icontains
           schema:
@@ -13871,22 +13867,22 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας
+          description: Filter by country code
         - in: query
           name: country_Alpha2
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: country_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by country name (case-insensitive)
         - in: query
           name: countryIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple country IDs (comma-separated)
         - in: query
           name: createdAfter
           schema:
@@ -13926,12 +13922,12 @@ paths:
           name: documentType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο εγγράφου
+          description: Filter by document type
         - in: query
           name: email
           schema:
             type: string
-          description: Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer email (case-insensitive)
         - in: query
           name: email_Icontains
           schema:
@@ -13947,12 +13943,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+          description: Filter final orders (completed, canceled, refunded)
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer first name (case-insensitive)
         - in: query
           name: firstName_Icontains
           schema:
@@ -13961,7 +13957,7 @@ paths:
           name: floor
           schema:
             type: string
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: hasCustomerNotes
           schema:
@@ -13973,7 +13969,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+          description: Filter orders that have/don't have customer notes
         - in: query
           name: hasPaymentId
           schema:
@@ -13985,7 +13981,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+          description: Filter orders that have/don't have payment ID
         - in: query
           name: hasStatusUpdatedAt
           schema:
@@ -13997,7 +13993,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+          description: Filter orders that have status update timestamp
         - in: query
           name: hasTracking
           schema:
@@ -14009,7 +14005,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+          description: Filter orders that have/don't have tracking number
         - in: query
           name: hasUser
           schema:
@@ -14021,7 +14017,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών με/χωρίς χρήστη
+          description: Filter orders that have/don't have a user
         - in: query
           name: id
           schema:
@@ -14034,7 +14030,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -14052,7 +14048,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ακυρωμένων παραγγελιών
+          description: Filter canceled orders
         - in: query
           name: isCompleted
           schema:
@@ -14064,7 +14060,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ολοκληρωμένων παραγγελιών
+          description: Filter completed orders
         - in: query
           name: isPaid
           schema:
@@ -14076,12 +14072,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+          description: Filter paid/unpaid orders
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by customer last name (case-insensitive)
         - in: query
           name: lastName_Icontains
           schema:
@@ -14090,7 +14086,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας
+          description: Filter by location type
         - in: query
           name: needsProcessing
           schema:
@@ -14102,7 +14098,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+          description: Filter orders that need processing
         - name: ordering
           in: query
           required: false
@@ -14149,7 +14145,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο πληρωμένο ποσό
+          description: Filter by maximum paid amount
         - in: query
           name: paidAmountMin
           schema:
@@ -14157,7 +14153,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+          description: Filter by minimum paid amount
         - in: query
           name: payWay
           schema:
@@ -14165,7 +14161,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: payWay_IsOnlinePayment
           schema:
@@ -14177,17 +14173,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά online μεθόδους πληρωμής
+          description: Filter by online payment methods
         - in: query
           name: payWay_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by payment method name (case-insensitive)
         - in: query
           name: paymentId
           schema:
             type: string
-          description: Φίλτρο ανά ID πληρωμής
+          description: Filter by payment ID
         - in: query
           name: paymentId_Icontains
           schema:
@@ -14196,7 +14192,7 @@ paths:
           name: paymentMethod
           schema:
             type: string
-          description: Φίλτρο ανά μέθοδο πληρωμής
+          description: Filter by payment method
         - in: query
           name: paymentMethod_Icontains
           schema:
@@ -14205,7 +14201,6 @@ paths:
           name: paymentStatus
           schema:
             type: string
-            title: Κατάσταση πληρωμής
             enum:
               - CANCELED
               - COMPLETED
@@ -14215,21 +14210,21 @@ paths:
               - PROCESSING
               - REFUNDED
           description: |-
-            Φίλτρο ανά κατάσταση πληρωμής
+            Filter by payment status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `FAILED` - Απέτυχε
-            * `REFUNDED` - Επιστροφή Χρημάτων
-            * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-            * `CANCELED` - Ακυρώθηκε
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `COMPLETED` - Completed
+            * `FAILED` - Failed
+            * `REFUNDED` - Refunded
+            * `PARTIALLY_REFUNDED` - Partially Refunded
+            * `CANCELED` - Canceled
         - in: query
           name: paymentStatus_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -14240,7 +14235,7 @@ paths:
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου
+          description: Filter by phone number
         - in: query
           name: phone_Icontains
           schema:
@@ -14249,7 +14244,7 @@ paths:
           name: place
           schema:
             type: string
-          description: Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by place (case-insensitive)
         - in: query
           name: place_Icontains
           schema:
@@ -14265,17 +14260,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+          description: Filter orders from the last 30 days
         - in: query
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: region_Name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by region name (case-insensitive)
         - name: search
           required: false
           in: query
@@ -14286,7 +14281,7 @@ paths:
           name: shippingCarrier
           schema:
             type: string
-          description: Φίλτρο ανά εταιρεία μεταφοράς
+          description: Filter by shipping carrier
         - in: query
           name: shippingCarrier_Icontains
           schema:
@@ -14312,7 +14307,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστα έξοδα αποστολής
+          description: Filter by maximum shipping price
         - in: query
           name: shippingPriceMin
           schema:
@@ -14320,12 +14315,11 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστα έξοδα αποστολής
+          description: Filter by minimum shipping price
         - in: query
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - CANCELED
               - COMPLETED
@@ -14336,22 +14330,22 @@ paths:
               - RETURNED
               - SHIPPED
           description: |-
-            Φίλτρο ανά κατάσταση παραγγελίας
+            Filter by order status
 
-            * `PENDING` - Εκκρεμεί
-            * `PROCESSING` - Σε επεξεργασία
-            * `SHIPPED` - Απεστάλη
-            * `DELIVERED` - Παραδόθηκε
-            * `COMPLETED` - Ολοκληρώθηκε
-            * `CANCELED` - Ακυρώθηκε
-            * `RETURNED` - Επιστράφηκε
-            * `REFUNDED` - Επιστροφή Χρημάτων
+            * `PENDING` - Pending
+            * `PROCESSING` - Processing
+            * `SHIPPED` - Shipped
+            * `DELIVERED` - Delivered
+            * `COMPLETED` - Completed
+            * `CANCELED` - Canceled
+            * `RETURNED` - Returned
+            * `REFUNDED` - Refunded
         - in: query
           name: status_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: string
@@ -14362,13 +14356,13 @@ paths:
           name: statusList
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+          description: Filter by multiple statuses (comma-separated)
         - in: query
           name: statusUpdatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+          description: Filter orders with status updated after this date
         - in: query
           name: statusUpdatedAt_Date
           schema:
@@ -14389,12 +14383,12 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+          description: Filter orders with status updated before this date
         - in: query
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by street (case-insensitive)
         - in: query
           name: street_Icontains
           schema:
@@ -14403,7 +14397,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -14412,7 +14406,7 @@ paths:
           name: trackingNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό παρακολούθησης
+          description: Filter by tracking number
         - in: query
           name: trackingNumber_Icontains
           schema:
@@ -14451,17 +14445,17 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: user_Email
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user email (case-insensitive)
         - in: query
           name: user_FirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user first name (case-insensitive)
         - in: query
           name: user_IsActive
           schema:
@@ -14473,17 +14467,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση χρήστη
+          description: Filter by user active status
         - in: query
           name: user_LastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by user last name (case-insensitive)
         - in: query
           name: userIds
           schema:
             type: string
-          description: Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+          description: Filter by multiple user IDs (comma-separated)
         - in: query
           name: uuid
           schema:
@@ -14493,7 +14487,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά Τ.Κ.
+          description: Filter by zipcode
       tags:
         - Orders
       security:
@@ -14538,8 +14532,8 @@ paths:
   /api/v1/order/uuid/{uuid}:
     get:
       operationId: retrieveOrderByUuid
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένη παραγγελία βάσει του UUID της
-      summary: Ανάκτηση παραγγελίας με UUID
+      description: Get detailed information about a specific order using its UUID
+      summary: Retrieve an order by UUID
       parameters:
         - in: path
           name: uuid
@@ -14591,8 +14585,8 @@ paths:
   /api/v1/order/viva_return:
     get:
       operationId: vivaReturnLookup
-      description: Το Smart Checkout του Viva ανακατευθύνει σε ένα στατικό URL επιτυχίας που έχει διαμορφωθεί στο merchant portal και προσθέτει ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (βλ. ενσωμάτωση Smart Checkout στο developer.viva.com). Αυτό το endpoint μετατρέπει αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t`` επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code`` που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση και το payment_status της παραγγελίας.
-      summary: Αναζήτηση παραγγελίας από τις παραμέτρους ανακατεύθυνσης μετά την πληρωμή του Viva Wallet
+      description: Viva's Smart Checkout redirects to a static success URL configured in the merchant portal and appends ``?t=<transaction_id>&s=<order_code>&lang=..&eventId=<int>&eci=..`` (see developer.viva.com Smart Checkout integration). This endpoint translates those params into the order's UUID so the storefront can forward the customer to the canonical ``/checkout/success/{uuid}`` route. ``t`` resolves via ``payment_id`` (set by the webhook, may lag the redirect); ``s`` resolves via the ``viva_order_code`` stored at session creation, so it works during the webhook race. Permission is open because both keys are unguessable Viva-generated identifiers and the response carries no PII — just the order's UUID, public id, status, and payment_status.
+      summary: Look up an order from Viva Wallet's post-payment redirect params
       parameters:
         - in: query
           name: s
@@ -14622,8 +14616,8 @@ paths:
   /api/v1/pay_way:
     get:
       operationId: listPayWay
-      description: 'Ανάκτηση λίστας Τρόποι πληρωμής με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Τρόποι πληρωμής
+      description: 'Retrieve a list of Pay Ways with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Pay Ways
       parameters:
         - in: query
           name: active
@@ -14636,7 +14630,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: cost_Gte
           schema:
@@ -14658,7 +14652,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο κόστος
+          description: Filter by maximum cost
         - in: query
           name: costMin
           schema:
@@ -14666,17 +14660,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο κόστος
+          description: Filter by minimum cost
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: description
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+          description: Filter by description (partial match)
         - in: query
           name: freeThreshold_Gte
           schema:
@@ -14698,7 +14692,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά μέγιστο όριο δωρεάν
+          description: Filter by maximum free threshold
         - in: query
           name: freeThresholdMin
           schema:
@@ -14706,7 +14700,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ελάχιστο όριο δωρεάν
+          description: Filter by minimum free threshold
         - in: query
           name: hasConfiguration
           schema:
@@ -14718,7 +14712,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μεθόδων πληρωμής με/χωρίς διαμόρφωση
+          description: Filter payment methods that have/don't have configuration
         - in: query
           name: hasIcon
           schema:
@@ -14730,7 +14724,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο μεθόδων πληρωμής με/χωρίς εικονίδιο
+          description: Filter payment methods that have/don't have an icon
         - in: query
           name: id
           schema:
@@ -14738,7 +14732,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID μεθόδου πληρωμής
+          description: Filter by payment method ID
         - in: query
           name: isOnlinePayment
           schema:
@@ -14750,7 +14744,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση online πληρωμής
+          description: Filter by online payment status
         - in: query
           name: languageCode
           schema:
@@ -14760,12 +14754,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by name (partial match)
         - name: ordering
           in: query
           required: false
@@ -14789,7 +14783,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -14798,7 +14792,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -14808,12 +14802,12 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: providerCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό παρόχου (μερική αντιστοίχιση)
+          description: Filter by provider code (partial match)
         - in: query
           name: providerCode_Icontains
           schema:
@@ -14829,7 +14823,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά απαίτηση επιβεβαίωσης
+          description: Filter by confirmation requirement
         - name: search
           required: false
           in: query
@@ -14840,12 +14834,12 @@ paths:
           name: shippingKind
           schema:
             type: string
-          description: Συνδυάστε με το ``shippingProviderCode`` για να φιλτράρετε τις μεθόδους πληρωμής βάσει των κανόνων συμβατότητας του μεταφορέα για αυτόν τον τύπο.
+          description: Pair with ``shippingProviderCode`` to filter pay ways by the carrier's compatibility rules for that kind.
         - in: query
           name: shippingProviderCode
           schema:
             type: string
-          description: Φίλτρο μεθόδων πληρωμής συμβατών με τον δεδομένο μεταφορέα αποστολής. Κάθε μεταφορέας διαθέτει τους δικούς του κανόνες συμβατότητας — το BoxNow (``boxnow``) υποστηρίζει αντικαταβολή σε lockers μέσω PAY ON THE GO και έτσι περνά κανονικά· η ACS περνά αμετάβλητη. Συνδυάστε με το ``shippingKind``.
+          description: Filter pay ways compatible with the given shipping carrier. Each carrier owns its own compatibility rules — BoxNow (``boxnow``) supports COD on lockers via PAY ON THE GO and so passes through; ACS passes through unchanged. Pair with ``shippingKind``.
         - in: query
           name: sortOrder
           schema:
@@ -14916,8 +14910,8 @@ paths:
           description: ''
     post:
       operationId: createPayWay
-      description: Δημιουργία νέου Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Μέθοδος Πληρωμής
+      description: Create a new Pay Way. Requires authentication.
+      summary: Create a Pay Way
       parameters:
         - in: query
           name: languageCode
@@ -14928,7 +14922,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -14985,8 +14979,8 @@ paths:
   /api/v1/pay_way/{id}:
     get:
       operationId: retrievePayWay
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Μέθοδος Πληρωμής.
-      summary: Ανάκτηση Μέθοδος Πληρωμής
+      description: Get detailed information about a specific Pay Way.
+      summary: Retrieve a Pay Way
       parameters:
         - in: path
           name: id
@@ -15002,7 +14996,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       security:
@@ -15041,8 +15035,8 @@ paths:
           description: ''
     put:
       operationId: updatePayWay
-      description: Ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Μέθοδος Πληρωμής
+      description: Update Pay Way information. Requires authentication.
+      summary: Update a Pay Way
       parameters:
         - in: path
           name: id
@@ -15058,7 +15052,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -15114,8 +15108,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdatePayWay
-      description: Μερική ενημέρωση πληροφοριών Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Μέθοδος Πληρωμής
+      description: Partially update Pay Way information. Requires authentication.
+      summary: Partially update a Pay Way
       parameters:
         - in: path
           name: id
@@ -15131,7 +15125,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Payment methods
       requestBody:
@@ -15186,8 +15180,8 @@ paths:
           description: ''
     delete:
       operationId: destroyPayWay
-      description: Διαγραφή Μέθοδος Πληρωμής. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Μέθοδος Πληρωμής
+      description: Delete a Pay Way. Requires authentication.
+      summary: Delete a Pay Way
       parameters:
         - in: path
           name: id
@@ -15222,8 +15216,8 @@ paths:
   /api/v1/product:
     get:
       operationId: listProduct
-      description: 'Ανάκτηση λίστας Προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Προϊόντα
+      description: 'Retrieve a list of Products with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Products
       parameters:
         - in: query
           name: active
@@ -15249,7 +15243,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -15269,7 +15263,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -15320,7 +15314,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: deletedAt_Date
           schema:
@@ -15408,7 +15402,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxDiscount
           schema:
@@ -15576,7 +15570,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -15585,7 +15579,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -15595,7 +15589,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: price
           schema:
@@ -15770,8 +15764,8 @@ paths:
           description: ''
     post:
       operationId: createProduct
-      description: Δημιουργία νέου Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Προϊόν
+      description: Create a new Product. Requires authentication.
+      summary: Create a Product
       parameters:
         - in: query
           name: languageCode
@@ -15782,7 +15776,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -15839,8 +15833,8 @@ paths:
   /api/v1/product/{id}:
     get:
       operationId: retrieveProduct
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Προϊόν.
-      summary: Ανάκτηση Προϊόν
+      description: Get detailed information about a specific Product.
+      summary: Retrieve a Product
       parameters:
         - in: path
           name: id
@@ -15859,7 +15853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       security:
@@ -15898,8 +15892,8 @@ paths:
           description: ''
     put:
       operationId: updateProduct
-      description: Ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Προϊόν
+      description: Update Product information. Requires authentication.
+      summary: Update a Product
       parameters:
         - in: path
           name: id
@@ -15918,7 +15912,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -15974,8 +15968,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProduct
-      description: Μερική ενημέρωση πληροφοριών Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Προϊόν
+      description: Partially update Product information. Requires authentication.
+      summary: Partially update a Product
       parameters:
         - in: path
           name: id
@@ -15994,7 +15988,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       requestBody:
@@ -16049,8 +16043,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProduct
-      description: Διαγραφή Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Προϊόν
+      description: Delete a Product. Requires authentication.
+      summary: Delete a Product
       parameters:
         - in: path
           name: id
@@ -16088,8 +16082,8 @@ paths:
   /api/v1/product/{id}/images:
     get:
       operationId: listProductImages
-      description: Λήψη όλων των εικόνων προϊόντος.
-      summary: Λήψη εικόνων προϊόντος
+      description: Get all images for a product.
+      summary: Get product images
       parameters:
         - in: path
           name: id
@@ -16109,7 +16103,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -16170,8 +16164,8 @@ paths:
   /api/v1/product/{id}/reviews:
     get:
       operationId: listProductReviews
-      description: Λήψη όλων των αξιολογήσεων ενός προϊόντος με υποστήριξη σελιδοποίησης.
-      summary: Λήψη κριτικών προϊόντος
+      description: Get all reviews for a product with pagination support.
+      summary: Get product reviews
       parameters:
         - in: path
           name: id
@@ -16205,7 +16199,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16214,7 +16208,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16224,7 +16218,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -16276,8 +16270,8 @@ paths:
   /api/v1/product/{id}/tags:
     get:
       operationId: listProductTags
-      description: Λήψη όλων των ετικετών που σχετίζονται με ένα προϊόν.
-      summary: Λήψη ετικετών προϊόντος
+      description: Get all tags associated with a product.
+      summary: Get product tags
       parameters:
         - in: path
           name: id
@@ -16348,8 +16342,8 @@ paths:
   /api/v1/product/{id}/update_view_count:
     post:
       operationId: incrementProductViews
-      description: Αύξηση του μετρητή προβολών ενός προϊόντος.
-      summary: Αύξηση προβολών προϊόντος
+      description: Increment the view count for a product.
+      summary: Increment product view count
       parameters:
         - in: path
           name: id
@@ -16404,8 +16398,8 @@ paths:
   /api/v1/product/{id}/variants:
     get:
       operationId: listProductVariants
-      description: Λήψη των αδερφών προϊόντων στην ομάδα παραλλαγών αυτού του προϊόντος, καθώς και των αξόνων παραλλαγής (π.χ. Χρώμα, Μνήμη) προς εμφάνιση ως επιλογείς. Επιστρέφει μόνο το ίδιο το προϊόν όταν δεν έχει ομάδα παραλλαγών.
-      summary: Λήψη παραλλαγών προϊόντος
+      description: Get the sibling products in this product's variant group, plus the variant axes (e.g. Colour, Memory) to render as selectors. Returns just the product itself when it has no variant group.
+      summary: Get product variants
       parameters:
         - in: path
           name: id
@@ -16425,7 +16419,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Products
       security:
@@ -16471,14 +16465,14 @@ paths:
   /api/v1/product/alert:
     get:
       operationId: listProductAlert
-      description: 'Ανάκτηση λίστας Ειδοποιήσεις προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ειδοποιήσεις προϊόντος
+      description: 'Retrieve a list of Product alerts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product alerts
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: isActive
           schema:
@@ -16494,13 +16488,12 @@ paths:
           name: kind
           schema:
             type: string
-            title: Είδος
             enum:
               - price_drop
               - restock
           description: |-
-            * `restock` - Αναπλήρωση
-            * `price_drop` - Πτώση τιμής
+            * `restock` - Restock
+            * `price_drop` - Price drop
         - in: query
           name: languageCode
           schema:
@@ -16510,7 +16503,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -16534,7 +16527,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16543,7 +16536,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16553,7 +16546,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -16610,8 +16603,8 @@ paths:
           description: ''
     post:
       operationId: createProductAlert
-      description: Δημιουργία νέου Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ειδοποίηση προϊόντος
+      description: Create a new Product alert. Requires authentication.
+      summary: Create a Product alert
       parameters:
         - in: query
           name: languageCode
@@ -16622,7 +16615,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Alerts
       requestBody:
@@ -16680,8 +16673,8 @@ paths:
   /api/v1/product/alert/{id}:
     get:
       operationId: retrieveProductAlert
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ειδοποίηση προϊόντος.
-      summary: Ανάκτηση Ειδοποίηση προϊόντος
+      description: Get detailed information about a specific Product alert.
+      summary: Retrieve a Product alert
       parameters:
         - in: path
           name: id
@@ -16700,7 +16693,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Alerts
       security:
@@ -16738,8 +16731,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductAlert
-      description: Διαγραφή Ειδοποίηση προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ειδοποίηση προϊόντος
+      description: Delete a Product alert. Requires authentication.
+      summary: Delete a Product alert
       parameters:
         - in: path
           name: id
@@ -16775,8 +16768,8 @@ paths:
   /api/v1/product/attribute:
     get:
       operationId: listAttribute
-      description: 'Ανάκτηση λίστας Χαρακτηριστικά με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Χαρακτηριστικά
+      description: 'Retrieve a list of Attributes with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Attributes
       parameters:
         - in: query
           name: active
@@ -16820,7 +16813,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasValues
           schema:
@@ -16844,7 +16837,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -16860,7 +16853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
@@ -16888,7 +16881,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -16897,7 +16890,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -16907,7 +16900,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -17013,8 +17006,8 @@ paths:
           description: ''
     post:
       operationId: createAttribute
-      description: Δημιουργία νέου Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Χαρακτηριστικό
+      description: Create a new Attribute. Requires authentication.
+      summary: Create a Attribute
       parameters:
         - in: query
           name: languageCode
@@ -17025,7 +17018,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17070,8 +17063,8 @@ paths:
   /api/v1/product/attribute/{id}:
     get:
       operationId: retrieveAttribute
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Χαρακτηριστικό.
-      summary: Ανάκτηση Χαρακτηριστικό
+      description: Get detailed information about a specific Attribute.
+      summary: Retrieve a Attribute
       parameters:
         - in: path
           name: id
@@ -17090,7 +17083,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17128,8 +17121,8 @@ paths:
           description: ''
     put:
       operationId: updateAttribute
-      description: Ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Χαρακτηριστικό
+      description: Update Attribute information. Requires authentication.
+      summary: Update a Attribute
       parameters:
         - in: path
           name: id
@@ -17148,7 +17141,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17192,8 +17185,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateAttribute
-      description: Μερική ενημέρωση πληροφοριών Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Χαρακτηριστικό
+      description: Partially update Attribute information. Requires authentication.
+      summary: Partially update a Attribute
       parameters:
         - in: path
           name: id
@@ -17212,7 +17205,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17256,8 +17249,8 @@ paths:
           description: ''
     delete:
       operationId: destroyAttribute
-      description: Διαγραφή Χαρακτηριστικό. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Χαρακτηριστικό
+      description: Delete a Attribute. Requires authentication.
+      summary: Delete a Attribute
       parameters:
         - in: path
           name: id
@@ -17295,8 +17288,8 @@ paths:
   /api/v1/product/attribute/value:
     get:
       operationId: listAttributeValue
-      description: 'Ανάκτηση λίστας Τιμές Χαρακτηριστικών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Τιμές Χαρακτηριστικών
+      description: 'Retrieve a list of Attribute Values with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Attribute Values
       parameters:
         - in: query
           name: active
@@ -17321,7 +17314,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17359,7 +17352,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -17372,7 +17365,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17388,7 +17381,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -17412,7 +17405,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -17421,7 +17414,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -17431,7 +17424,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -17541,8 +17534,8 @@ paths:
           description: ''
     post:
       operationId: createAttributeValue
-      description: Δημιουργία νέου Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Τιμή Χαρακτηριστικού
+      description: Create a new Attribute Value. Requires authentication.
+      summary: Create a Attribute Value
       parameters:
         - in: query
           name: languageCode
@@ -17553,7 +17546,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17598,8 +17591,8 @@ paths:
   /api/v1/product/attribute/value/{id}:
     get:
       operationId: retrieveAttributeValue
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Τιμή Χαρακτηριστικού.
-      summary: Ανάκτηση Τιμή Χαρακτηριστικού
+      description: Get detailed information about a specific Attribute Value.
+      summary: Retrieve a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17618,7 +17611,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17656,8 +17649,8 @@ paths:
           description: ''
     put:
       operationId: updateAttributeValue
-      description: Ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Τιμή Χαρακτηριστικού
+      description: Update Attribute Value information. Requires authentication.
+      summary: Update a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17676,7 +17669,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17720,8 +17713,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateAttributeValue
-      description: Μερική ενημέρωση πληροφοριών Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Τιμή Χαρακτηριστικού
+      description: Partially update Attribute Value information. Requires authentication.
+      summary: Partially update a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17740,7 +17733,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Attributes
       security:
@@ -17784,8 +17777,8 @@ paths:
           description: ''
     delete:
       operationId: destroyAttributeValue
-      description: Διαγραφή Τιμή Χαρακτηριστικού. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Τιμή Χαρακτηριστικού
+      description: Delete a Attribute Value. Requires authentication.
+      summary: Delete a Attribute Value
       parameters:
         - in: path
           name: id
@@ -17823,8 +17816,8 @@ paths:
   /api/v1/product/category:
     get:
       operationId: listProductCategory
-      description: 'Ανάκτηση λίστας Κατηγορίες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κατηγορίες προϊόντος
+      description: 'Retrieve a list of Product Categories with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Categories
       parameters:
         - in: query
           name: active
@@ -17876,7 +17869,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: descendantOf
           schema:
@@ -17921,7 +17914,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -17961,7 +17954,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: level
           schema:
@@ -18039,7 +18032,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -18048,7 +18041,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -18058,7 +18051,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: parent
           schema:
@@ -18194,8 +18187,8 @@ paths:
           description: ''
     post:
       operationId: createProductCategory
-      description: Δημιουργία νέου Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κατηγορία Προϊόντος
+      description: Create a new Product Category. Requires authentication.
+      summary: Create a Product Category
       parameters:
         - in: query
           name: languageCode
@@ -18206,7 +18199,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18263,8 +18256,8 @@ paths:
   /api/v1/product/category/{id}:
     get:
       operationId: retrieveProductCategory
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κατηγορία Προϊόντος.
-      summary: Ανάκτηση Κατηγορία Προϊόντος
+      description: Get detailed information about a specific Product Category.
+      summary: Retrieve a Product Category
       parameters:
         - in: path
           name: id
@@ -18283,7 +18276,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       security:
@@ -18322,8 +18315,8 @@ paths:
           description: ''
     put:
       operationId: updateProductCategory
-      description: Ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κατηγορία Προϊόντος
+      description: Update Product Category information. Requires authentication.
+      summary: Update a Product Category
       parameters:
         - in: path
           name: id
@@ -18342,7 +18335,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18398,8 +18391,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductCategory
-      description: Μερική ενημέρωση πληροφοριών Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κατηγορία Προϊόντος
+      description: Partially update Product Category information. Requires authentication.
+      summary: Partially update a Product Category
       parameters:
         - in: path
           name: id
@@ -18418,7 +18411,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Categories
       requestBody:
@@ -18473,8 +18466,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductCategory
-      description: Διαγραφή Κατηγορία Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κατηγορία Προϊόντος
+      description: Delete a Product Category. Requires authentication.
+      summary: Delete a Product Category
       parameters:
         - in: path
           name: id
@@ -18605,7 +18598,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -18835,8 +18828,8 @@ paths:
   /api/v1/product/category/image:
     get:
       operationId: listProductCategoryImage
-      description: 'Ανάκτηση λίστας Εικόνες Κατηγορίας Προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Εικόνες Κατηγορίας Προϊόντος
+      description: 'Retrieve a list of Product Category Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Category Images
       parameters:
         - in: query
           name: active
@@ -18860,7 +18853,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -18872,7 +18865,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -18885,16 +18877,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - in: query
           name: languageCode
           schema:
@@ -18904,7 +18896,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -18928,7 +18920,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -18937,7 +18929,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -18947,7 +18939,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -18998,8 +18990,8 @@ paths:
           description: ''
     post:
       operationId: createProductCategoryImage
-      description: Δημιουργία νέου Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Εικόνα Κατηγορίας Προϊόντος
+      description: Create a new Product Category Image. Requires authentication.
+      summary: Create a Product Category Image
       parameters:
         - in: query
           name: languageCode
@@ -19010,7 +19002,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19067,8 +19059,8 @@ paths:
   /api/v1/product/category/image/{id}:
     get:
       operationId: retrieveProductCategoryImage
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Κατηγορίας Προϊόντος.
-      summary: Ανάκτηση Εικόνα Κατηγορίας Προϊόντος
+      description: Get detailed information about a specific Product Category Image.
+      summary: Retrieve a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19087,7 +19079,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       security:
@@ -19126,8 +19118,8 @@ paths:
           description: ''
     put:
       operationId: updateProductCategoryImage
-      description: Ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Εικόνα Κατηγορίας Προϊόντος
+      description: Update Product Category Image information. Requires authentication.
+      summary: Update a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19146,7 +19138,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19202,8 +19194,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductCategoryImage
-      description: Μερική ενημέρωση πληροφοριών Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Εικόνα Κατηγορίας Προϊόντος
+      description: Partially update Product Category Image information. Requires authentication.
+      summary: Partially update a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19222,7 +19214,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Category Images
       requestBody:
@@ -19277,8 +19269,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductCategoryImage
-      description: Διαγραφή Εικόνα Κατηγορίας Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Εικόνα Κατηγορίας Προϊόντος
+      description: Delete a Product Category Image. Requires authentication.
+      summary: Delete a Product Category Image
       parameters:
         - in: path
           name: id
@@ -19316,8 +19308,8 @@ paths:
   /api/v1/product/category/image/bulk_update:
     patch:
       operationId: bulkUpdateProductCategoryImages
-      description: Ενημέρωση πολλαπλών εικόνων κατηγορίας ταυτόχρονα. Μπορεί να ενημερώσει την κατάσταση ενεργοποίησης και τη σειρά ταξινόμησης.
-      summary: Μαζική ενημέρωση εικόνων κατηγορίας
+      description: Update multiple category images at once. Can update active status and sort order.
+      summary: Bulk update category images
       tags:
         - Product Category Images
       requestBody:
@@ -19373,8 +19365,8 @@ paths:
   /api/v1/product/category/image/by_category:
     get:
       operationId: getProductCategoryImagesByCategory
-      description: Ανάκτηση όλων των εικόνων για συγκεκριμένη κατηγορία.
-      summary: Λήψη εικόνων ανά κατηγορία
+      description: Retrieve all images for a specific category.
+      summary: Get images by category
       parameters:
         - in: query
           name: active
@@ -19405,7 +19397,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -19418,16 +19409,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - name: ordering
           in: query
           required: false
@@ -19488,8 +19479,8 @@ paths:
   /api/v1/product/category/image/by_type:
     get:
       operationId: getProductCategoryImagesByType
-      description: Ανάκτηση όλων των εικόνων συγκεκριμένου τύπου (κύρια, banner, εικονίδιο κ.λπ.).
-      summary: Λήψη εικόνων ανά τύπο
+      description: Retrieve all images of a specific type (main, banner, icon, etc.).
+      summary: Get images by type
       parameters:
         - in: query
           name: active
@@ -19520,7 +19511,6 @@ paths:
           name: imageType
           schema:
             type: string
-            title: Τύπος εικόνας
             enum:
               - BACKGROUND
               - BANNER
@@ -19533,16 +19523,16 @@ paths:
               - SEASONAL
               - THUMBNAIL
           description: |-
-            * `MAIN` - Κύρια εικόνα
-            * `BANNER` - Banner
-            * `ICON` - Εικονίδιο
-            * `THUMBNAIL` - Μικρογραφία
-            * `GALLERY` - Εικόνα συλλογής
-            * `BACKGROUND` - Εικόνα φόντου
-            * `HERO` - Κεντρική εικόνα
-            * `FEATURE` - Κεντρική Εικόνα
-            * `PROMOTIONAL` - Προωθητική εικόνα
-            * `SEASONAL` - Εποχιακή εικόνα
+            * `MAIN` - Main Image
+            * `BANNER` - Banner Image
+            * `ICON` - Icon Image
+            * `THUMBNAIL` - Thumbnail Image
+            * `GALLERY` - Gallery Image
+            * `BACKGROUND` - Background Image
+            * `HERO` - Hero Image
+            * `FEATURE` - Feature Image
+            * `PROMOTIONAL` - Promotional Image
+            * `SEASONAL` - Seasonal Image
         - name: ordering
           in: query
           required: false
@@ -19603,8 +19593,8 @@ paths:
   /api/v1/product/favourite:
     get:
       operationId: listProductFavourite
-      description: 'Ανάκτηση λίστας Αγαπημένα προϊόντα με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Αγαπημένα προϊόντα
+      description: 'Retrieve a list of Product Favourites with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Favourites
       parameters:
         - in: query
           name: createdAfter
@@ -19622,7 +19612,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -19639,7 +19629,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -19663,7 +19653,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -19672,7 +19662,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -19682,7 +19672,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -19777,8 +19767,8 @@ paths:
           description: ''
     post:
       operationId: createProductFavourite
-      description: Δημιουργία νέου Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Αγαπημένο Προϊόν
+      description: Create a new Product Favourite. Requires authentication.
+      summary: Create a Product Favourite
       parameters:
         - in: query
           name: languageCode
@@ -19789,7 +19779,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -19846,8 +19836,8 @@ paths:
   /api/v1/product/favourite/{id}:
     get:
       operationId: retrieveProductFavourite
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Αγαπημένο Προϊόν.
-      summary: Ανάκτηση Αγαπημένο Προϊόν
+      description: Get detailed information about a specific Product Favourite.
+      summary: Retrieve a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19863,7 +19853,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       security:
@@ -19901,8 +19891,8 @@ paths:
           description: ''
     put:
       operationId: updateProductFavourite
-      description: Ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Αγαπημένο Προϊόν
+      description: Update Product Favourite information. Requires authentication.
+      summary: Update a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19918,7 +19908,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -19974,8 +19964,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductFavourite
-      description: Μερική ενημέρωση πληροφοριών Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Αγαπημένο Προϊόν
+      description: Partially update Product Favourite information. Requires authentication.
+      summary: Partially update a Product Favourite
       parameters:
         - in: path
           name: id
@@ -19991,7 +19981,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Favourites
       requestBody:
@@ -20046,8 +20036,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductFavourite
-      description: Διαγραφή Αγαπημένο Προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Αγαπημένο Προϊόν
+      description: Delete a Product Favourite. Requires authentication.
+      summary: Delete a Product Favourite
       parameters:
         - in: path
           name: id
@@ -20082,8 +20072,8 @@ paths:
   /api/v1/product/favourite/{id}/product:
     get:
       operationId: getProductFavouriteProduct
-      description: Λήψη λεπτομερών πληροφοριών για το προϊόν σε αυτή την εγγραφή αγαπημένων.
-      summary: Λήψη λεπτομερειών αγαπημένου προϊόντος
+      description: Get detailed information about the product in this favourite entry.
+      summary: Get favourite product details
       parameters:
         - in: path
           name: id
@@ -20134,8 +20124,8 @@ paths:
   /api/v1/product/favourite/favourites_by_products:
     post:
       operationId: getProductFavouritesByProducts
-      description: Λήψη εγγραφών αγαπημένων για τα καθορισμένα ID προϊόντων. Απαιτεί ταυτοποίηση.
-      summary: Λήψη αγαπημένων ανά IDs προϊόντων
+      description: Get favourite entries for the specified product IDs. Requires authentication.
+      summary: Get favourites by product IDs
       parameters:
         - in: query
           name: createdAfter
@@ -20272,8 +20262,8 @@ paths:
   /api/v1/product/image:
     get:
       operationId: listProductImage
-      description: 'Ανάκτηση λίστας Εικόνες προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Εικόνες προϊόντος
+      description: 'Retrieve a list of Product Images with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Images
       parameters:
         - in: query
           name: createdAt
@@ -20284,7 +20274,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -20312,7 +20302,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -20336,7 +20326,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -20345,7 +20335,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -20355,7 +20345,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -20425,8 +20415,8 @@ paths:
           description: ''
     post:
       operationId: createProductImage
-      description: Δημιουργία νέου Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Εικόνα Προϊόντος
+      description: Create a new Product Image. Requires authentication.
+      summary: Create a Product Image
       parameters:
         - in: query
           name: languageCode
@@ -20437,7 +20427,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20494,8 +20484,8 @@ paths:
   /api/v1/product/image/{id}:
     get:
       operationId: retrieveProductImage
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Εικόνα Προϊόντος.
-      summary: Ανάκτηση Εικόνα Προϊόντος
+      description: Get detailed information about a specific Product Image.
+      summary: Retrieve a Product Image
       parameters:
         - in: path
           name: id
@@ -20514,7 +20504,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       security:
@@ -20553,8 +20543,8 @@ paths:
           description: ''
     put:
       operationId: updateProductImage
-      description: Ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Εικόνα Προϊόντος
+      description: Update Product Image information. Requires authentication.
+      summary: Update a Product Image
       parameters:
         - in: path
           name: id
@@ -20573,7 +20563,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20629,8 +20619,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductImage
-      description: Μερική ενημέρωση πληροφοριών Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Εικόνα Προϊόντος
+      description: Partially update Product Image information. Requires authentication.
+      summary: Partially update a Product Image
       parameters:
         - in: path
           name: id
@@ -20649,7 +20639,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Images
       requestBody:
@@ -20704,8 +20694,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductImage
-      description: Διαγραφή Εικόνα Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Εικόνα Προϊόντος
+      description: Delete a Product Image. Requires authentication.
+      summary: Delete a Product Image
       parameters:
         - in: path
           name: id
@@ -20743,20 +20733,20 @@ paths:
   /api/v1/product/review:
     get:
       operationId: listProductReview
-      description: 'Ανάκτηση λίστας Κριτικές προϊόντος με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Κριτικές προϊόντος
+      description: 'Retrieve a list of Product Reviews with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Product Reviews
       parameters:
         - in: query
           name: comment
           schema:
             type: string
-          description: Φίλτρο ανά περιεχόμενο σχολίου (μερική αντιστοίχιση)
+          description: Filter by comment content (partial match)
         - in: query
           name: createdAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items created after this date
         - in: query
           name: createdAt_Date
           schema:
@@ -20777,7 +20767,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items created before this date
         - in: query
           name: currentlyPublished
           schema:
@@ -20789,12 +20779,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+          description: Filter items that are currently published (published_at <= now and is_published=True)
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasComment
           schema:
@@ -20806,7 +20796,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αξιολογήσεων με/χωρίς σχόλια
+          description: Filter reviews that have/don't have comments
         - in: query
           name: id
           schema:
@@ -20814,7 +20804,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID κριτικής
+          description: Filter by review ID
         - in: query
           name: isPublished
           schema:
@@ -20826,7 +20816,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση δημοσίευσης
+          description: Filter by published status
         - in: query
           name: languageCode
           schema:
@@ -20836,7 +20826,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxRate
           schema:
@@ -20844,7 +20834,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη βαθμολογία (alias)
+          description: Filter by maximum rating (alias)
         - in: query
           name: minRate
           schema:
@@ -20852,7 +20842,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη βαθμολογία (alias)
+          description: Filter by minimum rating (alias)
         - name: ordering
           in: query
           required: false
@@ -20876,7 +20866,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -20885,7 +20875,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -20895,7 +20885,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: product
           schema:
@@ -20903,7 +20893,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: productActive
           schema:
@@ -20915,7 +20905,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση προϊόντος
+          description: Filter by product active status
         - in: query
           name: productAvgRatingMax
           schema:
@@ -20923,7 +20913,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο προϊόντων με μέγιστη μέση βαθμολογία
+          description: Filter products with maximum average rating
         - in: query
           name: productAvgRatingMin
           schema:
@@ -20931,7 +20921,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο προϊόντων με ελάχιστη μέση βαθμολογία
+          description: Filter products with minimum average rating
         - in: query
           name: productCategory
           schema:
@@ -20939,7 +20929,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID κατηγορίας προϊόντος
+          description: Filter by product category ID
         - in: query
           name: productId
           schema:
@@ -20947,18 +20937,18 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID προϊόντος
+          description: Filter by product ID
         - in: query
           name: productName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+          description: Filter by product name (partial match)
         - in: query
           name: publishedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items published after this date
         - in: query
           name: publishedAt_Date
           schema:
@@ -20979,7 +20969,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items published before this date
         - in: query
           name: publishedRecentDays
           schema:
@@ -20987,7 +20977,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο αξιολογήσεων που δημοσιεύθηκαν τις τελευταίες N ημέρες
+          description: Filter reviews published in the last N days
         - in: query
           name: rate
           schema:
@@ -20996,18 +20986,18 @@ paths:
                 pattern: ^-?\d+$
               - type: integer
           description: |-
-            Φίλτρο ανά ακριβή βαθμολογία
+            Filter by exact rating
 
-            * `1` - Ένα
-            * `2` - Δύο
-            * `3` - Τρία
-            * `4` - Τέσσερα
-            * `5` - Πέντε
-            * `6` - Έξι
-            * `7` - Επτά
-            * `8` - Οκτώ
-            * `9` - Εννέα
-            * `10` - Δέκα
+            * `1` - One
+            * `2` - Two
+            * `3` - Three
+            * `4` - Four
+            * `5` - Five
+            * `6` - Six
+            * `7` - Seven
+            * `8` - Eight
+            * `9` - Nine
+            * `10` - Ten
         - in: query
           name: rate_Gte
           schema:
@@ -21029,7 +21019,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά μέγιστη βαθμολογία
+          description: Filter by maximum rating
         - in: query
           name: rateMin
           schema:
@@ -21037,7 +21027,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ελάχιστη βαθμολογία
+          description: Filter by minimum rating
         - in: query
           name: recentDays
           schema:
@@ -21045,7 +21035,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο αξιολογήσεων των τελευταίων N ημερών
+          description: Filter reviews from the last N days
         - name: search
           required: false
           in: query
@@ -21056,23 +21046,22 @@ paths:
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - 'FALSE'
               - NEW
               - 'TRUE'
           description: |-
-            Φίλτρο ανά κατάσταση αξιολόγησης
+            Filter by review status
 
-            * `NEW` - Νέο
-            * `TRUE` - Ναι
-            * `FALSE` - Όχι
+            * `NEW` - New
+            * `TRUE` - True
+            * `FALSE` - False
         - in: query
           name: updatedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+          description: Filter items updated after this date
         - in: query
           name: updatedAt_Date
           schema:
@@ -21093,7 +21082,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+          description: Filter items updated before this date
         - in: query
           name: user
           schema:
@@ -21101,17 +21090,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: userEmail
           schema:
             type: string
-          description: Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+          description: Filter by user email (partial match)
         - in: query
           name: userFirstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χρήστη (μερική αντιστοίχιση)
+          description: Filter by user first name (partial match)
         - in: query
           name: userId
           schema:
@@ -21119,12 +21108,12 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ανά ID χρήστη
+          description: Filter by user ID
         - in: query
           name: userLastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο χρήστη (μερική αντιστοίχιση)
+          description: Filter by user last name (partial match)
         - in: query
           name: userReviewCountMin
           schema:
@@ -21132,7 +21121,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο χρηστών με ελάχιστο αριθμό αξιολογήσεων
+          description: Filter users with minimum number of reviews
         - in: query
           name: uuid
           schema:
@@ -21149,7 +21138,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο αξιολογήσεων από επαληθευμένες αγορές
+          description: Filter reviews from verified purchases
       tags:
         - Product Reviews
       security:
@@ -21194,8 +21183,8 @@ paths:
           description: ''
     post:
       operationId: createProductReview
-      description: Δημιουργία νέου Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Κριτική Προϊόντος
+      description: Create a new Product Review. Requires authentication.
+      summary: Create a Product Review
       parameters:
         - in: query
           name: languageCode
@@ -21206,7 +21195,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21263,8 +21252,8 @@ paths:
   /api/v1/product/review/{id}:
     get:
       operationId: retrieveProductReview
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Κριτική Προϊόντος.
-      summary: Ανάκτηση Κριτική Προϊόντος
+      description: Get detailed information about a specific Product Review.
+      summary: Retrieve a Product Review
       parameters:
         - in: path
           name: id
@@ -21283,7 +21272,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       security:
@@ -21322,8 +21311,8 @@ paths:
           description: ''
     put:
       operationId: updateProductReview
-      description: Ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Κριτική Προϊόντος
+      description: Update Product Review information. Requires authentication.
+      summary: Update a Product Review
       parameters:
         - in: path
           name: id
@@ -21342,7 +21331,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21398,8 +21387,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateProductReview
-      description: Μερική ενημέρωση πληροφοριών Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Κριτική Προϊόντος
+      description: Partially update Product Review information. Requires authentication.
+      summary: Partially update a Product Review
       parameters:
         - in: path
           name: id
@@ -21418,7 +21407,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Product Reviews
       requestBody:
@@ -21473,8 +21462,8 @@ paths:
           description: ''
     delete:
       operationId: destroyProductReview
-      description: Διαγραφή Κριτική Προϊόντος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Κριτική Προϊόντος
+      description: Delete a Product Review. Requires authentication.
+      summary: Delete a Product Review
       parameters:
         - in: path
           name: id
@@ -21512,8 +21501,8 @@ paths:
   /api/v1/product/review/{id}/product:
     get:
       operationId: getProductReviewProduct
-      description: Λήψη λεπτομερών πληροφοριών για το προϊόν στο οποίο αναφέρεται αυτή η αξιολόγηση.
-      summary: Λήψη λεπτομερειών προϊόντος κριτικής
+      description: Get detailed information about the product this review is for.
+      summary: Get reviewed product details
       parameters:
         - in: path
           name: id
@@ -21565,8 +21554,8 @@ paths:
   /api/v1/product/review/{id}/user_product_review:
     get:
       operationId: getUserProductReview
-      description: Λήψη της αξιολόγησης του τρέχοντος χρήστη για συγκεκριμένο προϊόν. Απαιτεί ταυτοποίηση.
-      summary: Λήψη κριτικής χρήστη για προϊόν
+      description: Get the current user's review for a specific product. Requires authentication.
+      summary: Get user's review for a product
       parameters:
         - in: path
           name: id
@@ -21617,14 +21606,14 @@ paths:
   /api/v1/region:
     get:
       operationId: listRegion
-      description: 'Ανάκτηση λίστας Περιοχές με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Περιοχές
+      description: 'Retrieve a list of Regions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Regions
       parameters:
         - in: query
           name: alpha
           schema:
             type: string
-          description: Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region alpha code (partial match)
         - in: query
           name: alpha_Icontains
           schema:
@@ -21633,17 +21622,17 @@ paths:
           name: alphaExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+          description: Filter by exact region alpha code
         - in: query
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -21660,7 +21649,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -21670,12 +21659,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: ordering
           in: query
           required: false
@@ -21699,7 +21688,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -21708,7 +21697,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -21718,7 +21707,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -21807,8 +21796,8 @@ paths:
           description: ''
     post:
       operationId: createRegion
-      description: Δημιουργία νέου Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Περιοχή
+      description: Create a new Region. Requires authentication.
+      summary: Create a Region
       parameters:
         - in: query
           name: languageCode
@@ -21819,7 +21808,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -21876,15 +21865,15 @@ paths:
   /api/v1/region/{alpha}:
     get:
       operationId: retrieveRegion
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Περιοχή.
-      summary: Ανάκτηση Περιοχή
+      description: Get detailed information about a specific Region.
+      summary: Retrieve a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -21895,7 +21884,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       security:
@@ -21934,15 +21923,15 @@ paths:
           description: ''
     put:
       operationId: updateRegion
-      description: Ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Περιοχή
+      description: Update Region information. Requires authentication.
+      summary: Update a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -21953,7 +21942,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -22009,15 +21998,15 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateRegion
-      description: Μερική ενημέρωση πληροφοριών Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Περιοχή
+      description: Partially update Region information. Requires authentication.
+      summary: Partially update a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: languageCode
@@ -22028,7 +22017,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Regions
       requestBody:
@@ -22083,15 +22072,15 @@ paths:
           description: ''
     delete:
       operationId: destroyRegion
-      description: Διαγραφή Περιοχή. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Περιοχή
+      description: Delete a Region. Requires authentication.
+      summary: Delete a Region
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
       tags:
         - Regions
@@ -22121,21 +22110,21 @@ paths:
   /api/v1/region/{alpha}/get_regions_by_country_alpha_2:
     get:
       operationId: listRegionsByCountry
-      description: Λήψη όλων των περιφερειών για συγκεκριμένη χώρα βάσει του κωδικού alpha-2 της.
-      summary: Λήψη περιφερειών ανά χώρα
+      description: Get all regions for a specific country using its alpha-2 code.
+      summary: Get regions by country
       parameters:
         - in: path
           name: alpha
           schema:
             type: string
-            title: Κωδικός περιφέρειας
-          description: A unique value identifying this Περιοχή.
+            title: Region Code
+          description: A unique value identifying this Region.
           required: true
         - in: query
           name: alpha
           schema:
             type: string
-          description: Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region alpha code (partial match)
         - in: query
           name: alpha_Icontains
           schema:
@@ -22144,17 +22133,17 @@ paths:
           name: alphaExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+          description: Filter by exact region alpha code
         - in: query
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha-2 κωδικό χώρας
+          description: Filter by country alpha-2 code
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -22171,7 +22160,7 @@ paths:
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: ordering
           in: query
           required: false
@@ -22286,24 +22275,24 @@ paths:
   /api/v1/search/analytics:
     get:
       operationId: api_v1_search_analytics_retrieve
-      description: Ανάκτηση συγκεντρωτικών αναλυτικών αναζήτησης, συμπεριλαμβανομένων των κορυφαίων ερωτημάτων, ερωτημάτων χωρίς αποτελέσματα, όγκου αναζήτησης ανά τύπο περιεχομένου και γλώσσα, μέσου αριθμού αποτελεσμάτων, μέσου χρόνου επεξεργασίας και ποσοστού κλικ. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά εύρος ημερομηνιών και τύπο περιεχομένου.
-      summary: Λήψη μετρικών αναζήτησης
+      description: Retrieve aggregated search analytics including top queries, zero-result queries, search volume by content type and language, average results count, average processing time, and click-through rate. Results can be filtered by date range and content type.
+      summary: Get search analytics metrics
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: 'Φίλτρο ανά τύπο περιεχομένου: ''product'', ''blog_post'', ή ''federated''. Αν δεν δοθεί, συμπεριλαμβάνει όλους τους τύπους περιεχομένου.'
+          description: 'Filter by content type: ''product'', ''blog_post'', or ''federated''. If not provided, includes all content types.'
         - in: query
           name: endDate
           schema:
             type: string
-          description: 'Ημερομηνία λήξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει δεδομένα έως τη σημερινή ημερομηνία.'
+          description: 'End date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes data up to current date.'
         - in: query
           name: startDate
           schema:
             type: string
-          description: 'Ημερομηνία έναρξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει όλα τα ιστορικά δεδομένα.'
+          description: 'Start date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes all historical data.'
       tags:
         - Search
       security:
@@ -22324,14 +22313,14 @@ paths:
   /api/v1/search/blog/post:
     get:
       operationId: api_v1_search_blog_post_retrieve
-      description: Αναζήτηση άρθρων με χρήση MeiliSearch. Παρέχει αναζήτηση πλήρους κειμένου με επισήμανση, κατάταξη και δυνατότητες facet. Τα αποτελέσματα μπορούν να φιλτραριστούν κατά γλώσσα.
-      summary: Αναζήτηση άρθρων
+      description: Search blog posts using MeiliSearch. Provides full-text search with highlighting, ranking, and faceting capabilities. Results can be filtered by language.
+      summary: Search blog posts
       parameters:
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: limit
           schema:
@@ -22339,7 +22328,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum number of results to return
         - in: query
           name: offset
           schema:
@@ -22347,12 +22336,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: query
           schema:
             type: string
-          description: String αναζήτησης
+          description: Search query string
           required: true
       tags:
         - Search
@@ -22372,17 +22361,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: ''
+  /api/v1/search/click:
+    post:
+      operationId: api_v1_search_click_create
+      description: Attribute a click on a search result to the query that produced it. The query_id comes from the search response. Feeds the click-through ranking signal and search analytics.
+      summary: Log a click on a search result
+      tags:
+        - Search
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchClickRequestRequest'
+        required: true
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchClickResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
   /api/v1/search/federated:
     get:
       operationId: api_v1_search_federated_retrieve
-      description: Ταυτόχρονη αναζήτηση σε πολλαπλούς τύπους περιεχομένου με χρήση του API multi_search του Meilisearch σε λειτουργία ομοσπονδίας. Τα αποτελέσματα σταθμίζονται και συγχωνεύονται, με τα προϊόντα να έχουν βάρος 1.0 και τα άρθρα βάρος 0.7.
-      summary: Ομοσπονδιακή αναζήτηση σε προϊόντα και άρθρα
+      description: Search multiple content types simultaneously using Meilisearch multi_search API with federation mode. Results are weighted and merged with products having weight 1.0 and blog posts having weight 0.7.
+      summary: Federated search across products and blog posts
       parameters:
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: limit
           schema:
@@ -22390,7 +22414,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος συνολικός αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum total number of results to return
         - in: query
           name: offset
           schema:
@@ -22398,12 +22422,12 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: query
           schema:
             type: string
-          description: String αναζήτησης
+          description: Search query string
           required: true
       tags:
         - Search
@@ -22426,29 +22450,29 @@ paths:
   /api/v1/search/product:
     get:
       operationId: api_v1_search_product_retrieve
-      description: Αναζήτηση προϊόντων με χρήση MeiliSearch, με υποστήριξη αναζήτησης πλήρους κειμένου, εύρους τιμής, δημοτικότητας, πλήθους προβολών και φίλτρων κατηγορίας. Επιστρέφει κατανομή facet και στατιστικά για δυναμικό UI φίλτρων.
-      summary: Αναζήτηση προϊόντων με προηγμένα φίλτρα
+      description: Search products using MeiliSearch with support for full-text search, price range, popularity, view count, and category filters. Returns facet distribution and statistics for dynamic filter UI.
+      summary: Search products with advanced filters
       parameters:
         - in: query
           name: attributeValues
           schema:
             type: string
-          description: ID τιμών χαρακτηριστικών διαχωρισμένα με κόμμα (attribute_values IN [ids])
+          description: Comma-separated attribute value IDs (attribute_values IN [ids])
         - in: query
           name: categories
           schema:
             type: string
-          description: ID κατηγοριών διαχωρισμένα με κόμμα (category IN [ids])
+          description: Comma-separated category IDs (category IN [ids])
         - in: query
           name: facets
           schema:
             type: string
-          description: Πεδία facet διαχωρισμένα με κόμμα για πλήθη και στατιστικά
+          description: Comma-separated facet fields for counts and stats
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+          description: Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
         - in: query
           name: likesMin
           schema:
@@ -22456,7 +22480,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ελάχιστων επισημάνσεων (likes_count >= value)
+          description: Minimum likes filter (likes_count >= value)
         - in: query
           name: limit
           schema:
@@ -22464,7 +22488,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+          description: Maximum number of results to return
         - in: query
           name: offset
           schema:
@@ -22472,7 +22496,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων προς παράλειψη
+          description: Number of results to skip
         - in: query
           name: priceMax
           schema:
@@ -22480,7 +22504,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο μέγιστης τιμής (final_price <= value)
+          description: Maximum price filter (final_price <= value)
         - in: query
           name: priceMin
           schema:
@@ -22488,17 +22512,17 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ελάχιστης τιμής (final_price >= value)
+          description: Minimum price filter (final_price >= value)
         - in: query
           name: query
           schema:
             type: string
-          description: Ερώτημα αναζήτησης πλήρους κειμένου (κενό για χωρίς φίλτρο αναζήτησης)
+          description: Full-text search query (empty for no search filter)
         - in: query
           name: sort
           schema:
             type: string
-          description: Πεδίο ταξινόμησης (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
+          description: Sort field (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
         - in: query
           name: viewsMin
           schema:
@@ -22506,7 +22530,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ελάχιστων προβολών (view_count >= value)
+          description: Minimum views filter (view_count >= value)
       tags:
         - Search
       security:
@@ -22528,19 +22552,19 @@ paths:
   /api/v1/search/trending:
     get:
       operationId: listTrendingSearches
-      description: Επιστρέφει τα πιο δημοφιλή ερωτήματα αναζήτησης των τελευταίων 24 ωρών, κατάλληλα για εμφάνιση στην κενή κατάσταση του modal αναζήτησης. Αποθηκεύεται σε cache για 5 λεπτά ανά (language_code, content_type, limit).
-      summary: Λίστα trending αναζητήσεων
+      description: Return the most popular search queries from the last 24 hours, suitable for surfacing in the search modal empty state. Cached for 5 minutes per (language_code, content_type, limit).
+      summary: List trending search queries
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: 'Φίλτρο ανά τύπο περιεχομένου: product, blog_post, federated. Προεπιλογή product.'
+          description: 'Filter by content type: product, blog_post, federated. Defaults to product.'
         - in: query
           name: languageCode
           schema:
             type: string
-          description: Φίλτρο ερωτημάτων ανά γλώσσα (π.χ. 'el').
+          description: Filter queries by language (e.g. 'el').
         - in: query
           name: limit
           schema:
@@ -22548,7 +22572,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Μέγιστα αποτελέσματα. Προεπιλογή 8, ανώτατο 20.
+          description: Max results. Default 8, cap 20.
       tags:
         - Search
       security:
@@ -22564,8 +22588,8 @@ paths:
   /api/v1/settings:
     get:
       operationId: api_v1_settings_list
-      description: Ανάκτηση όλων των ρυθμίσεων με τα ονόματα, τις τιμές και τους τύπους τους
-      summary: Λίστα όλων των ρυθμίσεων
+      description: Retrieve all settings with their names, values, and types
+      summary: List all available settings
       tags:
         - Settings
       security:
@@ -22588,14 +22612,14 @@ paths:
   /api/v1/settings/get:
     get:
       operationId: api_v1_settings_get_retrieve
-      description: Ανάκτηση συγκεκριμένης τιμής ρύθμισης βάσει του ονόματος κλειδιού της
-      summary: Λήψη ρύθμισης με κλειδί
+      description: Retrieve a specific setting value by its key name
+      summary: Get setting by key
       parameters:
         - in: query
           name: key
           schema:
             type: string
-          description: Όνομα κλειδιού ρύθμισης (π.χ. CHECKOUT_SHIPPING_PRICE)
+          description: Setting key name (e.g., CHECKOUT_SHIPPING_PRICE)
           required: true
       tags:
         - Settings
@@ -22889,14 +22913,14 @@ paths:
   /api/v1/shipping/boxnow/lockers:
     get:
       operationId: listBoxNowLocker
-      description: 'Ανάκτηση λίστας Lockers BoxNow με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Lockers BoxNow
+      description: 'Retrieve a list of BoxNow Lockers with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List BoxNow Lockers
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -22906,7 +22930,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -22930,7 +22954,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -22939,7 +22963,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -22949,7 +22973,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -23001,8 +23025,8 @@ paths:
   /api/v1/shipping/boxnow/lockers/{id}:
     get:
       operationId: retrieveBoxNowLocker
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Locker BoxNow.
-      summary: Ανάκτηση Locker BoxNow
+      description: Get detailed information about a specific BoxNow Locker.
+      summary: Retrieve a BoxNow Locker
       parameters:
         - in: path
           name: id
@@ -23018,7 +23042,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - BoxNow lockers
       security:
@@ -23266,8 +23290,8 @@ paths:
   /api/v1/tag:
     get:
       operationId: listTag
-      description: 'Ανάκτηση λίστας Ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Ετικέτες
+      description: 'Retrieve a list of Tags with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Tags
       parameters:
         - in: query
           name: active
@@ -23280,17 +23304,17 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: contentType
           schema:
             type: string
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο τύπο περιεχομένου
+          description: Filter tags used for specific content type
         - in: query
           name: contentType_AppLabel
           schema:
             type: string
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για περιεχόμενο από συγκεκριμένη εφαρμογή
+          description: Filter tags used for content from specific app
         - in: query
           name: createdAfter
           schema:
@@ -23322,7 +23346,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasLabel
           schema:
@@ -23334,7 +23358,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών με/χωρίς ετικέτα
+          description: Filter tags that have/don't have a label
         - in: query
           name: hasUsage
           schema:
@@ -23346,7 +23370,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών χρησιμοποιούμενων/μη
+          description: Filter tags that are/aren't used
         - in: query
           name: id
           schema:
@@ -23359,7 +23383,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -23370,17 +23394,17 @@ paths:
           name: label
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+          description: Filter by tag label (partial match)
         - in: query
           name: label_Exact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή ετικέτα
+          description: Filter by exact tag label
         - in: query
           name: label_Startswith
           schema:
             type: string
-          description: Φίλτρο ετικετών με ετικέτα που ξεκινά με
+          description: Filter tags with labels starting with
         - in: query
           name: languageCode
           schema:
@@ -23390,7 +23414,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: maxUsageCount
           schema:
@@ -23398,7 +23422,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών που χρησιμοποιούνται έως X φορές
+          description: Filter tags used at most X times
         - in: query
           name: minUsageCount
           schema:
@@ -23406,7 +23430,7 @@ paths:
               - type: string
                 pattern: ^-?\d+(\.\d+)?$
               - type: number
-          description: Φίλτρο ετικετών που χρησιμοποιούνται τουλάχιστον X φορές
+          description: Filter tags used at least X times
         - in: query
           name: mostUsed
           schema:
@@ -23418,7 +23442,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+          description: Order tags by usage count (most used first)
         - in: query
           name: objectId
           schema:
@@ -23426,7 +23450,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο ID αντικειμένου
+          description: Filter tags used for specific object ID
         - name: ordering
           in: query
           required: false
@@ -23450,7 +23474,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -23459,7 +23483,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -23469,7 +23493,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -23520,7 +23544,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ετικετών που δεν χρησιμοποιούνται
+          description: Filter tags not used anywhere
         - in: query
           name: updatedAfter
           schema:
@@ -23597,8 +23621,8 @@ paths:
           description: ''
     post:
       operationId: createTag
-      description: Δημιουργία νέου Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Ετικέτα
+      description: Create a new Tag. Requires authentication.
+      summary: Create a Tag
       parameters:
         - in: query
           name: languageCode
@@ -23609,7 +23633,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23666,8 +23690,8 @@ paths:
   /api/v1/tag/{id}:
     get:
       operationId: retrieveTag
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Ετικέτα.
-      summary: Ανάκτηση Ετικέτα
+      description: Get detailed information about a specific Tag.
+      summary: Retrieve a Tag
       parameters:
         - in: path
           name: id
@@ -23686,7 +23710,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       security:
@@ -23725,8 +23749,8 @@ paths:
           description: ''
     put:
       operationId: updateTag
-      description: Ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Ετικέτα
+      description: Update Tag information. Requires authentication.
+      summary: Update a Tag
       parameters:
         - in: path
           name: id
@@ -23745,7 +23769,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23801,8 +23825,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateTag
-      description: Μερική ενημέρωση πληροφοριών Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Ετικέτα
+      description: Partially update Tag information. Requires authentication.
+      summary: Partially update a Tag
       parameters:
         - in: path
           name: id
@@ -23821,7 +23845,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tags
       requestBody:
@@ -23876,8 +23900,8 @@ paths:
           description: ''
     delete:
       operationId: destroyTag
-      description: Διαγραφή Ετικέτα. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Ετικέτα
+      description: Delete a Tag. Requires authentication.
+      summary: Delete a Tag
       parameters:
         - in: path
           name: id
@@ -23915,19 +23939,19 @@ paths:
   /api/v1/tagged-item:
     get:
       operationId: listTaggedItem
-      description: 'Ανάκτηση λίστας Αντικείμενα με ετικέτες με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Αντικείμενα με ετικέτες
+      description: 'Retrieve a list of Tagged Items with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Tagged Items
       parameters:
         - in: query
           name: contentType
           schema:
             type: string
-          description: Φίλτρο ανά όνομα model τύπου περιεχομένου
+          description: Filter by content type model name
         - in: query
           name: contentType_AppLabel
           schema:
             type: string
-          description: Φίλτρο ανά app label τύπου περιεχομένου
+          description: Filter by content type app label
         - in: query
           name: createdAfter
           schema:
@@ -23959,7 +23983,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: id
           schema:
@@ -23972,7 +23996,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -23988,7 +24012,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: objectId
           schema:
@@ -23996,19 +24020,19 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά ID αντικειμένου
+          description: Filter by object ID
         - in: query
           name: objectId_In
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
                   maximum: 2147483647
                   minimum: 0
-          description: Φίλτρο ανά πολλαπλά ID αντικειμένων (διαχωρισμένα με κόμμα)
+          description: Filter by multiple object IDs (comma-separated)
           explode: false
           style: form
         - name: ordering
@@ -24034,7 +24058,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -24043,7 +24067,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -24053,7 +24077,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -24067,7 +24091,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά συγκεκριμένο ID ετικέτας
+          description: Filter by specific tag ID
         - in: query
           name: tag_Active
           schema:
@@ -24079,12 +24103,12 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά ενεργή κατάσταση ετικέτας
+          description: Filter by tag active status
         - in: query
           name: tag_Label
           schema:
             type: string
-          description: Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+          description: Filter by tag label (partial match)
         - in: query
           name: updatedAfter
           schema:
@@ -24161,8 +24185,8 @@ paths:
           description: ''
     post:
       operationId: createTaggedItem
-      description: Δημιουργία νέου Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Σχετιζόμενο Είδος
+      description: Create a new Tagged Item. Requires authentication.
+      summary: Create a Tagged Item
       parameters:
         - in: query
           name: languageCode
@@ -24173,7 +24197,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24230,8 +24254,8 @@ paths:
   /api/v1/tagged-item/{id}:
     get:
       operationId: retrieveTaggedItem
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Σχετιζόμενο Είδος.
-      summary: Ανάκτηση Σχετιζόμενο Είδος
+      description: Get detailed information about a specific Tagged Item.
+      summary: Retrieve a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24250,7 +24274,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       security:
@@ -24289,8 +24313,8 @@ paths:
           description: ''
     put:
       operationId: updateTaggedItem
-      description: Ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Σχετιζόμενο Είδος
+      description: Update Tagged Item information. Requires authentication.
+      summary: Update a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24309,7 +24333,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24365,8 +24389,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateTaggedItem
-      description: Μερική ενημέρωση πληροφοριών Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Σχετιζόμενο Είδος
+      description: Partially update Tagged Item information. Requires authentication.
+      summary: Partially update a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24385,7 +24409,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Tagged Items
       requestBody:
@@ -24440,8 +24464,8 @@ paths:
           description: ''
     delete:
       operationId: destroyTaggedItem
-      description: Διαγραφή Σχετιζόμενο Είδος. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Σχετιζόμενο Είδος
+      description: Delete a Tagged Item. Requires authentication.
+      summary: Delete a Tagged Item
       parameters:
         - in: path
           name: id
@@ -24500,14 +24524,14 @@ paths:
   /api/v1/user/account:
     get:
       operationId: listUserAccount
-      description: 'Ανάκτηση λίστας Λογαριασμοί Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Λογαριασμοί Χρηστών
+      description: 'Retrieve a list of User Accounts with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Accounts
       parameters:
         - in: query
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: languageCode
           schema:
@@ -24517,7 +24541,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -24541,7 +24565,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -24550,7 +24574,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -24560,7 +24584,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -24610,8 +24634,8 @@ paths:
           description: ''
     post:
       operationId: createUserAccount
-      description: Δημιουργία νέου Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Λογαριασμός Χρήστη
+      description: Create a new User Account. Requires authentication.
+      summary: Create a User Account
       parameters:
         - in: query
           name: languageCode
@@ -24622,7 +24646,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24679,8 +24703,8 @@ paths:
   /api/v1/user/account/{id}:
     get:
       operationId: retrieveUserAccount
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Λογαριασμός Χρήστη.
-      summary: Ανάκτηση Λογαριασμός Χρήστη
+      description: Get detailed information about a specific User Account.
+      summary: Retrieve a User Account
       parameters:
         - in: path
           name: id
@@ -24699,7 +24723,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       security:
@@ -24737,8 +24761,8 @@ paths:
           description: ''
     put:
       operationId: updateUserAccount
-      description: Ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Λογαριασμός Χρήστη
+      description: Update User Account information. Requires authentication.
+      summary: Update a User Account
       parameters:
         - in: path
           name: id
@@ -24757,7 +24781,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24813,8 +24837,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserAccount
-      description: Μερική ενημέρωση πληροφοριών Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Λογαριασμός Χρήστη
+      description: Partially update User Account information. Requires authentication.
+      summary: Partially update a User Account
       parameters:
         - in: path
           name: id
@@ -24833,7 +24857,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Accounts
       requestBody:
@@ -24889,8 +24913,8 @@ paths:
   /api/v1/user/account/{id}/addresses:
     get:
       operationId: getUserAccountAddresses
-      description: Λήψη όλων των διευθύνσεων για συγκεκριμένο χρήστη.
-      summary: Λήψη διευθύνσεων χρήστη
+      description: Get all addresses for a specific user.
+      summary: Get user's addresses
       parameters:
         - in: path
           name: id
@@ -24975,8 +24999,8 @@ paths:
   /api/v1/user/account/{id}/blog_post_comments:
     get:
       operationId: getUserAccountBlogPostComments
-      description: Λήψη όλων των σχολίων σε άρθρα που έχει γράψει συγκεκριμένος χρήστης.
-      summary: Λήψη σχολίων blog χρήστη
+      description: Get all blog post comments written by a specific user.
+      summary: Get user's blog comments
       parameters:
         - in: path
           name: id
@@ -25061,8 +25085,8 @@ paths:
   /api/v1/user/account/{id}/change_username:
     post:
       operationId: changeUserAccountUsername
-      description: Αλλαγή του ονόματος χρήστη για συγκεκριμένο χρήστη.
-      summary: Αλλαγή ονόματος χρήστη
+      description: Change the username for a specific user.
+      summary: Change username
       parameters:
         - in: path
           name: id
@@ -25128,8 +25152,8 @@ paths:
   /api/v1/user/account/{id}/data_exports:
     get:
       operationId: listUserAccountDataExports
-      description: Λίστα πρόσφατων αιτημάτων εξαγωγής δεδομένων για αυτόν τον χρήστη, ώστε η διεπαφή να εμφανίζει την πρόοδο και τον τελευταίο σύνδεσμο λήψης.
-      summary: Λίστα εξαγωγών δεδομένων GDPR
+      description: List recent data-export requests for this user so the UI can show progress and the last download link.
+      summary: List GDPR data exports
       parameters:
         - in: path
           name: id
@@ -25214,8 +25238,8 @@ paths:
   /api/v1/user/account/{id}/delete_account:
     post:
       operationId: deleteUserAccountGdpr
-      description: Ανωνυμοποιεί τις παραγγελίες του χρήστη (διατηρούνται για φορολογικούς/λογιστικούς λόγους) και διαγράφει οριστικά κάθε άλλη συνδεδεμένη εγγραφή. Μη αναστρέψιμο. Ο καλών πρέπει να έχει επανα-ταυτοποιηθεί μέσω allauth εντός του χρονικού παραθύρου που ορίζεται από το ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.
-      summary: Διαγραφή λογαριασμού (δικαίωμα διαγραφής GDPR)
+      description: Anonymises the user's orders (kept for tax/accounting) and hard-deletes every other linked record. Irreversible. Caller must have re-authenticated via allauth within the window configured by ``ACCOUNT_REAUTHENTICATION_TIMEOUT``.
+      summary: Delete account (GDPR right-to-erasure)
       parameters:
         - in: path
           name: id
@@ -25281,8 +25305,8 @@ paths:
   /api/v1/user/account/{id}/favourite_products:
     get:
       operationId: getUserAccountFavouriteProducts
-      description: Λήψη όλων των αγαπημένων προϊόντων για συγκεκριμένο χρήστη.
-      summary: Λήψη αγαπημένων προϊόντων χρήστη
+      description: Get all favourite products for a specific user.
+      summary: Get user's favourite products
       parameters:
         - in: path
           name: id
@@ -25367,8 +25391,8 @@ paths:
   /api/v1/user/account/{id}/liked_blog_posts:
     get:
       operationId: getUserAccountLikedBlogPosts
-      description: Λήψη όλων των άρθρων που έχει επισημάνει συγκεκριμένος χρήστης.
-      summary: Λήψη άρθρων με επισήμανση χρήστη
+      description: Get all blog posts liked by a specific user.
+      summary: Get user's liked blog posts
       parameters:
         - in: path
           name: id
@@ -25453,8 +25477,8 @@ paths:
   /api/v1/user/account/{id}/notifications:
     get:
       operationId: getUserAccountNotifications
-      description: Λήψη όλων των ειδοποιήσεων για συγκεκριμένο χρήστη.
-      summary: Λήψη ειδοποιήσεων χρήστη
+      description: Get all notifications for a specific user.
+      summary: Get user's notifications
       parameters:
         - in: path
           name: id
@@ -25506,7 +25530,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ειδοποιήσεων κατά κατάσταση ορατότητας.
+          description: Filter notifications by seen/unseen state.
       tags:
         - User Accounts
       security:
@@ -25551,8 +25575,8 @@ paths:
   /api/v1/user/account/{id}/orders:
     get:
       operationId: getUserAccountOrders
-      description: Λήψη όλων των παραγγελιών για συγκεκριμένο χρήστη.
-      summary: Λήψη παραγγελιών χρήστη
+      description: Get all orders for a specific user.
+      summary: Get user's orders
       parameters:
         - in: path
           name: id
@@ -25637,8 +25661,8 @@ paths:
   /api/v1/user/account/{id}/product_reviews:
     get:
       operationId: getUserAccountProductReviews
-      description: Λήψη όλων των αξιολογήσεων προϊόντων που έχει γράψει συγκεκριμένος χρήστης.
-      summary: Λήψη κριτικών προϊόντος χρήστη
+      description: Get all product reviews written by a specific user.
+      summary: Get user's product reviews
       parameters:
         - in: path
           name: id
@@ -25723,8 +25747,8 @@ paths:
   /api/v1/user/account/{id}/request_data_export:
     post:
       operationId: requestUserAccountDataExport
-      description: Ουρά εργασίας που συγκεντρώνει τα προσωπικά δεδομένα του χρήστη και αποστέλλει με email έναν εφάπαξ σύνδεσμο λήψης. Επιστρέφει τη νέα εγγραφή UserDataExport.
-      summary: Αίτημα εξαγωγής δεδομένων GDPR
+      description: Queue a job that compiles the user's personal data and emails a one-off download link. Returns the new UserDataExport record.
+      summary: Request GDPR data export
       parameters:
         - in: path
           name: id
@@ -25778,14 +25802,14 @@ paths:
   /api/v1/user/address:
     get:
       operationId: listUserAddress
-      description: 'Ανάκτηση λίστας Διευθύνσεις Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Διευθύνσεις Χρηστών
+      description: 'Retrieve a list of User Addresses with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Addresses
       parameters:
         - in: query
           name: city
           schema:
             type: string
-          description: Φίλτρο ανά όνομα πόλης (μερική αντιστοίχιση)
+          description: Filter by city name (partial match)
         - in: query
           name: city_Icontains
           schema:
@@ -25794,17 +25818,17 @@ paths:
           name: country
           schema:
             type: string
-          description: Φίλτρο ανά alpha_2 κωδικό χώρας
+          description: Filter by country alpha_2 code
         - in: query
           name: countryCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό χώρας (π.χ. 'US', 'CA')
+          description: Filter by country code (e.g., 'US', 'CA')
         - in: query
           name: countryName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+          description: Filter by country name (partial match)
         - in: query
           name: createdAfter
           schema:
@@ -25836,12 +25860,12 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: firstName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by first name (partial match)
         - in: query
           name: firstName_Icontains
           schema:
@@ -25850,7 +25874,6 @@ paths:
           name: floor
           schema:
             type: string
-            title: Όροφος
             enum:
               - ''
               - BASEMENT
@@ -25861,12 +25884,12 @@ paths:
               - SECOND_FLOOR
               - SIXTH_FLOOR_PLUS
               - THIRD_FLOOR
-          description: Φίλτρο ανά όροφο
+          description: Filter by floor
         - in: query
           name: fullName
           schema:
             type: string
-          description: Φίλτρο ανά πλήρες όνομα (όνομα + επώνυμο)
+          description: Filter by full name (first + last name)
         - in: query
           name: hasNotes
           schema:
@@ -25878,7 +25901,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο διευθύνσεων με σημειώσεις
+          description: Filter addresses that have notes
         - in: query
           name: id
           schema:
@@ -25891,7 +25914,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -25909,7 +25932,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κύρια διεύθυνση
+          description: Filter by main address status
         - in: query
           name: languageCode
           schema:
@@ -25919,12 +25942,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: lastName
           schema:
             type: string
-          description: Φίλτρο ανά επώνυμο (μερική αντιστοίχιση)
+          description: Filter by last name (partial match)
         - in: query
           name: lastName_Icontains
           schema:
@@ -25933,7 +25956,7 @@ paths:
           name: locationType
           schema:
             type: string
-          description: Φίλτρο ανά τύπο τοποθεσίας (ακριβής αντιστοίχιση, χωρίς διάκριση πεζών/κεφαλαίων)
+          description: Filter by location type (exact match, case insensitive)
         - in: query
           name: locationType_Icontains
           schema:
@@ -25966,7 +25989,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -25975,7 +25998,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -25985,12 +26008,12 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: phone
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό τηλεφώνου (μερική αντιστοίχιση)
+          description: Filter by phone number (partial match)
         - in: query
           name: phone_Icontains
           schema:
@@ -25999,17 +26022,17 @@ paths:
           name: region
           schema:
             type: string
-          description: Φίλτρο ανά αλφαριθμητικό κωδικό περιφέρειας
+          description: Filter by region alpha code
         - in: query
           name: regionCode
           schema:
             type: string
-          description: Φίλτρο ανά κωδικό περιφέρειας
+          description: Filter by region code
         - in: query
           name: regionName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+          description: Filter by region name (partial match)
         - name: search
           required: false
           in: query
@@ -26020,7 +26043,7 @@ paths:
           name: street
           schema:
             type: string
-          description: Φίλτρο ανά όνομα οδού (μερική αντιστοίχιση)
+          description: Filter by street name (partial match)
         - in: query
           name: street_Icontains
           schema:
@@ -26029,7 +26052,7 @@ paths:
           name: streetNumber
           schema:
             type: string
-          description: Φίλτρο ανά αριθμό
+          description: Filter by street number
         - in: query
           name: streetNumber_Icontains
           schema:
@@ -26078,7 +26101,7 @@ paths:
           name: zipcode
           schema:
             type: string
-          description: Φίλτρο ανά ταχυδρομικό κώδικα (μερική αντιστοίχιση)
+          description: Filter by zipcode (partial match)
         - in: query
           name: zipcode_Icontains
           schema:
@@ -26087,7 +26110,7 @@ paths:
           name: zipcodeExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβή ταχυδρομικό κώδικα
+          description: Filter by exact zipcode
       tags:
         - User Addresses
       security:
@@ -26131,8 +26154,8 @@ paths:
           description: ''
     post:
       operationId: createUserAddress
-      description: Δημιουργία νέου Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Διεύθυνση Χρήστη
+      description: Create a new User Address. Requires authentication.
+      summary: Create a User Address
       parameters:
         - in: query
           name: languageCode
@@ -26143,7 +26166,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26200,8 +26223,8 @@ paths:
   /api/v1/user/address/{id}:
     get:
       operationId: retrieveUserAddress
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Διεύθυνση Χρήστη.
-      summary: Ανάκτηση Διεύθυνση Χρήστη
+      description: Get detailed information about a specific User Address.
+      summary: Retrieve a User Address
       parameters:
         - in: path
           name: id
@@ -26220,7 +26243,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       security:
@@ -26258,8 +26281,8 @@ paths:
           description: ''
     put:
       operationId: updateUserAddress
-      description: Ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Διεύθυνση Χρήστη
+      description: Update User Address information. Requires authentication.
+      summary: Update a User Address
       parameters:
         - in: path
           name: id
@@ -26278,7 +26301,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26334,8 +26357,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserAddress
-      description: Μερική ενημέρωση πληροφοριών Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Διεύθυνση Χρήστη
+      description: Partially update User Address information. Requires authentication.
+      summary: Partially update a User Address
       parameters:
         - in: path
           name: id
@@ -26354,7 +26377,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Addresses
       requestBody:
@@ -26409,8 +26432,8 @@ paths:
           description: ''
     delete:
       operationId: destroyUserAddress
-      description: Διαγραφή Διεύθυνση Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Διεύθυνση Χρήστη
+      description: Delete a User Address. Requires authentication.
+      summary: Delete a User Address
       parameters:
         - in: path
           name: id
@@ -26448,8 +26471,8 @@ paths:
   /api/v1/user/address/{id}/set_main:
     post:
       operationId: setMainUserAddress
-      description: Ορισμός αυτής της διεύθυνσης ως κύριας διεύθυνσης του χρήστη.
-      summary: Ορισμός διεύθυνσης ως κύριας
+      description: Set this address as the user's main address.
+      summary: Set address as main
       parameters:
         - in: path
           name: id
@@ -26503,8 +26526,8 @@ paths:
   /api/v1/user/data_export/{token}/download:
     get:
       operationId: downloadUserDataExport
-      description: Επιστρέφει το πακέτο JSON που παρήγαγε η εργασία εξαγωγής. Το token έχει ένα μόνο πεδίο εφαρμογής, συνδέεται με μία εγγραφή UserDataExport, και λήγει 7 ημέρες μετά την παραγωγή της εξαγωγής.
-      summary: Λήψη πακέτου εξαγωγής δεδομένων GDPR
+      description: Returns the JSON bundle produced by the export task. The token is single-scope, tied to one UserDataExport row, and expires 7 days after the export was produced.
+      summary: Download a GDPR data export bundle
       parameters:
         - in: path
           name: token
@@ -26525,8 +26548,8 @@ paths:
   /api/v1/user/subscription:
     get:
       operationId: listUserSubscription
-      description: 'Ανάκτηση λίστας Συνδρομές Χρηστών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Συνδρομές Χρηστών
+      description: 'Retrieve a list of User Subscriptions with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List User Subscriptions
       parameters:
         - in: query
           name: createdAfter
@@ -26559,7 +26582,7 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: hasMetadata
           schema:
@@ -26571,7 +26594,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο εγγραφών με metadata
+          description: Filter subscriptions that have metadata
         - in: query
           name: id
           schema:
@@ -26584,7 +26607,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -26602,7 +26625,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση επιβεβαίωσης
+          description: Filter by confirmation status
         - in: query
           name: languageCode
           schema:
@@ -26612,7 +26635,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - name: ordering
           in: query
           required: false
@@ -26636,7 +26659,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -26645,7 +26668,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -26655,7 +26678,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - name: search
           required: false
           in: query
@@ -26666,25 +26689,24 @@ paths:
           name: status
           schema:
             type: string
-            title: Κατάσταση
             enum:
               - ACTIVE
               - BOUNCED
               - PENDING
               - UNSUBSCRIBED
           description: |-
-            Φίλτρο ανά κατάσταση συνδρομής
+            Filter by subscription status
 
-            * `ACTIVE` - Ενεργή
-            * `PENDING` - Εκκρεμεί Επιβεβαίωση
-            * `UNSUBSCRIBED` - Διαγραφή
-            * `BOUNCED` - Επιστράφηκε
+            * `ACTIVE` - Active
+            * `PENDING` - Pending Confirmation
+            * `UNSUBSCRIBED` - Unsubscribed
+            * `BOUNCED` - Bounced
         - in: query
           name: subscribedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+          description: Filter subscriptions created after this date
         - in: query
           name: subscribedAt_Date
           schema:
@@ -26705,7 +26727,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+          description: Filter subscriptions created before this date
         - in: query
           name: topic
           schema:
@@ -26713,12 +26735,11 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Φίλτρο ανά θέμα συνδρομής
+          description: Filter by subscription topic
         - in: query
           name: topicCategory
           schema:
             type: string
-            title: Κατηγορία
             enum:
               - ACCOUNT
               - MARKETING
@@ -26728,41 +26749,41 @@ paths:
               - PROMOTIONAL
               - SYSTEM
           description: |-
-            Φίλτρο ανά κατηγορία θέματος
+            Filter by topic category
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         - in: query
           name: topicDescription
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή θέματος (μερική αντιστοίχιση)
+          description: Filter by topic description (partial match)
         - in: query
           name: topicName
           schema:
             type: string
-          description: Φίλτρο ανά όνομα θέματος (μερική αντιστοίχιση)
+          description: Filter by topic name (partial match)
         - in: query
           name: topicSlug
           schema:
             type: string
-          description: Φίλτρο ανά slug θέματος (μερική αντιστοίχιση)
+          description: Filter by topic slug (partial match)
         - in: query
           name: topicSlugExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές slug θέματος
+          description: Filter by exact topic slug
         - in: query
           name: unsubscribedAfter
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών με διαγραφή μετά από αυτή την ημερομηνία
+          description: Filter subscriptions unsubscribed after this date
         - in: query
           name: unsubscribedAt_Date
           schema:
@@ -26783,7 +26804,7 @@ paths:
           schema:
             type: string
             format: date-time
-          description: Φίλτρο εγγραφών με διαγραφή πριν από αυτή την ημερομηνία
+          description: Filter subscriptions unsubscribed before this date
         - in: query
           name: updatedAfter
           schema:
@@ -26859,8 +26880,8 @@ paths:
           description: ''
     post:
       operationId: createUserSubscription
-      description: Δημιουργία νέου Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Συνδρομή Χρήστη
+      description: Create a new User Subscription. Requires authentication.
+      summary: Create a User Subscription
       parameters:
         - in: query
           name: languageCode
@@ -26871,7 +26892,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -26928,8 +26949,8 @@ paths:
   /api/v1/user/subscription/{id}:
     get:
       operationId: retrieveUserSubscription
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Συνδρομή Χρήστη.
-      summary: Ανάκτηση Συνδρομή Χρήστη
+      description: Get detailed information about a specific User Subscription.
+      summary: Retrieve a User Subscription
       parameters:
         - in: path
           name: id
@@ -26948,7 +26969,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       security:
@@ -26986,8 +27007,8 @@ paths:
           description: ''
     put:
       operationId: updateUserSubscription
-      description: Ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Συνδρομή Χρήστη
+      description: Update User Subscription information. Requires authentication.
+      summary: Update a User Subscription
       parameters:
         - in: path
           name: id
@@ -27006,7 +27027,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -27062,8 +27083,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateUserSubscription
-      description: Μερική ενημέρωση πληροφοριών Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Συνδρομή Χρήστη
+      description: Partially update User Subscription information. Requires authentication.
+      summary: Partially update a User Subscription
       parameters:
         - in: path
           name: id
@@ -27082,7 +27103,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - User Subscription
       requestBody:
@@ -27137,8 +27158,8 @@ paths:
           description: ''
     delete:
       operationId: destroyUserSubscription
-      description: Διαγραφή Συνδρομή Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Συνδρομή Χρήστη
+      description: Delete a User Subscription. Requires authentication.
+      summary: Delete a User Subscription
       parameters:
         - in: path
           name: id
@@ -27176,8 +27197,8 @@ paths:
   /api/v1/user/subscription/{id}/confirm:
     post:
       operationId: confirmUserSubscription
-      description: Επιβεβαίωση εκκρεμούς εγγραφής με χρήση του token επιβεβαίωσης.
-      summary: Επιβεβαίωση συνδρομής χρήστη
+      description: Confirm a pending subscription using the confirmation token.
+      summary: Confirm a user subscription
       parameters:
         - in: path
           name: id
@@ -27231,8 +27252,8 @@ paths:
   /api/v1/user/subscription/bulk_update:
     post:
       operationId: bulkUpdateUserSubscriptions
-      description: Εγγραφή ή διαγραφή από πολλαπλά θέματα ταυτόχρονα.
-      summary: Μαζική ενημέρωση συνδρομών χρήστη
+      description: Subscribe or unsubscribe from multiple topics at once.
+      summary: Bulk update user subscriptions
       tags:
         - User Subscriptions
       requestBody:
@@ -27295,7 +27316,7 @@ paths:
         The confirmation token itself is 64 chars of random entropy (sufficient
         authorization); no login required. Accepts both GET (user clicks the
         link in a mail client) and POST (for programmatic confirmation).
-      summary: Επιβεβαίωση εκκρεμούς εγγραφής μέσω token email
+      summary: Confirm a pending subscription via email token
       parameters:
         - in: path
           name: token
@@ -27355,14 +27376,13 @@ paths:
   /api/v1/user/subscription/topic:
     get:
       operationId: listSubscriptionTopic
-      description: 'Ανάκτηση λίστας Θέματα Συνδρομών με δυνατότητες φιλτραρίσματος και αναζήτησης. Υποστηρίζει πολλαπλές στρατηγικές σελιδοποίησης: pageNumber (προεπιλογή), cursor και limitOffset.'
-      summary: Λίστα Θέματα Συνδρομών
+      description: 'Retrieve a list of Subscription Topics with filtering and search capabilities. Supports multiple pagination strategies: pageNumber (default), cursor, and limitOffset.'
+      summary: List Subscription Topics
       parameters:
         - in: query
           name: category
           schema:
             type: string
-            title: Κατηγορία
             enum:
               - ACCOUNT
               - MARKETING
@@ -27372,15 +27392,15 @@ paths:
               - PROMOTIONAL
               - SYSTEM
           description: |-
-            Φίλτρο ανά κατηγορία θέματος
+            Filter by topic category
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         - in: query
           name: createdAfter
           schema:
@@ -27412,12 +27432,12 @@ paths:
           name: cursor
           schema:
             type: string
-          description: Δείκτης (cursor) για σελιδοποίηση
+          description: Cursor for pagination
         - in: query
           name: description
           schema:
             type: string
-          description: Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+          description: Filter by description (partial match)
         - in: query
           name: hasSubscribers
           schema:
@@ -27429,7 +27449,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο θεμάτων με εγγεγραμμένους
+          description: Filter topics that have subscribers
         - in: query
           name: id
           schema:
@@ -27442,7 +27462,7 @@ paths:
           schema:
             oneOf:
               - type: string
-                description: Τιμές διαχωρισμένες με κόμμα
+                description: Comma-separated values
               - type: array
                 items:
                   type: integer
@@ -27460,7 +27480,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά κατάσταση ενεργοποίησης
+          description: Filter by active status
         - in: query
           name: isDefault
           schema:
@@ -27472,7 +27492,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά προεπιλεγμένη κατάσταση εγγραφής
+          description: Filter by default subscription status
         - in: query
           name: languageCode
           schema:
@@ -27482,12 +27502,12 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
         - in: query
           name: name
           schema:
             type: string
-          description: Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+          description: Filter by name (partial match)
         - name: ordering
           in: query
           required: false
@@ -27511,7 +27531,7 @@ paths:
               - type: string
                 pattern: ^-?\d+$
               - type: integer
-          description: Αριθμός αποτελεσμάτων ανά σελίδα
+          description: Number of results to return per page
         - in: query
           name: pagination
           schema:
@@ -27520,7 +27540,7 @@ paths:
               - 'false'
               - 'true'
             default: 'true'
-          description: Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+          description: Enable or disable pagination
         - in: query
           name: paginationType
           schema:
@@ -27530,7 +27550,7 @@ paths:
               - limitOffset
               - pageNumber
             default: pageNumber
-          description: Τύπος στρατηγικής σελιδοποίησης
+          description: Pagination strategy type
         - in: query
           name: requiresConfirmation
           schema:
@@ -27542,7 +27562,7 @@ paths:
                   - '1'
                   - '0'
               - type: boolean
-          description: Φίλτρο ανά απαίτηση επιβεβαίωσης
+          description: Filter by confirmation requirement
         - name: search
           required: false
           in: query
@@ -27553,7 +27573,7 @@ paths:
           name: slug
           schema:
             type: string
-          description: Φίλτρο ανά slug (μερική αντιστοίχιση)
+          description: Filter by slug (partial match)
         - in: query
           name: slug_Icontains
           schema:
@@ -27562,7 +27582,7 @@ paths:
           name: slugExact
           schema:
             type: string
-          description: Φίλτρο ανά ακριβές slug
+          description: Filter by exact slug
         - in: query
           name: updatedAfter
           schema:
@@ -27638,8 +27658,8 @@ paths:
           description: ''
     post:
       operationId: createSubscriptionTopic
-      description: Δημιουργία νέου Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Θέμα Συνδρομής
+      description: Create a new Subscription Topic. Requires authentication.
+      summary: Create a Subscription Topic
       parameters:
         - in: query
           name: languageCode
@@ -27650,7 +27670,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27707,8 +27727,8 @@ paths:
   /api/v1/user/subscription/topic/{id}:
     get:
       operationId: retrieveSubscriptionTopic
-      description: Λήψη λεπτομερών πληροφοριών για συγκεκριμένο Θέμα Συνδρομής.
-      summary: Ανάκτηση Θέμα Συνδρομής
+      description: Get detailed information about a specific Subscription Topic.
+      summary: Retrieve a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27727,7 +27747,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       security:
@@ -27765,8 +27785,8 @@ paths:
           description: ''
     put:
       operationId: updateSubscriptionTopic
-      description: Ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Ενημέρωση Θέμα Συνδρομής
+      description: Update Subscription Topic information. Requires authentication.
+      summary: Update a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27785,7 +27805,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27841,8 +27861,8 @@ paths:
           description: ''
     patch:
       operationId: partialUpdateSubscriptionTopic
-      description: Μερική ενημέρωση πληροφοριών Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Μερική ενημέρωση Θέμα Συνδρομής
+      description: Partially update Subscription Topic information. Requires authentication.
+      summary: Partially update a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27861,7 +27881,7 @@ paths:
               - el
               - en
             default: el
-          description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+          description: Language code for translations (el, en, de)
       tags:
         - Subscription Topics
       requestBody:
@@ -27916,8 +27936,8 @@ paths:
           description: ''
     delete:
       operationId: destroySubscriptionTopic
-      description: Διαγραφή Θέμα Συνδρομής. Απαιτεί ταυτοποίηση.
-      summary: Διαγραφή Θέμα Συνδρομής
+      description: Delete a Subscription Topic. Requires authentication.
+      summary: Delete a Subscription Topic
       parameters:
         - in: path
           name: id
@@ -27955,8 +27975,8 @@ paths:
   /api/v1/user/subscription/topic/{id}/subscribe:
     post:
       operationId: subscribeToTopic
-      description: Εγγραφή του τρέχοντος χρήστη σε συγκεκριμένο θέμα εγγραφής.
-      summary: Εγγραφή σε θέμα
+      description: Subscribe the current user to a specific subscription topic.
+      summary: Subscribe to a topic
       parameters:
         - in: path
           name: id
@@ -28016,8 +28036,8 @@ paths:
   /api/v1/user/subscription/topic/{id}/unsubscribe:
     post:
       operationId: unsubscribeFromTopic
-      description: Διαγραφή του τρέχοντος χρήστη από συγκεκριμένο θέμα εγγραφής.
-      summary: Διαγραφή από θέμα
+      description: Unsubscribe the current user from a specific subscription topic.
+      summary: Unsubscribe from a topic
       parameters:
         - in: path
           name: id
@@ -28071,8 +28091,8 @@ paths:
   /api/v1/user/subscription/topic/my_subscriptions:
     get:
       operationId: getMySubscriptionTopics
-      description: Λήψη των θεμάτων εγγραφής στα οποία είναι εγγεγραμμένος και των διαθέσιμων θεμάτων για τον τρέχοντα χρήστη.
-      summary: Λήψη συνδρομών μου
+      description: Get the current user's subscribed and available subscription topics.
+      summary: Get my subscriptions
       tags:
         - Subscription Topics
       security:
@@ -28131,7 +28151,7 @@ paths:
 
         Unsubscribes from ALL active subscriptions — used by emails without a
         topic binding such as re-engagement and abandoned-cart.
-      summary: Διαγραφή από όλα τα θέματα μέσω συνδέσμου email (GET)
+      summary: Unsubscribe from all topics via email link (GET)
       parameters:
         - in: path
           name: token
@@ -28155,8 +28175,8 @@ paths:
           description: ''
     post:
       operationId: unsubscribeFromAllOneClick
-      description: Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).
-      summary: Διαγραφή με ένα κλικ από όλα τα θέματα κατά RFC 8058
+      description: Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).
+      summary: RFC 8058 one-click unsubscribe from all topics
       parameters:
         - in: path
           name: token
@@ -28175,7 +28195,7 @@ paths:
         Topic-scoped unsubscribe: `/unsubscribe/<token>/<topic_slug>`.
 
         Used by marketing emails with a specific List-ID (newsletter etc.).
-      summary: Διαγραφή από θέμα μέσω συνδέσμου email (GET)
+      summary: Unsubscribe from a topic via email link (GET)
       parameters:
         - in: path
           name: token
@@ -28204,8 +28224,8 @@ paths:
           description: ''
     post:
       operationId: unsubscribeFromTopicOneClick
-      description: Καλείται από προγράμματα email που τηρούν το List-Unsubscribe-Post=One-Click. Επιστρέφει 200 OK ανεξάρτητα από την εγκυρότητα του token (σιωπηλά, κατά RFC 8058).
-      summary: Διαγραφή με ένα κλικ από θέμα κατά RFC 8058
+      description: Invoked by mail clients honoring List-Unsubscribe-Post=One-Click. Returns 200 OK regardless of token validity (silent per RFC 8058).
+      summary: RFC 8058 one-click unsubscribe from a topic
       parameters:
         - in: path
           name: token
@@ -28333,8 +28353,8 @@ components:
         - 2
       type: integer
       description: |-
-        * `1` - Προπληρωμένο
-        * `2` - Αντικαταβολή
+        * `1` - Prepaid
+        * `2` - Cash on delivery
     AcsPickupList:
       type: object
       properties:
@@ -28344,19 +28364,17 @@ components:
         pickupListNo:
           type: string
           readOnly: true
-          title: Αριθμός λίστας παραλαβής
-          description: PickupList_No που επιστρέφεται από το ACS_Issue_Pickup_List.
+          title: Pickup list number
+          description: PickupList_No returned by ACS_Issue_Pickup_List.
         issuedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εκδόθηκε στις
         issuedBy:
           type: integer
           readOnly: true
           nullable: true
-          title: Εκδόθηκε από
-          description: Διαχειριστής που ενεργοποίησε τη χειροκίνητη έκδοση. Null όταν η λίστα εκδόθηκε από την καθημερινή εργασία Celery beat.
+          description: Admin who triggered the manual issue. Null when the daily Celery beat task issued the list.
         issuedByUsername:
           type: string
           nullable: true
@@ -28364,22 +28382,18 @@ components:
         billingCode:
           type: string
           readOnly: true
-          title: Κωδικός χρέωσης
-          description: Billing_Code που καταγράφεται τη στιγμή της έκδοσης, ώστε τα ιστορικά manifest να παραμένουν επανεκτυπώσιμα ακόμη κι αν αλλάξει η μεταβλητή περιβάλλοντος.
+          description: Billing_Code captured at issuance time so historical manifests stay reprintable even if the env var changes.
         voucherCount:
           type: integer
           readOnly: true
-          title: Πλήθος vouchers
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - billingCode
         - createdAt
@@ -28405,103 +28419,92 @@ components:
           type: string
           readOnly: true
           nullable: true
-          title: Αριθμός voucher
-          description: 10ψήφιο voucher ACS (Voucher_No από το ACS_Create_Voucher).
+          title: Voucher number
+          description: 10-digit ACS voucher (Voucher_No from ACS_Create_Voucher).
         shipmentState:
           allOf:
             - $ref: '#/components/schemas/ShipmentStateEnum'
           readOnly: true
-          title: Κατάσταση αποστολής
         shipmentStateDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή shipment_state
+          description: Human-readable label for the shipment_state choice
         deliveryKind:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
           readOnly: true
-          title: Τρόπος παράδοσης
         weightGrams:
           type: integer
           readOnly: true
-          title: Βάρος (γραμμάρια)
-          description: Εσωτερικά γραμμάρια· μετατρέπονται σε κιλά (>= 0,5) κατά την κλήση API σύμφωνα με τις απαιτήσεις βάρους της ACS.
+          title: Weight (grams)
+          description: Internal grams; converted to kilograms (>= 0.5) at API call time per ACS Weight requirements.
         itemQuantity:
           type: integer
           readOnly: true
-          title: Ποσότητα ειδών
         chargeType:
           allOf:
             - $ref: '#/components/schemas/AcsChargeType'
           readOnly: true
-          title: Τύπος χρέωσης
         deliveryProducts:
           type: string
           readOnly: true
-          title: Προϊόντα παράδοσης
-          description: Κωδικοί Acs_Delivery_Products διαχωρισμένοι με κόμμα (COD, REC, SAT, RDO …).
+          description: Comma-separated Acs_Delivery_Products codes (COD, REC, SAT, RDO …).
         lastEventAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίο συμβάν
         lastPolledAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταία ανάκτηση
-          description: Χρησιμοποιείται από το poll_acs_tracking_batch για κατανομή φορτίου και παράλειψη αποστολών που ελέγχθηκαν τα τελευταία 15 λεπτά.
+          description: Used by poll_acs_tracking_batch to spread load and skip shipments polled within the last 15 minutes.
         deliveryDate:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ημερομηνία παράδοσης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         stationDestinationExternalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID καταστήματος προορισμού
-          description: Μη κανονικοποιημένο ACS_SHOP_STATION_ID — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή AcsStation.
+          title: Destination station external ID
+          description: Denormalised ACS_SHOP_STATION_ID — preserved even if the AcsStation row is deleted.
         stationBranchDestination:
           type: string
           readOnly: true
-          title: Υποκατάστημα προορισμού
-          description: Τιμή Acs_Station_Branch_Destination.
+          title: Destination branch
+          description: Acs_Station_Branch_Destination value.
         station:
           allOf:
             - $ref: '#/components/schemas/AcsStation'
           nullable: true
           readOnly: true
-          description: Στοιχεία καταστήματος προορισμού ACS (παραλαβές Smartpoint).
+          description: Destination ACS station details (Smartpoint pickups).
         events:
           type: array
           items:
             $ref: '#/components/schemas/AcsTrackingEvent'
           readOnly: true
-          description: Τελευταία 50 συμβάντα παρακολούθησης ταξινομημένα κατά event_time φθίνουσα.
+          description: Last 50 tracking events ordered by event_time desc.
         labelUrl:
           type: string
           nullable: true
-          description: Σχετικό URL για λήψη του PDF voucher μέσω του proxy Django.
+          description: Relative URL to download the voucher PDF via the Django proxy.
           readOnly: true
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Αίτημα ακύρωσης στις
       required:
         - cancelRequestedAt
         - chargeType
@@ -28542,50 +28545,42 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
-          description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το ''ATH'')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.'
+          description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under ''ATH''); the (external_id, branch_code) pair is the locker''s identity.'
         branchCode:
           type: string
           readOnly: true
           default: ''
-          title: Κωδικός υποκαταστήματος
-          description: ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+          description: ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
         shopKind:
           allOf:
             - $ref: '#/components/schemas/ShopKindEnum'
           readOnly: true
-          title: Είδος καταστήματος
           description: |-
-            ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
+            ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
 
-            * `1` - Κατάστημα
-            * `2` - Συνεργαζόμενο κατάστημα (2)
-            * `3` - Συνεργαζόμενο κατάστημα (3)
+            * `1` - Shop
+            * `2` - Partner shop (2)
+            * `3` - Partner shop (3)
             * `4` - Xpress Point
             * `5` - Kiosk
-            * `7` - Smartpoint (χωρίς locker)
+            * `7` - Smartpoint (no locker)
             * `8` - Smartpoint locker
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         city:
           type: string
           readOnly: true
-          title: Πόλη
         postalCode:
           type: string
           readOnly: true
-          title: Ταχυδρομικός κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας.
+          description: ISO 3166-1 alpha-2 country code.
         lat:
           type: string
           nullable: true
@@ -28600,27 +28595,22 @@ components:
         workingHours:
           type: string
           readOnly: true
-          title: Ωράριο λειτουργίας
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - addressLine1
         - branchCode
@@ -28658,50 +28648,42 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
-          description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το ''ATH'')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.'
+          description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under ''ATH''); the (external_id, branch_code) pair is the locker''s identity.'
         branchCode:
           type: string
           readOnly: true
           default: ''
-          title: Κωδικός υποκαταστήματος
-          description: ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+          description: ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
         shopKind:
           allOf:
             - $ref: '#/components/schemas/ShopKindEnum'
           readOnly: true
-          title: Είδος καταστήματος
           description: |-
-            ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
+            ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
 
-            * `1` - Κατάστημα
-            * `2` - Συνεργαζόμενο κατάστημα (2)
-            * `3` - Συνεργαζόμενο κατάστημα (3)
+            * `1` - Shop
+            * `2` - Partner shop (2)
+            * `3` - Partner shop (3)
             * `4` - Xpress Point
             * `5` - Kiosk
-            * `7` - Smartpoint (χωρίς locker)
+            * `7` - Smartpoint (no locker)
             * `8` - Smartpoint locker
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         city:
           type: string
           readOnly: true
-          title: Πόλη
         postalCode:
           type: string
           readOnly: true
-          title: Ταχυδρομικός κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας.
+          description: ISO 3166-1 alpha-2 country code.
         lat:
           type: string
           nullable: true
@@ -28716,35 +28698,28 @@ components:
         workingHours:
           type: string
           readOnly: true
-          title: Ωράριο λειτουργίας
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         region:
           type: string
           readOnly: true
-          title: Περιοχή
         phone:
           type: string
           readOnly: true
@@ -28781,29 +28756,24 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ώρα συμβάντος
-          description: Checkpoint_Date_Time από το ACS_TrackingDetails.
+          description: Checkpoint_Date_Time from ACS_TrackingDetails.
         checkpointAction:
           type: string
           readOnly: true
-          title: Ενέργεια σημείου ελέγχου
-          description: Checkpoint_Action_Description — κείμενο στα ελληνικά σε αναγνώσιμη μορφή που περιγράφει το συμβάν.
+          description: Checkpoint_Action_Description — human-readable Greek text describing the event.
         checkpointLocation:
           type: string
           readOnly: true
-          title: Σημείο ελέγχου
           description: Checkpoint_Location_Description.
         notes:
           type: string
           readOnly: true
-          title: Σημειώσεις
-          description: Πεδίο σχολίων ACS.
+          description: ACS Comments field.
         receivedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Παραλήφθηκε στις
-          description: Πραγματικός χρόνος κατά τον οποίο η εργασία παρακολούθησης παρατήρησε αυτό το συμβάν.
+          description: Wall-clock time when the polling task observed this event.
       required:
         - checkpointAction
         - checkpointLocation
@@ -28918,12 +28888,10 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         valuesCount:
           type: integer
           readOnly: true
@@ -28934,12 +28902,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -28986,12 +28952,10 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: integer
           readOnly: true
@@ -28999,12 +28963,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - attribute
         - attributeName
@@ -29054,18 +29016,16 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         numberOfPosts:
           type: integer
           readOnly: true
@@ -29123,18 +29083,16 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         numberOfPosts:
           type: integer
           readOnly: true
@@ -29192,7 +29150,6 @@ components:
         user:
           type: integer
         website:
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -29247,7 +29204,6 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postCount:
           type: integer
           description: |-
@@ -29269,12 +29225,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - hasChildren
@@ -29331,7 +29285,6 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postCount:
           type: integer
           description: |-
@@ -29353,12 +29306,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         children:
           type: array
           items:
@@ -29412,10 +29363,10 @@ components:
       properties:
         id:
           type: integer
-          description: ID κατηγορίας
+          description: Category ID
         sortOrder:
           type: integer
-          description: Νέα τιμή σειράς ταξινόμησης
+          description: New sort order value
       required:
         - id
         - sortOrder
@@ -29426,7 +29377,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BlogCategoryReorderItemRequest'
-          description: Λίστα κατηγοριών με νέες σειρές ταξινόμησης
+          description: List of categories with new sort orders
       required:
         - categories
     BlogCategoryReorderResponse:
@@ -29434,10 +29385,10 @@ components:
       properties:
         updatedCount:
           type: integer
-          description: Αριθμός ενημερωμένων κατηγοριών
+          description: Number of categories updated
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
       required:
         - message
         - updatedCount
@@ -29518,11 +29469,11 @@ components:
           type: string
           nullable: true
           readOnly: true
-          description: Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+          description: First 150 characters of the comment content
         isReply:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+          description: Whether this comment is a reply to another comment
         parent:
           type: integer
           readOnly: true
@@ -29530,15 +29481,14 @@ components:
         hasReplies:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+          description: Whether this comment has approved replies
         approved:
           type: boolean
           readOnly: true
-          title: Εγκεκριμένο
         isEdited:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει επεξεργαστεί
+          description: Whether this comment has been edited
         likesCount:
           type: integer
           readOnly: true
@@ -29548,17 +29498,15 @@ components:
         userHasLiked:
           type: boolean
           readOnly: true
-          description: Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+          description: Whether the current user has liked this comment
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -29612,11 +29560,11 @@ components:
           type: string
           nullable: true
           readOnly: true
-          description: Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+          description: First 150 characters of the comment content
         isReply:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+          description: Whether this comment is a reply to another comment
         parent:
           type: integer
           readOnly: true
@@ -29624,15 +29572,14 @@ components:
         hasReplies:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+          description: Whether this comment has approved replies
         approved:
           type: boolean
           readOnly: true
-          title: Εγκεκριμένο
         isEdited:
           type: boolean
           readOnly: true
-          description: Αν αυτό το σχόλιο έχει επεξεργαστεί
+          description: Whether this comment has been edited
         likesCount:
           type: integer
           readOnly: true
@@ -29642,17 +29589,15 @@ components:
         userHasLiked:
           type: boolean
           readOnly: true
-          description: Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+          description: Whether the current user has liked this comment
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -29661,7 +29606,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/BlogPost'
           readOnly: true
-          description: Βασικές πληροφορίες για το άρθρο
+          description: Basic information about the blog post
         parentComment:
           type: object
           nullable: true
@@ -29681,13 +29626,13 @@ components:
             - user
             - createdAt
           readOnly: true
-          description: Γονικό σχόλιο, αν πρόκειται για απάντηση
+          description: Parent comment if this is a reply
         childrenComments:
           type: array
           items:
             $ref: '#/components/schemas/BlogComment'
           readOnly: true
-          description: Άμεσα εγκεκριμένα θυγατρικά σχόλια (απαντήσεις)
+          description: Direct approved child comments (replies)
         ancestorsPath:
           type: array
           items:
@@ -29704,7 +29649,7 @@ components:
               - contentPreview
               - user
           readOnly: true
-          description: Διαδρομή από το ριζικό σχόλιο έως αυτό
+          description: Path from root comment to this comment
         treePosition:
           type: object
           properties:
@@ -29722,7 +29667,7 @@ components:
             - approvedDescendantsCount
             - siblingsCount
           readOnly: true
-          description: Πληροφορίες θέσης στο δέντρο σχολίων
+          description: Position information in the comment tree
       required:
         - ancestorsPath
         - approved
@@ -29751,7 +29696,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID σχολίων για έλεγχο κατάστασης επισήμανσης
+          description: List of comment IDs to check like status for
       required:
         - commentIds
     BlogCommentLikedCommentsResponse:
@@ -29761,7 +29706,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID σχολίων που έχει επισημάνει ο τρέχων χρήστης
+          description: List of comment IDs that are liked by the current user
       required:
         - likedCommentIds
     BlogCommentWriteRequest:
@@ -29853,11 +29798,9 @@ components:
             type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         likesCount:
           type: integer
           description: Return likes count from annotation or query database.
@@ -29872,23 +29815,19 @@ components:
           readOnly: true
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         mainImagePath:
           type: string
           readOnly: true
@@ -29982,11 +29921,9 @@ components:
           readOnly: true
         featured:
           type: boolean
-          title: Προβεβλημένο
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         likesCount:
           type: integer
           description: Return likes count from annotation or query database.
@@ -30001,23 +29938,19 @@ components:
           readOnly: true
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         mainImagePath:
           type: string
           readOnly: true
@@ -30032,15 +29965,12 @@ components:
           readOnly: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - author
@@ -30069,7 +29999,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID άρθρων για έλεγχο επισημάνσεων
+          description: List of post IDs to check for likes
       required:
         - postIds
     BlogPostLikedPostsResponse:
@@ -30079,12 +30009,27 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID άρθρων με επισήμανση
+          description: List of liked post IDs
       required:
         - postIds
     BlogPostMeiliSearchResponse:
       type: object
+      description: |-
+        Common disclosure fields every search response carries.
+
+        ``query_id`` attributes later clicks to this query (see the
+        ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+        query the zero-result fallback actually matched, so clients can
+        disclose "showing results for …" instead of silently swapping.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
         offset:
@@ -30099,6 +30044,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     BlogPostMeiliSearchResult:
       type: object
@@ -30189,21 +30136,16 @@ components:
           type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - author
@@ -30237,26 +30179,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postsCount:
           type: string
           readOnly: true
-          description: Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+          description: Number of blog posts using this tag
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30296,26 +30234,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         postsCount:
           type: string
           readOnly: true
-          description: Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+          description: Number of blog posts using this tag
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30352,7 +30286,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
       required:
         - translations
     BoxNowCustomerRequest:
@@ -30361,23 +30294,23 @@ components:
       properties:
         name:
           type: string
-          description: Πλήρες όνομα πελάτη
+          description: Customer full name
         email:
           type: string
-          description: Email πελάτη
+          description: Customer email address
         phoneNumber:
           type: string
-          description: Τηλέφωνο πελάτη
+          description: Customer phone number
     BoxNowEventLocationRequest:
       type: object
       description: Nested ``eventLocation`` object within a BoxNow webhook payload.
       properties:
         displayName:
           type: string
-          description: Όνομα locker ή hub σε αναγνώσιμη μορφή
+          description: Human-readable locker or hub name
         postalCode:
           type: string
-          description: Ταχυδρομικός κώδικας της τοποθεσίας του συμβάντος
+          description: Postal code of the event location
     BoxNowLocker:
       type: object
       description: |-
@@ -30392,19 +30325,16 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
           description: BoxNow APM identifier (string)
         type:
           allOf:
             - $ref: '#/components/schemas/TypeEnum'
           readOnly: true
-          title: Τύπος
         imageUrl:
           type: string
           format: uri
           readOnly: true
           nullable: true
-          title: URL εικόνας
         lat:
           type: number
           format: double
@@ -30413,7 +30343,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό πλάτος
+          title: Latitude
         lng:
           type: number
           format: double
@@ -30422,32 +30352,26 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό μήκος
+          title: Longitude
         title:
           type: string
           readOnly: true
-          title: Τίτλος
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
@@ -30455,24 +30379,20 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
-          description: Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+          description: Timestamp of the most recent sync from BoxNow API
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30510,19 +30430,16 @@ components:
         externalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID
           description: BoxNow APM identifier (string)
         type:
           allOf:
             - $ref: '#/components/schemas/TypeEnum'
           readOnly: true
-          title: Τύπος
         imageUrl:
           type: string
           format: uri
           readOnly: true
           nullable: true
-          title: URL εικόνας
         lat:
           type: number
           format: double
@@ -30531,7 +30448,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό πλάτος
+          title: Latitude
         lng:
           type: number
           format: double
@@ -30540,32 +30457,26 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Γεωγραφικό μήκος
+          title: Longitude
         title:
           type: string
           readOnly: true
-          title: Τίτλος
         name:
           type: string
           readOnly: true
-          title: Όνομα
         addressLine1:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 1
         addressLine2:
           type: string
           readOnly: true
-          title: Διεύθυνση γραμμή 2
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
         countryCode:
           type: string
           readOnly: true
-          title: Κωδικός χώρας
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
@@ -30573,24 +30484,20 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         lastSyncedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίος συγχρονισμός
-          description: Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+          description: Timestamp of the most recent sync from BoxNow API
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -30625,30 +30532,30 @@ components:
         city:
           type: string
           minLength: 1
-          description: Όνομα πόλης για αναζήτηση πλησιέστερου locker
+          description: City name for nearest-locker lookup
           maxLength: 128
         street:
           type: string
           minLength: 1
-          description: Οδός και αριθμός
+          description: Street name and number
           maxLength: 255
         postalCode:
           type: string
           minLength: 1
-          description: Ταχυδρομικός κώδικας
+          description: Postal / ZIP code
           maxLength: 16
         region:
           type: string
           minLength: 1
           default: el-GR
-          description: 'Ετικέτα γλώσσας IETF / κωδικός περιφέρειας (προεπιλογή: el-GR)'
+          description: 'IETF language tag / region code (default: el-GR)'
           maxLength: 8
         compartmentSize:
           type: integer
           maximum: 3
           minimum: 1
           default: 1
-          description: 'Απαιτούμενο μέγεθος θυρίδας: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο'
+          description: 'Required compartment size: 1=Small, 2=Medium, 3=Large'
       required:
         - city
         - postalCode
@@ -30666,60 +30573,60 @@ components:
         id:
           type: string
           readOnly: true
-          description: Αναγνωριστικό APM BoxNow
+          description: BoxNow APM identifier
         type:
           type: string
           readOnly: true
-          description: Τύπος locker (π.χ. apm, warehouse)
+          description: Locker type (e.g. apm, warehouse)
         image:
           type: string
           readOnly: true
-          description: URL εικόνας locker
+          description: URL of locker image
         lat:
           type: string
           readOnly: true
-          description: Γεωγραφικό πλάτος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+          description: Latitude (string as returned by BoxNow)
         lng:
           type: string
           readOnly: true
-          description: Γεωγραφικό μήκος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+          description: Longitude (string as returned by BoxNow)
         title:
           type: string
           readOnly: true
-          description: Σύντομος τίτλος εμφάνισης
+          description: Short display title
         name:
           type: string
           readOnly: true
-          description: Πλήρες όνομα locker
+          description: Full locker name
         postalCode:
           type: string
           readOnly: true
-          description: Ταχ. κώδικας του locker
+          description: Postal code of the locker
         country:
           type: string
           readOnly: true
-          description: ISO 3166-1 alpha-2 κωδικός χώρας
+          description: ISO 3166-1 alpha-2 country code
         note:
           type: string
           readOnly: true
-          description: Λειτουργική σημείωση από BoxNow
+          description: Operational note from BoxNow
         addressLine1:
           type: string
           readOnly: true
-          description: Κύρια γραμμή διεύθυνσης
+          description: Primary address line
         addressLine2:
           type: string
           readOnly: true
-          description: Δευτερεύουσα γραμμή διεύθυνσης
+          description: Secondary address line
         region:
           type: string
           readOnly: true
-          description: Ετικέτα περιφέρειας IETF που επιστρέφεται από το BoxNow
+          description: IETF region tag returned by BoxNow
         distance:
           type: number
           format: double
           readOnly: true
-          description: Απόσταση από τη δεδομένη διεύθυνση σε χιλιόμετρα
+          description: Distance from the supplied address in kilometres
       required:
         - addressLine1
         - addressLine2
@@ -30749,68 +30656,59 @@ components:
         webhookMessageId:
           type: string
           readOnly: true
-          title: ID μηνύματος webhook
-          description: Πεδίο 'id' του CloudEvents — κλειδί ιδεμποτεντίας
+          description: CloudEvents 'id' field — idempotency key
         eventType:
           allOf:
             - $ref: '#/components/schemas/BoxNowParcelState'
           readOnly: true
-          title: Τύπος συμβάντος
           description: |-
-            Συμβάν BoxNow αντιστοιχισμένο από το πεδίο 'event' του webhook
+            BoxNow event mapped from the webhook 'event' field
 
-            * `pending_creation` - Εκκρεμής δημιουργία
-            * `new` - Νέο
-            * `in_depot` - Σε αποθήκη
-            * `final_destination` - Στο locker
-            * `delivered` - Παραδόθηκε
-            * `returned` - Επιστράφηκε
-            * `expired` - Έληξε
-            * `canceled` - Ακυρώθηκε
-            * `accepted_for_return` - Αποδεκτό για επιστροφή
-            * `accepted_to_locker` - Αποδεκτό σε locker
-            * `missing` - Λείπει
-            * `lost` - Χάθηκε
+            * `pending_creation` - Pending creation
+            * `new` - New
+            * `in_depot` - In depot
+            * `final_destination` - At locker
+            * `delivered` - Delivered
+            * `returned` - Returned
+            * `expired` - Expired
+            * `canceled` - Canceled
+            * `accepted_for_return` - Accepted for return
+            * `accepted_to_locker` - Accepted to locker
+            * `missing` - Missing
+            * `lost` - Lost
         eventTypeDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή event_type
+          description: Human-readable label for the event_type choice
         parcelState:
           type: string
           readOnly: true
-          title: Κατάσταση Δέματος
-          description: Ακατέργαστη τιμή 'data.parcelState' από το payload του webhook BoxNow
+          description: Raw 'data.parcelState' value from BoxNow webhook payload
         eventTime:
           type: string
           format: date-time
           readOnly: true
-          title: Ώρα συμβάντος
-          description: Χρονοσήμανση από το 'data.time' στο payload του webhook
+          description: Timestamp from 'data.time' in the webhook payload
         displayName:
           type: string
           readOnly: true
-          title: Εμφανιζόμενο όνομα
           description: data.eventLocation.displayName
         postalCode:
           type: string
           readOnly: true
-          title: Ταχ. Κώδικας
           description: data.eventLocation.postalCode
         additionalInformation:
           type: string
           readOnly: true
-          title: Πρόσθετες Πληροφορίες
         receivedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Παραλήφθηκε στις
-          description: Χρονοσήμανση λήψης του webhook από το GrooveShop (διαφορετική από το event_time)
+          description: Timestamp when GrooveShop received the webhook (separate from event_time)
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - additionalInformation
         - createdAt
@@ -30839,18 +30737,18 @@ components:
         - lost
       type: string
       description: |-
-        * `pending_creation` - Εκκρεμής δημιουργία
-        * `new` - Νέο
-        * `in_depot` - Σε αποθήκη
-        * `final_destination` - Στο locker
-        * `delivered` - Παραδόθηκε
-        * `returned` - Επιστράφηκε
-        * `expired` - Έληξε
-        * `canceled` - Ακυρώθηκε
-        * `accepted_for_return` - Αποδεκτό για επιστροφή
-        * `accepted_to_locker` - Αποδεκτό σε locker
-        * `missing` - Λείπει
-        * `lost` - Χάθηκε
+        * `pending_creation` - Pending creation
+        * `new` - New
+        * `in_depot` - In depot
+        * `final_destination` - At locker
+        * `delivered` - Delivered
+        * `returned` - Returned
+        * `expired` - Expired
+        * `canceled` - Canceled
+        * `accepted_for_return` - Accepted for return
+        * `accepted_to_locker` - Accepted to locker
+        * `missing` - Missing
+        * `lost` - Lost
     BoxNowShipmentDetail:
       type: object
       description: |-
@@ -30878,75 +30776,66 @@ components:
           type: string
           readOnly: true
           nullable: true
-          title: Αναγνωριστικό αιτήματος παράδοσης
-          description: ID αιτήματος παράδοσης BoxNow που επιστρέφεται από το POST /api/v1/delivery-requests
+          description: BoxNow delivery-request ID returned from POST /api/v1/delivery-requests
         parcelId:
           type: string
           readOnly: true
           nullable: true
-          title: ID δέματος
-          description: 10ψήφιος αριθμός BoxNow voucher
+          description: 10-digit BoxNow voucher number
         lockerExternalId:
           type: string
           readOnly: true
-          title: Εξωτερικό ID locker
-          description: Μη κανονικοποιημένο ID APM BoxNow — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή BoxNowLocker
+          description: Denormalised BoxNow APM ID — preserved even if the BoxNowLocker row is deleted
         parcelState:
           allOf:
             - $ref: '#/components/schemas/BoxNowParcelState'
           readOnly: true
-          title: Κατάσταση Δέματος
         parcelStateDisplay:
           type: string
           readOnly: true
-          description: Ετικέτα σε αναγνώσιμη μορφή για την τιμή parcel_state
+          description: Human-readable label for the parcel_state choice
         compartmentSize:
           allOf:
             - $ref: '#/components/schemas/CompartmentSizeEnum'
           readOnly: true
-          title: Μέγεθος θυρίδας
         paymentMode:
           allOf:
             - $ref: '#/components/schemas/PaymentModeEnum'
           readOnly: true
-          title: Τρόπος πληρωμής
         lastEventAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Τελευταίο συμβάν
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         locker:
           allOf:
             - $ref: '#/components/schemas/BoxNowLocker'
           nullable: true
           readOnly: true
-          description: Ενσωματωμένα στοιχεία locker BoxNow
+          description: Nested BoxNow locker details
         events:
           type: array
           items:
             $ref: '#/components/schemas/BoxNowParcelEvent'
           readOnly: true
-          description: Τελευταία 20 συμβάντα δέματος ταξινομημένα κατά event_time φθίνουσα
+          description: Last 20 parcel events ordered by event_time desc
         labelUrl:
           type: string
           nullable: true
-          description: Σχετικό URL για λήψη του PDF ετικέτας δέματος μέσω του endpoint proxy Django
+          description: Relative URL to download the parcel label PDF via the Django proxy endpoint
           readOnly: true
         weightGrams:
           type: integer
           readOnly: true
-          title: Βάρος (γραμμάρια)
+          title: Weight (grams)
         amountToBeCollected:
           type: number
           format: double
@@ -30955,18 +30844,15 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Ποσό προς Είσπραξη
-          description: Ποσό που εισπράττεται κατά την παράδοση (PoG / COD). Πάντα 0 στη Φάση 1.
+          description: Amount collected at delivery (PoG / COD). Always 0 in Phase 1.
         allowReturn:
           type: boolean
           readOnly: true
-          title: Επιτρέπεται επιστροφή
         cancelRequestedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ημερομηνία αιτήματος ακύρωσης
       required:
         - allowReturn
         - amountToBeCollected
@@ -31000,40 +30886,40 @@ components:
         parcelId:
           type: string
           minLength: 1
-          description: 10ψήφιος αριθμός voucher/δέματος BoxNow
+          description: 10-digit BoxNow voucher/parcel number
         parcelState:
           type: string
           minLength: 1
-          description: Λεξιλόγιο κατάστασης δέματος BoxNow (data.parcelState)
+          description: BoxNow parcel state vocabulary (data.parcelState)
         parcelReferenceNumber:
           type: string
-          description: Προαιρετικός αριθμός αναφοράς εμπόρου
+          description: Optional merchant reference number
         parcelName:
           type: string
-          description: Προαιρετικό όνομα δέματος
+          description: Optional descriptive parcel name
         orderNumber:
           type: string
           minLength: 1
-          description: Αριθμός παραγγελίας εμπόρου που αποστέλλεται κατά τη δημιουργία αιτήματος παράδοσης
+          description: Merchant order number sent during delivery-request creation
         event:
           type: string
           minLength: 1
-          description: Συμβολοσειρά τύπου συμβάντος BoxNow (π.χ. 'in-depot', 'final-destination', 'delivered')
+          description: BoxNow event type string (e.g. 'in-depot', 'final-destination', 'delivered')
         eventLocation:
           allOf:
             - $ref: '#/components/schemas/BoxNowEventLocationRequest'
-          description: Πλαίσιο τοποθεσίας συμβάντος
+          description: Location context for this event
         customer:
           allOf:
             - $ref: '#/components/schemas/BoxNowCustomerRequest'
-          description: Στοιχεία πελάτη που σχετίζονται με το δέμα
+          description: Customer details associated with the parcel
         additionalInformation:
           type: string
-          description: Ελεύθερο κείμενο με επιπλέον πληροφορίες από το BoxNow
+          description: Free-text additional information from BoxNow
         time:
           type: string
           format: date-time
-          description: Χρονοσήμανση όταν συνέβη το συμβάν στο BoxNow
+          description: Timestamp when the event occurred at BoxNow
       required:
         - event
         - orderNumber
@@ -31053,40 +30939,40 @@ components:
         specversion:
           type: string
           minLength: 1
-          description: 'Έκδοση προδιαγραφής CloudEvents (αναμενόμενη: ''1.0'')'
+          description: 'CloudEvents specification version (expected: ''1.0'')'
         type:
           type: string
           minLength: 1
-          description: 'Τύπος συμβάντος (αναμενόμενος: ''gr.boxnow.parcel_event_change'')'
+          description: 'Event type (expected: ''gr.boxnow.parcel_event_change'')'
         source:
           type: string
           format: uri
           minLength: 1
-          description: URL προέλευσης πηγής συμβάντος
+          description: Origin URL of the event source
         subject:
           type: string
           minLength: 1
-          description: Θέμα του συμβάντος (συνήθως το ID δέματος)
+          description: Subject of the event (typically the parcel ID)
         id:
           type: string
           minLength: 1
-          description: Μοναδικό ID CloudEvents· χρησιμοποιείται ως κλειδί ιδεμποτεντίας (αποθηκεύεται ως webhook_message_id)
+          description: Unique CloudEvents ID; used as idempotency key (stored as webhook_message_id)
         time:
           type: string
           format: date-time
-          description: Χρονοσήμανση δημιουργίας του φακέλου
+          description: Timestamp the envelope was generated
         datacontenttype:
           type: string
           minLength: 1
-          description: 'Τύπος MIME του πεδίου data (αναμενόμενος: ''application/json'')'
+          description: 'MIME type of the data field (expected: ''application/json'')'
         datasignature:
           type: string
           minLength: 1
-          description: Δεκαεξαδικό digest HMAC-SHA256 του ακατέργαστου JSON αντικειμένου 'data'· χρησιμοποιείται για επαλήθευση υπογραφής
+          description: HMAC-SHA256 hex digest of the raw 'data' JSON object; used for signature verification
         data:
           allOf:
             - $ref: '#/components/schemas/BoxNowWebhookDataRequest'
-          description: Payload συμβάντος δέματος
+          description: Parcel event payload
       required:
         - data
         - datacontenttype
@@ -31116,12 +31002,12 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID θεμάτων για εγγραφή/διαγραφή
+          description: List of topic IDs to subscribe/unsubscribe
         action:
           allOf:
             - $ref: '#/components/schemas/ActionEnum'
           description: |-
-            Ενέργεια προς εκτέλεση σε θέματα
+            Action to perform on the topics
 
             * `subscribe` - subscribe
             * `unsubscribe` - unsubscribe
@@ -31226,26 +31112,23 @@ components:
         totalWeightGrams:
           type: integer
           readOnly: true
-          description: Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+          description: Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
         currency:
           type: string
           readOnly: true
-          description: Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+          description: ISO 4217 currency code for all monetary values in this cart
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         lastActivity:
           type: string
           format: date-time
           readOnly: true
-          title: Τελευταία δραστηριότητα
       required:
         - createdAt
         - currency
@@ -31279,26 +31162,26 @@ components:
         payWayId:
           type: integer
           minimum: 1
-          description: ID της επιλεγμένης μεθόδου πληρωμής (πρέπει να είναι online Stripe).
+          description: ID of the selected PayWay (must be online Stripe).
         shippingKind:
           allOf:
             - $ref: '#/components/schemas/CartCreatePaymentIntentRequestShippingKindEnum'
           description: |-
-            Τύπος εκπλήρωσης για τον μεταφορέα (home_delivery ή pickup_point). Απαιτείται ώστε να τηρούνται οι επιμέρους σημαίες λειτουργίας (π.χ. ACS_SMARTPOINT_ENABLED) και ο έλεγχος PICKUP_POINT του BoxNow.
+            Fulfilment kind for the carrier (home_delivery or pickup_point). Required so the per-kind feature flags (e.g. ACS_SMARTPOINT_ENABLED) and BoxNow's PICKUP_POINT gate are honoured.
 
             * `home_delivery` - home_delivery
             * `pickup_point` - pickup_point
         shippingProviderCode:
           type: string
-          description: Κωδικός μεταφορέα που αντιστοιχεί σε καταχωρημένο προσαρμογέα αποστολής (π.χ. 'acs', 'boxnow'). Απαιτείται για ``pickup_point``· παραλείψτε/αφήστε κενό για ``home_delivery`` (το backend χρησιμοποιεί τη γενική πάγια χρέωση, αντίστοιχη με αυτή που θα υπολογίσει η επαλήθευση δημιουργίας παραγγελίας για το ίδιο αίτημα).
+          description: Carrier code matching a registered shipping adapter (e.g. 'acs', 'boxnow'). Required for ``pickup_point``; omit/empty for ``home_delivery`` (the backend uses the generic flat rate, matching what the order-create verification will compute for the same body).
           maxLength: 32
         countryId:
           type: string
-          description: Προαιρετικός κωδικός χώρας ISO 3166-1 alpha-2 — καθορίζει τον συντελεστή αποστολής σε επίπεδο χώρας. Πρέπει να ταιριάζει με αυτόν που θα φέρει το αίτημα δημιουργίας παραγγελίας.
+          description: Optional ISO 3166-1 alpha-2 country code — drives the country-level shipping multiplier. Match what the order-create body will carry.
           maxLength: 2
         regionId:
           type: string
-          description: Προαιρετικός κωδικός περιφέρειας — καθορίζει την προσαρμογή αποστολής σε επίπεδο περιφέρειας.
+          description: Optional region code — drives the region-level shipping adjustment.
           maxLength: 16
       required:
         - payWayId
@@ -31376,32 +31259,29 @@ components:
         totalWeightGrams:
           type: integer
           readOnly: true
-          description: Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+          description: Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
         currency:
           type: string
           readOnly: true
-          description: Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+          description: ISO 4217 currency code for all monetary values in this cart
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         lastActivity:
           type: string
           format: date-time
           readOnly: true
-          title: Τελευταία δραστηριότητα
         recommendations:
           type: array
           items:
             $ref: '#/components/schemas/Product'
           readOnly: true
-          description: Προτάσεις προϊόντων βάσει περιεχομένου καλαθιού
+          description: Product recommendations based on cart contents
       required:
         - createdAt
         - currency
@@ -31434,7 +31314,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
         weightInfo:
           type: object
           properties:
@@ -31449,7 +31328,7 @@ components:
             - totalWeight
             - weightUnit
           readOnly: true
-          description: Πληροφορίες βάρους για υπολογισμούς αποστολής
+          description: Weight information for shipping calculations
         price:
           type: number
           format: double
@@ -31514,12 +31393,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31550,7 +31427,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
       required:
         - product
     CartItemDetail:
@@ -31570,7 +31446,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
         weightInfo:
           type: object
           properties:
@@ -31585,7 +31460,7 @@ components:
             - totalWeight
             - weightUnit
           readOnly: true
-          description: Πληροφορίες βάρους για υπολογισμούς αποστολής
+          description: Weight information for shipping calculations
         price:
           type: number
           format: double
@@ -31650,12 +31525,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31665,7 +31538,7 @@ components:
           items:
             $ref: '#/components/schemas/Product'
           readOnly: true
-          description: Σχετικά προϊόντα που ίσως ενδιαφέρουν τον πελάτη
+          description: Related products that might interest the customer
       required:
         - cartId
         - createdAt
@@ -31691,17 +31564,16 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
     CartPaymentIntentResponse:
       type: object
       description: Response body returned by the create-payment-intent cart action.
       properties:
         clientSecret:
           type: string
-          description: Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+          description: Stripe PaymentIntent client secret for frontend confirmation
         paymentIntentId:
           type: string
-          description: ID του Stripe PaymentIntent προς αποθήκευση στην παραγγελία
+          description: Stripe PaymentIntent ID to be stored on the order
         amount:
           type: number
           format: double
@@ -31709,10 +31581,10 @@ components:
           minimum: -10000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          description: Συνολικό ποσό χρέωσης (καλάθι + αποστολή + έξοδα πληρωμής)
+          description: Total charge amount (cart + shipping + payment fee)
         currency:
           type: string
-          description: Κωδικός νομίσματος ISO 4217 (π.χ. EUR)
+          description: ISO 4217 currency code (e.g. EUR)
           maxLength: 3
       required:
         - amount
@@ -31747,16 +31619,16 @@ components:
           description: Stripe PaymentIntent ID that charged the token
         status:
           type: string
-          description: Κατάσταση πληρωμής
+          description: Payment status
         amount:
           type: string
-          description: Ποσό πληρωμής
+          description: Payment amount
         currency:
           type: string
-          description: Νόμισμα πληρωμής
+          description: Payment currency
         provider:
           type: string
-          description: Όνομα παρόχου πληρωμών
+          description: Payment provider name
       required:
         - amount
         - currency
@@ -31791,7 +31663,6 @@ components:
           readOnly: true
         name:
           type: string
-          title: Όνομα
           maxLength: 100
         email:
           type: string
@@ -31799,17 +31670,14 @@ components:
           maxLength: 254
         message:
           type: string
-          title: Μήνυμα
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31828,7 +31696,6 @@ components:
         name:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 100
         email:
           type: string
@@ -31838,7 +31705,6 @@ components:
         message:
           type: string
           minLength: 1
-          title: Μήνυμα
       required:
         - email
         - message
@@ -31867,12 +31733,12 @@ components:
                   type: string
         alpha2:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -31880,28 +31746,24 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31942,12 +31804,12 @@ components:
                   type: string
         alpha2:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -31955,28 +31817,24 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -31988,7 +31846,7 @@ components:
           type: array
           items:
             type: string
-            title: Κωδικός περιφέρειας
+            title: Region Code
           readOnly: true
       required:
         - alpha2
@@ -32025,13 +31883,13 @@ components:
         alpha2:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -32039,13 +31897,12 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
       required:
         - alpha2
         - alpha3
@@ -32107,37 +31964,37 @@ components:
             type: string
             minLength: 1
             maxLength: 500
-          description: Επιπλέον δεδομένα πληρωμής που απαιτούνται από τον πάροχο πληρωμών
+          description: Additional payment data required by the payment provider
     CreatePaymentIntentResponse:
       type: object
       properties:
         paymentId:
           type: string
-          description: ID payment intent από τον πάροχο πληρωμών
+          description: Payment intent ID from the payment provider
         status:
           type: string
-          description: Κατάσταση πληρωμής
+          description: Payment status
         amount:
           type: string
-          description: Ποσό πληρωμής
+          description: Payment amount
         currency:
           type: string
-          description: Νόμισμα πληρωμής
+          description: Payment currency
         provider:
           type: string
-          description: Όνομα παρόχου πληρωμών
+          description: Payment provider name
         clientSecret:
           type: string
-          description: Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+          description: Stripe PaymentIntent client secret for frontend confirmation
         requiresAction:
           type: boolean
           default: false
-          description: Αν η πληρωμή απαιτεί επιπλέον ενέργεια (3D Secure κ.λπ.)
+          description: Whether the payment requires additional action (3D Secure, etc.)
         nextAction:
           type: object
           additionalProperties: {}
           nullable: true
-          description: Επόμενη ενέργεια που απαιτείται για την ολοκλήρωση της πληρωμής
+          description: Next action required for payment completion
       required:
         - amount
         - currency
@@ -32177,7 +32034,7 @@ components:
         confirmation:
           type: string
           minLength: 1
-          description: Πρέπει να ισούται ακριβώς με τη συμβολοσειρά "DELETE".
+          description: Must equal the literal string "DELETE".
       required:
         - confirmation
     DeleteAccountResponse:
@@ -32230,6 +32087,14 @@ components:
       type: object
       description: Serializer for federated search response.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
           description: Maximum number of results requested
@@ -32248,6 +32113,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     FederatedSearchResult:
       type: object
@@ -32354,14 +32221,14 @@ components:
         - SIXTH_FLOOR_PLUS
       type: string
       description: |-
-        * `BASEMENT` - Υπόγειο
-        * `GROUND_FLOOR` - Ισόγειο
-        * `FIRST_FLOOR` - 1ος όροφος
-        * `SECOND_FLOOR` - 2ος όροφος
-        * `THIRD_FLOOR` - 3ος όροφος
-        * `FOURTH_FLOOR` - 4ος όροφος
-        * `FIFTH_FLOOR` - 5ος όροφος
-        * `SIXTH_FLOOR_PLUS` - 6ος όροφος +
+        * `BASEMENT` - Basement
+        * `GROUND_FLOOR` - Ground Floor
+        * `FIRST_FLOOR` - First Floor
+        * `SECOND_FLOOR` - Second Floor
+        * `THIRD_FLOOR` - Third Floor
+        * `FOURTH_FLOOR` - Fourth Floor
+        * `FIFTH_FLOOR` - Fifth Floor
+        * `SIXTH_FLOOR_PLUS` - Sixth Floor Plus
     FreeShippingInfo:
       type: object
       description: Response payload for the free-shipping-info endpoint.
@@ -32378,7 +32245,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Χαμηλότερο όριο μεταξύ των ενεργών παρόχων — ο κύριος αριθμός 'δωρεάν αποστολή από X €'. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+          description: Lowest threshold across active providers — the headline 'free shipping from X €' number. Null when no active provider advertises a threshold.
         maxThreshold:
           type: number
           format: double
@@ -32387,7 +32254,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Υψηλότερο όριο μεταξύ των ενεργών παρόχων — το υποσύνολο στο οποίο κάθε μεταφορέας αποστέλλει δωρεάν. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+          description: Highest threshold across active providers — the subtotal at which every carrier ships free. Null when no active provider advertises a threshold.
         currency:
           type: string
           maxLength: 3
@@ -32413,7 +32280,7 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          description: Υποσύνολο καλαθιού στο νόμισμα της απόκρισης πάνω από το οποίο αυτός ο συνδυασμός (πάροχος, τύπος) αποστέλλει δωρεάν.
+          description: Cart subtotal in the response's currency above which this (provider, kind) ships free.
         priority:
           type: integer
       required:
@@ -32449,16 +32316,16 @@ components:
         - SEASONAL
       type: string
       description: |-
-        * `MAIN` - Κύρια εικόνα
-        * `BANNER` - Banner
-        * `ICON` - Εικονίδιο
-        * `THUMBNAIL` - Μικρογραφία
-        * `GALLERY` - Εικόνα συλλογής
-        * `BACKGROUND` - Εικόνα φόντου
-        * `HERO` - Κεντρική εικόνα
-        * `FEATURE` - Κεντρική Εικόνα
-        * `PROMOTIONAL` - Προωθητική εικόνα
-        * `SEASONAL` - Εποχιακή εικόνα
+        * `MAIN` - Main Image
+        * `BANNER` - Banner Image
+        * `ICON` - Icon Image
+        * `THUMBNAIL` - Thumbnail Image
+        * `GALLERY` - Gallery Image
+        * `BACKGROUND` - Background Image
+        * `HERO` - Hero Image
+        * `FEATURE` - Feature Image
+        * `PROMOTIONAL` - Promotional Image
+        * `SEASONAL` - Seasonal Image
     InvoiceDownloadResponse:
       type: object
       description: Invoice metadata plus an absolute URL to the streaming endpoint.
@@ -32466,14 +32333,12 @@ components:
         invoiceNumber:
           type: string
           readOnly: true
-          title: Αριθμός τιμολογίου
-          description: Διαδοχικό αναγνωριστικό στη μορφή ``INV-{YEAR}-{NNNNNN}``. Δεν επιτρέπονται κενά βάσει της ελληνικής φορολογικής νομοθεσίας.
+          description: Sequential identifier in the form ``INV-{YEAR}-{NNNNNN}``. Gaps are not allowed by Greek tax law.
         issueDate:
           type: string
           format: date
           readOnly: true
-          title: Ημερομηνία έκδοσης
-          description: Φορολογική ημερομηνία έκδοσης. Αμετάβλητη μόλις εκδοθεί το τιμολόγιο — χρησιμοποιείται για διαδοχική αρίθμηση και αναφορές.
+          description: Fiscal date of issue. Immutable once the invoice is rendered — used for sequential numbering and reporting.
         downloadUrl:
           type: string
           nullable: true
@@ -32502,11 +32367,9 @@ components:
         currency:
           type: string
           readOnly: true
-          title: Νόμισμα
         vatBreakdown:
           readOnly: true
-          title: Ανάλυση ΦΠΑ
-          description: Λίστα σε cache από γραμμές ``{rate, subtotal, vat, gross}`` — παγιωμένη τη στιγμή της έκδοσης, ώστε η εκ νέου απόδοση του τιμολογίου να δίνει πάντα τον ίδιο πίνακα ΦΠΑ ακόμη κι αν αλλάξουν οι συντελεστές των προϊόντων.
+          description: Cached list of ``{rate, subtotal, vat, gross}`` rows — frozen at issue time so re-rendering the invoice always yields the same VAT table even if product rates change.
       required:
         - currency
         - downloadUrl
@@ -32523,9 +32386,9 @@ components:
         - OTHER
       type: string
       description: |-
-        * `HOME` - Σπίτι
-        * `OFFICE` - Γραφείο
-        * `OTHER` - Άλλο
+        * `HOME` - Αρχική
+        * `OFFICE` - Office
+        * `OTHER` - Other
     LoyaltySummary:
       type: object
       description: |-
@@ -32596,8 +32459,7 @@ components:
         requiredLevel:
           type: integer
           readOnly: true
-          title: Απαιτούμενο επίπεδο
-          description: Ελάχιστο επίπεδο για την επίτευξη αυτού του tier
+          description: Minimum level to achieve this tier
         pointsMultiplier:
           type: number
           format: double
@@ -32606,13 +32468,11 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Πολλαπλασιαστής πόντων
-          description: Πολλαπλασιαστής που εφαρμόζεται στους πόντους που κερδίζουν οι χρήστες σε αυτό το tier
+          description: Multiplier applied to earned points for users in this tier
         icon:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         mainImagePath:
           type: string
           readOnly: true
@@ -32661,42 +32521,35 @@ components:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         kind:
-          allOf:
-            - $ref: '#/components/schemas/NotificationKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/NotificationKindEnum'
         category:
-          allOf:
-            - $ref: '#/components/schemas/NotificationCategory'
-          title: Κατηγορία
+          $ref: '#/components/schemas/NotificationCategory'
         priority:
-          allOf:
-            - $ref: '#/components/schemas/PriorityEnum'
-          title: Προτεραιότητα
+          $ref: '#/components/schemas/PriorityEnum'
         notificationType:
-          title: Τύπος ειδοποίησης
           description: |-
-            Λεπτομερές αναγνωριστικό συμβάντος. Δείτε ``notification.enum.NotificationTypeEnum`` για τον πλήρη κατάλογο. Αφήνεται κενό για περιστασιακές ανακοινώσεις διαχειριστή.
+            Fine-grained event identifier. See ``notification.enum.NotificationTypeEnum`` for the full catalogue. Left blank for ad-hoc admin broadcasts.
 
-            * `order_created` - Η παραγγελία δημιουργήθηκε
-            * `order_processing` - Επεξεργασία παραγγελίας
-            * `order_shipped` - Η παραγγελία απεστάλη
-            * `order_delivered` - Η παραγγελία παραδόθηκε
-            * `order_completed` - Η παραγγελία ολοκληρώθηκε
-            * `order_canceled` - Η παραγγελία ακυρώθηκε
-            * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-            * `shipment_dispatched` - Αποστολή απεστάλη
-            * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-            * `payment_failed` - Η πληρωμή απέτυχε
-            * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-            * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-            * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-            * `comment_liked` - Επισήμανση σχολίου blog
-            * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-            * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-            * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+            * `order_created` - Order created
+            * `order_processing` - Order processing
+            * `order_shipped` - Order shipped
+            * `order_delivered` - Order delivered
+            * `order_completed` - Order completed
+            * `order_canceled` - Order canceled
+            * `order_refunded` - Order refunded
+            * `shipment_dispatched` - Shipment dispatched
+            * `payment_confirmed` - Payment confirmed
+            * `payment_failed` - Payment failed
+            * `price_drop_favourite` - Price drop (favourited product)
+            * `restock_favourite` - Back in stock (favourited product)
+            * `loyalty_tier_up` - Loyalty tier promotion
+            * `comment_liked` - Blog comment liked
+            * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+            * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+            * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
           oneOf:
             - $ref: '#/components/schemas/NotificationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -32704,17 +32557,14 @@ components:
           type: string
           format: date-time
           nullable: true
-          title: Ημερομηνία Λήξης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32744,26 +32594,26 @@ components:
         - RECOMMENDATION
       type: string
       description: |-
-        * `ORDER` - Παραγγελία
-        * `PAYMENT` - Πληρωμή
-        * `SHIPPING` - Μεταφορικά
-        * `CART` - Καλάθι
-        * `PRODUCT` - Προϊόν
-        * `ACCOUNT` - Λογαριασμός Ανενεργός
-        * `SECURITY` - Ασφάλεια
-        * `PROMOTION` - Προσφορά
-        * `SYSTEM` - Σύστημα
-        * `REVIEW` - Εξέταση
-        * `WISHLIST` - Λίστα επιθυμιών
-        * `SUPPORT` - Υποστήριξη
+        * `ORDER` - Ταξινόμηση
+        * `PAYMENT` - Payment
+        * `SHIPPING` - Shipping
+        * `CART` - Cart
+        * `PRODUCT` - Product
+        * `ACCOUNT` - Account
+        * `SECURITY` - Security
+        * `PROMOTION` - Promotion
+        * `SYSTEM` - System
+        * `REVIEW` - Review
+        * `WISHLIST` - Wishlist
+        * `SUPPORT` - Support
         * `NEWSLETTER` - Newsletter
-        * `RECOMMENDATION` - Σύσταση
+        * `RECOMMENDATION` - Recommendation
     NotificationCountResponse:
       type: object
       properties:
         count:
           type: integer
-          description: Αριθμός μη ορατών ειδοποιήσεων
+          description: Number of unseen notifications
       required:
         - count
     NotificationIdsRequest:
@@ -32785,16 +32635,16 @@ components:
       type: string
       description: |-
         * `ERROR` - Σφάλμα
-        * `SUCCESS` - Επιτυχία
-        * `INFO` - Πληροφορία
-        * `WARNING` - Προειδοποίηση
-        * `DANGER` - Κίνδυνος
+        * `SUCCESS` - Success
+        * `INFO` - Info
+        * `WARNING` - Warning
+        * `DANGER` - Danger
     NotificationSuccessResponse:
       type: object
       properties:
         success:
           type: boolean
-          description: Αν η λειτουργία ήταν επιτυχής
+          description: Whether the operation was successful
     NotificationTypeEnum:
       enum:
         - order_created
@@ -32816,23 +32666,23 @@ components:
         - ACS_OUT_FOR_DELIVERY
       type: string
       description: |-
-        * `order_created` - Η παραγγελία δημιουργήθηκε
-        * `order_processing` - Επεξεργασία παραγγελίας
-        * `order_shipped` - Η παραγγελία απεστάλη
-        * `order_delivered` - Η παραγγελία παραδόθηκε
-        * `order_completed` - Η παραγγελία ολοκληρώθηκε
-        * `order_canceled` - Η παραγγελία ακυρώθηκε
-        * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-        * `shipment_dispatched` - Αποστολή απεστάλη
-        * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-        * `payment_failed` - Η πληρωμή απέτυχε
-        * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-        * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-        * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-        * `comment_liked` - Επισήμανση σχολίου blog
-        * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-        * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-        * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+        * `order_created` - Order created
+        * `order_processing` - Order processing
+        * `order_shipped` - Order shipped
+        * `order_delivered` - Order delivered
+        * `order_completed` - Order completed
+        * `order_canceled` - Order canceled
+        * `order_refunded` - Order refunded
+        * `shipment_dispatched` - Shipment dispatched
+        * `payment_confirmed` - Payment confirmed
+        * `payment_failed` - Payment failed
+        * `price_drop_favourite` - Price drop (favourited product)
+        * `restock_favourite` - Back in stock (favourited product)
+        * `loyalty_tier_up` - Loyalty tier promotion
+        * `comment_liked` - Blog comment liked
+        * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+        * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+        * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
     NotificationUser:
       type: object
       properties:
@@ -32847,22 +32697,18 @@ components:
           readOnly: true
         seen:
           type: boolean
-          title: Ορατό
         seenAt:
           type: string
           format: date-time
           nullable: true
-          title: Ορατό στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32881,7 +32727,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID χρηστών ειδοποίησης προς σήμανση ως ορατά/μη ορατά
+          description: List of notification user IDs to mark as seen/unseen
       required:
         - notificationUserIds
     NotificationUserDetail:
@@ -32900,22 +32746,18 @@ components:
           readOnly: true
         seen:
           type: boolean
-          title: Ορατό
         seenAt:
           type: string
           format: date-time
           nullable: true
-          title: Ορατό στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -32932,7 +32774,6 @@ components:
       properties:
         seen:
           type: boolean
-          title: Ορατό
     Order:
       type: object
       properties:
@@ -32944,37 +32785,31 @@ components:
           nullable: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         payWay:
           type: integer
           nullable: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/OrderStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/OrderStatus'
         statusDisplay:
           type: string
           readOnly: true
@@ -32983,14 +32818,11 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-          title: Κατάσταση ενημερώθηκε στις
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -32998,21 +32830,17 @@ components:
           maxLength: 255
         zipcode:
           type: string
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         paidAmount:
           type: number
           format: double
@@ -33042,19 +32870,15 @@ components:
           exclusiveMinimum: true
           readOnly: true
         documentType:
-          allOf:
-            - $ref: '#/components/schemas/OrderDocumentType'
-          title: Τύπος Εγγράφου
+          $ref: '#/components/schemas/OrderDocumentType'
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -33081,10 +32905,8 @@ components:
         paymentId:
           type: string
           nullable: true
-          title: ID πληρωμής
           maxLength: 255
         paymentStatus:
-          title: Κατάσταση πληρωμής
           oneOf:
             - $ref: '#/components/schemas/PaymentStatusEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -33094,7 +32916,6 @@ components:
           description: Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
         paymentMethod:
           type: string
-          title: Μέθοδος πληρωμής
           maxLength: 50
         isOnlinePayment:
           type: boolean
@@ -33141,8 +32962,8 @@ components:
         - INVOICE
       type: string
       description: |-
-        * `RECEIPT` - Απόδειξη
-        * `INVOICE` - Τιμολόγιο
+        * `RECEIPT` - Receipt
+        * `INVOICE` - Invoice
     OrderCreateFromCartRequest:
       type: object
       description: |-
@@ -33157,103 +32978,103 @@ components:
       properties:
         payWayId:
           type: integer
-          description: ID μεθόδου πληρωμής
+          description: Payment method ID
         paymentIntentId:
           type: string
           nullable: true
-          description: ID payment intent από τον πάροχο πληρωμών (υποχρεωτικό για online πληρωμές)
+          description: Payment intent ID from payment provider (required for online payments)
         firstName:
           type: string
           minLength: 1
-          description: Όνομα πελάτη
+          description: Customer first name
           maxLength: 150
         lastName:
           type: string
           minLength: 1
-          description: Επώνυμο πελάτη
+          description: Customer last name
           maxLength: 150
         email:
           type: string
           format: email
           minLength: 1
-          description: Email πελάτη
+          description: Customer email address
         street:
           type: string
           minLength: 1
-          description: Όνομα οδού
+          description: Street name
           maxLength: 255
         streetNumber:
           type: string
-          description: Αριθμός οδού
+          description: Street number
           maxLength: 50
         city:
           type: string
           minLength: 1
-          description: Όνομα πόλης
+          description: City name
           maxLength: 100
         zipcode:
           type: string
           minLength: 1
-          description: Ταχυδρομικός κώδικας
+          description: Postal/ZIP code
           maxLength: 20
         countryId:
           type: string
           minLength: 1
-          description: Κωδικός χώρας alpha-2 (π.χ. 'GR', 'US')
+          description: Country alpha-2 code (e.g., 'GR', 'US')
         regionId:
           type: string
           nullable: true
-          description: Αλφαριθμητικός κωδικός περιφέρειας
+          description: Region alpha code
         phone:
           type: string
           minLength: 1
-          description: Τηλέφωνο πελάτη
+          description: Customer phone number
         customerNotes:
           type: string
-          description: Σημειώσεις πελάτη ή ειδικές οδηγίες
+          description: Customer notes or special instructions
           maxLength: 500
         floor:
           type: string
-          description: Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)
+          description: Floor number or label (e.g. FIRST_FLOOR)
           maxLength: 50
         locationType:
           type: string
-          description: Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)
+          description: Location type, e.g. HOME or OFFICE (optional)
           maxLength: 100
         billingVatId:
           type: string
-          description: ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.
+          description: Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.
           maxLength: 12
         billingCountry:
           type: string
-          description: Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.
+          description: ISO 3166-1 alpha-2 country code for the buyer's tax identity. Defaults to the order country when blank.
           maxLength: 2
         documentType:
           allOf:
             - $ref: '#/components/schemas/OrderCreateDocumentType'
           default: RECEIPT
           description: |-
-            RECEIPT (Α.Λ.Π., Tier A — λιανική) ή INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Η επιλογή INVOICE απαιτεί έγκυρο ``billing_vat_id``.
+            RECEIPT (Α.Λ.Π., Tier A — retail) or INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Selecting INVOICE requires a valid ``billing_vat_id``.
 
-            * `RECEIPT` - Απόδειξη
-            * `INVOICE` - Τιμολόγιο
+            * `RECEIPT` - Receipt
+            * `INVOICE` - Invoice
         loyaltyPointsToRedeem:
           type: integer
           minimum: 0
           nullable: true
-          description: Αριθμός πόντων πιστότητας προς εξαργύρωση για έκπτωση σε αυτή την παραγγελία
+          description: Number of loyalty points to redeem for discount on this order
         boxnowLockerId:
           type: string
-          description: ID locker APM BoxNow από το widget
+          description: BoxNow APM locker ID from the widget
           maxLength: 64
         boxnowCompartmentSize:
           type: integer
           maximum: 3
           minimum: 1
           default: 1
-          description: 'Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο'
+          description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large'
         shippingProviderCode:
-          description: Κωδικός μεταφορέα από /api/v1/shipping/options (π.χ. 'acs').
+          description: Carrier code from /api/v1/shipping/options (e.g. 'acs').
           oneOf:
             - type: string
               maxLength: 32
@@ -33264,37 +33085,37 @@ components:
           allOf:
             - $ref: '#/components/schemas/ShippingKind'
           description: |-
-            Γενικός τύπος εκπλήρωσης, ανεξάρτητος από τον πάροχο.
+            Generic fulfilment kind, independent of provider.
 
-            * `home_delivery` - Κατ' οίκον παράδοση
-            * `pickup_point` - Σημείο παραλαβής / locker
+            * `home_delivery` - Home delivery
+            * `pickup_point` - Pickup point / locker
         acsStationExternalId:
           type: string
-          description: Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).
+          description: ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).
           maxLength: 32
         acsStationBranch:
           type: string
-          description: Τιμή ACS_Station_Branch_Destination.
+          description: ACS_Station_Branch_Destination value.
           maxLength: 32
         acsChargeType:
           allOf:
             - $ref: '#/components/schemas/AcsChargeType'
           description: |-
-            Προαιρετική παράκαμψη του ACS Charge_Type ανά παραγγελία. Αφήστε το κενό για χρήση της προεπιλογής σε επίπεδο μεταφορέα (COD σε σύμβαση μόνο-COD). Ο ορισμός εδώ έχει νόημα μόνο αν η εμπορική σύμβαση με την ACS επιτρέπει την επιλεγμένη τιμή — μη έγκυροι συνδυασμοί απορρίπτονται από το ACS_Create_Voucher.
+            Optional per-order ACS Charge_Type override. Leave unset to use the carrier-level default (COD on a COD-only contract). Setting this here only makes sense if the ACS commercial contract permits the chosen value — invalid combinations are rejected by ACS_Create_Voucher.
 
-            * `1` - Προπληρωμένο
-            * `2` - Αντικαταβολή
+            * `1` - Prepaid
+            * `2` - Cash on delivery
         acsItemQuantity:
           type: integer
           maximum: 20
           minimum: 1
-          description: Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.
+          description: Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.
         meta:
           type: object
           additionalProperties: {}
           writeOnly: true
           nullable: true
-          description: 'Πλαίσιο Meta Pixel: κλειδιά ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict με {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict με boolean ``ads``). Κενό dict / null όταν ο πελάτης αρνήθηκε τα cookies μάρκετινγκ· ο αποστολέας CAPI τότε παραλείπει την αποστολή.'
+          description: 'Meta Pixel context: keys ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict of {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict with ``ads`` boolean). Empty dict / null when the customer declined marketing cookies; the CAPI dispatcher then skips the send.'
       required:
         - city
         - countryId
@@ -33316,37 +33137,31 @@ components:
           nullable: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         payWay:
           type: integer
           nullable: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/OrderStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/OrderStatus'
         statusDisplay:
           type: string
           readOnly: true
@@ -33355,14 +33170,11 @@ components:
           format: date-time
           readOnly: true
           nullable: true
-          title: Κατάσταση ενημερώθηκε στις
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -33370,22 +33182,18 @@ components:
           maxLength: 255
         zipcode:
           type: string
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           readOnly: true
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         paidAmount:
           type: number
           format: double
@@ -33415,19 +33223,15 @@ components:
           exclusiveMinimum: true
           readOnly: true
         documentType:
-          allOf:
-            - $ref: '#/components/schemas/OrderDocumentType'
-          title: Τύπος Εγγράφου
+          $ref: '#/components/schemas/OrderDocumentType'
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -33454,10 +33258,8 @@ components:
         paymentId:
           type: string
           nullable: true
-          title: ID πληρωμής
           maxLength: 255
         paymentStatus:
-          title: Κατάσταση πληρωμής
           oneOf:
             - $ref: '#/components/schemas/PaymentStatusEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -33467,7 +33269,6 @@ components:
           description: Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
         paymentMethod:
           type: string
-          title: Μέθοδος πληρωμής
           maxLength: 50
         isOnlinePayment:
           type: boolean
@@ -33595,11 +33396,9 @@ components:
           description: Cancellation context for CANCELED orders — exposes the operator-supplied reason, timestamp, and shipment-cancel outcome from ``order.metadata['cancellation']``. Returns null when the order was not canceled. Internal flags from the metadata bag (webhook idempotency markers, mint tickets) are intentionally not surfaced.
         trackingNumber:
           type: string
-          title: Αριθμός Παρακολούθησης
           maxLength: 255
         shippingCarrier:
           type: string
-          title: Εταιρεία μεταφοράς
           maxLength: 255
         customerFullName:
           type: string
@@ -33674,12 +33473,12 @@ components:
         - CREDIT_NOTE
       type: string
       description: |-
-        * `RECEIPT` - Απόδειξη
-        * `INVOICE` - Τιμολόγιο
-        * `PROFORMA` - Προτιμολόγιο
-        * `SHIPPING_LABEL` - Ετικέτα αποστολής
-        * `RETURN_LABEL` - Ετικέτα επιστροφής
-        * `CREDIT_NOTE` - Πιστωτικό
+        * `RECEIPT` - Receipt
+        * `INVOICE` - Invoice
+        * `PROFORMA` - Proforma Invoice
+        * `SHIPPING_LABEL` - Shipping Label
+        * `RETURN_LABEL` - Return Label
+        * `CREDIT_NOTE` - Credit Note
     OrderItem:
       type: object
       properties:
@@ -33706,15 +33505,12 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         isRefunded:
           type: boolean
           readOnly: true
-          title: Έχει επιστραφεί
         refundedQuantity:
           type: integer
           readOnly: true
-          title: Επιστραφείσα ποσότητα
         netQuantity:
           type: integer
           readOnly: true
@@ -33730,12 +33526,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -33757,10 +33551,8 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - product
     OrderItemDetail:
@@ -33791,15 +33583,12 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         isRefunded:
           type: boolean
           readOnly: true
-          title: Έχει επιστραφεί
         refundedQuantity:
           type: integer
           readOnly: true
-          title: Επιστραφείσα ποσότητα
         netQuantity:
           type: integer
           readOnly: true
@@ -33815,17 +33604,14 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         originalQuantity:
           type: integer
           readOnly: true
           nullable: true
-          title: Αρχική ποσότητα
         refundedAmount:
           type: number
           format: double
@@ -33846,10 +33632,8 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - createdAt
         - id
@@ -33872,10 +33656,10 @@ components:
         quantity:
           type: integer
           minimum: 1
-          description: Ποσότητα προς επιστροφή. Αν δεν δοθεί, επιστρέφονται όλα.
+          description: Quantity to refund. If not provided, refunds all.
         reason:
           type: string
-          description: Προαιρετική αιτία επιστροφής
+          description: Optional reason for the refund
           maxLength: 255
     OrderItemRefundResponse:
       type: object
@@ -33906,10 +33690,8 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
       required:
         - order
         - product
@@ -33925,56 +33707,50 @@ components:
         - REFUNDED
       type: string
       description: |-
-        * `PENDING` - Εκκρεμεί
-        * `PROCESSING` - Σε επεξεργασία
-        * `SHIPPED` - Απεστάλη
-        * `DELIVERED` - Παραδόθηκε
-        * `COMPLETED` - Ολοκληρώθηκε
-        * `CANCELED` - Ακυρώθηκε
-        * `RETURNED` - Επιστράφηκε
-        * `REFUNDED` - Επιστροφή Χρημάτων
+        * `PENDING` - Pending
+        * `PROCESSING` - Processing
+        * `SHIPPED` - Shipped
+        * `DELIVERED` - Delivered
+        * `COMPLETED` - Completed
+        * `CANCELED` - Canceled
+        * `RETURNED` - Returned
+        * `REFUNDED` - Refunded
     OrderWriteRequest:
       type: object
       properties:
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -33984,23 +33760,19 @@ components:
         zipcode:
           type: string
           minLength: 1
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           minLength: 1
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         items:
           type: array
           items:
@@ -35332,7 +35104,6 @@ components:
         user:
           type: integer
         website:
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -35456,21 +35227,16 @@ components:
           type: integer
         featured:
           type: boolean
-          title: Προβεβλημένο
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
     PatchedBlogTagWriteRequest:
       type: object
@@ -35496,7 +35262,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
     PatchedCartItemUpdateRequest:
       type: object
       properties:
@@ -35504,7 +35269,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Ποσότητα
     PatchedCountryWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35530,13 +35294,13 @@ components:
         alpha2:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           pattern: ^[A-Z]{2}$
           maxLength: 2
         alpha3:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 3)
+          title: Country Code Alpha 3
           pattern: ^[A-Z]{3}$
           maxLength: 3
         isoCc:
@@ -35544,19 +35308,17 @@ components:
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός ISO χώρας
+          title: ISO Country Code
         phoneCode:
           type: integer
           maximum: 32767
           minimum: 0
           nullable: true
-          title: Κωδικός κλήσης
     PatchedNotificationUserWriteRequest:
       type: object
       properties:
         seen:
           type: boolean
-          title: Ορατό
     PatchedOrderItemWriteRequest:
       type: object
       properties:
@@ -35568,52 +35330,44 @@ components:
           type: integer
           maximum: 2147483647
           minimum: -2147483648
-          title: Ποσότητα
         notes:
           type: string
-          title: Σημειώσεις
     PatchedOrderWriteRequest:
       type: object
       properties:
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         email:
           type: string
@@ -35623,23 +35377,19 @@ components:
         zipcode:
           type: string
           minLength: 1
-          title: Τ.Κ.
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         phone:
           type: string
           minLength: 1
         customerNotes:
           type: string
-          title: Σημειώσεις Πελάτη
         items:
           type: array
           items:
@@ -35680,7 +35430,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -35699,24 +35448,20 @@ components:
           type: string
           format: binary
           nullable: true
-          title: Εικονίδιο
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           nullable: true
-          title: Διαμόρφωση Παρόχου
-          description: Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+          title: Provider Configuration
+          description: Provider-specific configuration (API keys, webhooks, etc.)
     PatchedProductCategoryImageBulkUpdateRequest:
       type: object
       properties:
@@ -35742,10 +35487,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         translations:
           type: object
           properties:
@@ -35805,21 +35548,17 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
     PatchedProductFavouriteWriteRequest:
       type: object
@@ -35838,7 +35577,6 @@ components:
           title: Εικόνα
         isMain:
           type: boolean
-          title: Κύριο
         translations:
           type: object
           properties:
@@ -35866,7 +35604,6 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         translations:
@@ -35938,7 +35675,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         weight:
           type: object
           properties:
@@ -35957,22 +35693,17 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         active:
           type: boolean
-          title: Ενεργή
     PatchedRegionWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -35998,12 +35729,12 @@ components:
         alpha:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
     PatchedSubscriptionTopicWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36035,35 +35766,33 @@ components:
         slug:
           type: string
           minLength: 1
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
     PatchedTagWriteRequest:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36088,14 +35817,13 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
     PatchedTaggedItemWriteRequest:
       type: object
       properties:
         tagId:
           type: integer
           writeOnly: true
-          description: ID ετικέτας προς ανάθεση
+          description: ID of the tag to assign
         contentType:
           type: integer
         objectId:
@@ -36108,45 +35836,37 @@ components:
         title:
           type: string
           minLength: 1
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
           minLength: 1
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -36155,28 +35875,25 @@ components:
           minLength: 1
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
     PatchedUserSubscriptionWriteRequest:
       type: object
       properties:
         topic:
           type: integer
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
     PatchedUserWriteRequest:
       type: object
       properties:
@@ -36184,15 +35901,13 @@ components:
           type: string
           format: email
           minLength: 1
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         username:
           nullable: true
@@ -36214,38 +35929,34 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           nullable: true
-          title: Προφίλ Twitter
+          title: Twitter Profile
           oneOf:
             - type: string
               format: uri
@@ -36254,7 +35965,7 @@ components:
               maxLength: 0
         linkedin:
           nullable: true
-          title: Προφίλ LinkedIn
+          title: LinkedIn Profile
           oneOf:
             - type: string
               format: uri
@@ -36263,7 +35974,7 @@ components:
               maxLength: 0
         facebook:
           nullable: true
-          title: Προφίλ Facebook
+          title: Facebook Profile
           oneOf:
             - type: string
               format: uri
@@ -36272,7 +35983,7 @@ components:
               maxLength: 0
         instagram:
           nullable: true
-          title: Προφίλ Instagram
+          title: Instagram Profile
           oneOf:
             - type: string
               format: uri
@@ -36281,7 +35992,6 @@ components:
               maxLength: 0
         website:
           nullable: true
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -36290,7 +36000,7 @@ components:
               maxLength: 0
         youtube:
           nullable: true
-          title: Προφίλ Youtube
+          title: Youtube Profile
           oneOf:
             - type: string
               format: uri
@@ -36299,7 +36009,7 @@ components:
               maxLength: 0
         github:
           nullable: true
-          title: Προφίλ Github
+          title: Github Profile
           oneOf:
             - type: string
               format: uri
@@ -36308,12 +36018,11 @@ components:
               maxLength: 0
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
           minLength: 1
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
     PayWay:
       type: object
@@ -36354,7 +36063,6 @@ components:
           readOnly: true
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36373,12 +36081,10 @@ components:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         mainImagePath:
           type: string
           readOnly: true
@@ -36386,12 +36092,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36401,17 +36105,14 @@ components:
           readOnly: true
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
       required:
         - cost
         - createdAt
@@ -36462,7 +36163,6 @@ components:
           readOnly: true
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36481,12 +36181,10 @@ components:
           type: string
           format: uri
           nullable: true
-          title: Εικονίδιο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         mainImagePath:
           type: string
           readOnly: true
@@ -36494,12 +36192,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36509,17 +36205,14 @@ components:
           readOnly: true
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           readOnly: true
       required:
@@ -36570,7 +36263,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         cost:
           type: number
           format: double
@@ -36589,24 +36281,20 @@ components:
           type: string
           format: binary
           nullable: true
-          title: Εικονίδιο
         providerCode:
           type: string
-          title: Κωδικός παρόχου
-          description: Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+          description: Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
           maxLength: 50
         isOnlinePayment:
           type: boolean
-          title: Είναι online πληρωμή
-          description: Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+          description: Whether this payment method is processed online
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+          description: Whether this payment method requires manual confirmation (e.g., bank transfer)
         configuration:
           nullable: true
-          title: Διαμόρφωση Παρόχου
-          description: Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+          title: Provider Configuration
+          description: Provider-specific configuration (API keys, webhooks, etc.)
       required:
         - cost
         - translations
@@ -36616,8 +36304,8 @@ components:
         - cod
       type: string
       description: |-
-        * `prepaid` - Προπληρωμένο
-        * `cod` - Αντικαταβολή
+        * `prepaid` - Prepaid
+        * `cod` - Cash on delivery
     PaymentStatusEnum:
       enum:
         - PENDING
@@ -36629,13 +36317,13 @@ components:
         - CANCELED
       type: string
       description: |-
-        * `PENDING` - Εκκρεμεί
-        * `PROCESSING` - Σε επεξεργασία
-        * `COMPLETED` - Ολοκληρώθηκε
-        * `FAILED` - Απέτυχε
-        * `REFUNDED` - Επιστροφή Χρημάτων
-        * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-        * `CANCELED` - Ακυρώθηκε
+        * `PENDING` - Pending
+        * `PROCESSING` - Processing
+        * `COMPLETED` - Completed
+        * `FAILED` - Failed
+        * `REFUNDED` - Refunded
+        * `PARTIALLY_REFUNDED` - Partially Refunded
+        * `CANCELED` - Canceled
     PaymentStatusResponse:
       type: object
       properties:
@@ -36693,13 +36381,11 @@ components:
         points:
           type: integer
           readOnly: true
-          title: Πόντοι
-          description: Θετικό για κέρδος/μπόνους, αρνητικό για εξαργύρωση/λήξη/προσαρμογή
+          description: Positive for earn/bonus, negative for redeem/expire/adjust
         transactionType:
           allOf:
             - $ref: '#/components/schemas/TransactionTypeEnum'
           readOnly: true
-          title: Τύπος συναλλαγής
         referenceOrder:
           type: integer
           readOnly: true
@@ -36707,12 +36393,10 @@ components:
         description:
           type: string
           readOnly: true
-          title: Περιγραφή
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - createdAt
         - description
@@ -36729,11 +36413,11 @@ components:
         - CRITICAL
       type: string
       description: |-
-        * `LOW` - Χαμηλή προτεραιότητα
-        * `NORMAL` - Κανονική προτεραιότητα
-        * `HIGH` - Υψηλή προτεραιότητα
-        * `URGENT` - Επείγουσα προτεραιότητα
-        * `CRITICAL` - Κρίσιμη προτεραιότητα
+        * `LOW` - Low Priority
+        * `NORMAL` - Normal Priority
+        * `HIGH` - High Priority
+        * `URGENT` - Urgent Priority
+        * `CRITICAL` - Critical Priority
     Product:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -36775,7 +36459,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -36796,20 +36480,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -36823,15 +36503,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -36840,7 +36517,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -36893,12 +36569,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -36944,9 +36618,7 @@ components:
           format: uuid
           readOnly: true
         kind:
-          allOf:
-            - $ref: '#/components/schemas/ProductAlertKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/ProductAlertKindEnum'
         product:
           type: integer
         user:
@@ -36969,23 +36641,19 @@ components:
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
         notifiedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Ειδοποιήθηκε στις
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -37002,15 +36670,13 @@ components:
         - price_drop
       type: string
       description: |-
-        * `restock` - Αναπλήρωση
-        * `price_drop` - Πτώση τιμής
+        * `restock` - Restock
+        * `price_drop` - Price drop
     ProductAlertRequest:
       type: object
       properties:
         kind:
-          allOf:
-            - $ref: '#/components/schemas/ProductAlertKindEnum'
-          title: Είδος
+          $ref: '#/components/schemas/ProductAlertKindEnum'
         product:
           type: integer
         email:
@@ -37054,7 +36720,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - attributeId
         - attributeName
@@ -37122,7 +36787,6 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
@@ -37136,12 +36800,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37192,7 +36854,6 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
@@ -37206,12 +36867,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37226,15 +36885,12 @@ components:
           readOnly: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - children
@@ -37267,15 +36923,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -37310,12 +36963,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37365,15 +37016,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -37408,12 +37056,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37444,10 +37090,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/ImageTypeEnum'
           default: MAIN
-          title: Τύπος εικόνας
         active:
           type: boolean
-          title: Ενεργή
         translations:
           type: object
           properties:
@@ -37511,21 +37155,17 @@ components:
           pattern: ^[-a-zA-Z0-9_]+$
         active:
           type: boolean
-          title: Ενεργή
         parent:
           type: integer
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
       required:
         - slug
@@ -37571,7 +37211,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -37592,20 +37232,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -37619,15 +37255,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -37636,7 +37269,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -37689,12 +37321,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37707,8 +37337,7 @@ components:
         priceDropAlertsEnabled:
           type: boolean
           readOnly: true
-          title: Ειδοποιήσεις πτώσης τιμής
-          description: Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+          description: When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
       required:
         - attributes
         - brand
@@ -37776,7 +37405,7 @@ components:
           type: integer
           readOnly: true
           nullable: true
-          description: Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+          description: Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
         brand:
           type: integer
           readOnly: true
@@ -37797,20 +37426,16 @@ components:
         viewCount:
           type: integer
           readOnly: true
-          title: Προβολές
         stock:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         lowStockThreshold:
           type: integer
           readOnly: true
-          title: Όριο χαμηλού αποθέματος
-          description: Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+          description: Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
         active:
           type: boolean
-          title: Ενεργή
         weight:
           type: object
           properties:
@@ -37824,15 +37449,12 @@ components:
           nullable: true
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         discountPercent:
           type: number
@@ -37841,7 +37463,6 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         discountValue:
           type: number
           format: double
@@ -37894,12 +37515,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37912,8 +37531,7 @@ components:
         priceDropAlertsEnabled:
           type: boolean
           readOnly: true
-          title: Ειδοποιήσεις πτώσης τιμής
-          description: Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+          description: When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
       required:
         - attributes
         - brand
@@ -37960,7 +37578,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         uuid:
           type: string
           format: uuid
@@ -37979,7 +37596,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID προϊόντων για έλεγχο αγαπημένων
+          description: List of product IDs to check for favorites
           maxItems: 100
       required:
         - productIds
@@ -38020,7 +37637,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38032,7 +37648,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -38090,12 +37705,10 @@ components:
           readOnly: true
         isMain:
           type: boolean
-          title: Κύριο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -38121,7 +37734,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
       required:
         - altText
         - createdAt
@@ -38165,12 +37777,10 @@ components:
           readOnly: true
         isMain:
           type: boolean
-          title: Κύριο
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         translations:
           type: object
           properties:
@@ -38196,7 +37806,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         imageDimensions:
           type: object
           properties:
@@ -38226,7 +37835,6 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - altText
         - createdAt
@@ -38255,7 +37863,6 @@ components:
           title: Εικόνα
         isMain:
           type: boolean
-          title: Κύριο
         translations:
           type: object
           properties:
@@ -38280,7 +37887,22 @@ components:
         - translations
     ProductMeiliSearchResponse:
       type: object
+      description: |-
+        Common disclosure fields every search response carries.
+
+        ``query_id`` attributes later clicks to this query (see the
+        ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+        query the zero-result fallback actually matched, so clients can
+        disclose "showing results for …" instead of silently swapping.
       properties:
+        queryId:
+          type: string
+          format: uuid
+          description: Identifier for this search, used to attribute clicks
+        relaxedQuery:
+          type: string
+          nullable: true
+          description: The relaxed query used by the zero-result fallback, or null when results matched the original query
         limit:
           type: integer
         offset:
@@ -38306,6 +37928,8 @@ components:
         - estimatedTotalHits
         - limit
         - offset
+        - queryId
+        - relaxedQuery
         - results
     ProductMeiliSearchResult:
       type: object
@@ -38415,32 +38039,25 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         status:
-          allOf:
-            - $ref: '#/components/schemas/ReviewStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/ReviewStatus'
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38491,32 +38108,25 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         status:
-          allOf:
-            - $ref: '#/components/schemas/ReviewStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/ReviewStatus'
         isPublished:
           type: boolean
-          title: Δημοσιευμένο
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         publishedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Δημοσιεύθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38558,7 +38168,6 @@ components:
         rate:
           allOf:
             - $ref: '#/components/schemas/RateEnum'
-          title: Συντ.
           minimum: 0
           maximum: 32767
         translations:
@@ -38624,11 +38233,9 @@ components:
         active:
           type: boolean
           readOnly: true
-          title: Ενεργή
         stock:
           type: integer
           readOnly: true
-          title: Απόθεμα
         price:
           type: number
           format: double
@@ -38653,7 +38260,6 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           readOnly: true
-          title: Ποσοστό Έκπτωσης
         mainImagePath:
           type: string
           readOnly: true
@@ -38741,7 +38347,6 @@ components:
           type: integer
           maximum: 2147483647
           minimum: 0
-          title: Απόθεμα
         weight:
           type: object
           properties:
@@ -38760,22 +38365,17 @@ components:
           minimum: -1000000000
           exclusiveMaximum: true
           exclusiveMinimum: true
-          title: Ποσοστό Έκπτωσης
         seoTitle:
           type: string
-          title: Τίτλος SEO
           maxLength: 70
         seoDescription:
           type: string
-          title: Περιγραφή SEO
           maxLength: 300
         seoKeywords:
           type: string
-          title: Λέξεις-κλειδιά SEO
           maxLength: 255
         active:
           type: boolean
-          title: Ενεργή
       required:
         - category
         - price
@@ -38796,16 +38396,16 @@ components:
         - 10
       type: integer
       description: |-
-        * `1` - Ένα
-        * `2` - Δύο
-        * `3` - Τρία
-        * `4` - Τέσσερα
-        * `5` - Πέντε
-        * `6` - Έξι
-        * `7` - Επτά
-        * `8` - Οκτώ
-        * `9` - Εννέα
-        * `10` - Δέκα
+        * `1` - One
+        * `2` - Two
+        * `3` - Three
+        * `4` - Four
+        * `5` - Five
+        * `6` - Six
+        * `7` - Seven
+        * `8` - Eight
+        * `9` - Nine
+        * `10` - Ten
     RedeemPointsRequestRequest:
       type: object
       description: Serializer for validating a points redemption request.
@@ -38884,26 +38484,23 @@ components:
                   type: string
         alpha:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38940,26 +38537,23 @@ components:
                   type: string
         alpha:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -38997,12 +38591,12 @@ components:
         alpha:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           maxLength: 10
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
       required:
         - alpha
         - country
@@ -39015,7 +38609,7 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID δεσμεύσεων προς απελευθέρωση
+          description: List of reservation IDs to release
       required:
         - reservationIds
     ReleaseReservationsResponse:
@@ -39024,16 +38618,16 @@ components:
       properties:
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
         releasedCount:
           type: integer
-          description: Αριθμός αποδεσμευμένων κρατήσεων
+          description: Number of reservations released
         failedReleases:
           type: array
           items:
             type: object
             additionalProperties: {}
-          description: Λίστα αποτυχημένων απελευθερώσεων με λεπτομέρειες σφάλματος
+          description: List of failed releases with error details
       required:
         - message
         - releasedCount
@@ -39079,13 +38673,21 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID δημιουργημένων δεσμεύσεων αποθέματος
+          description: List of created stock reservation IDs
         message:
           type: string
-          description: Μήνυμα επιτυχίας
+          description: Success message
       required:
         - message
         - reservationIds
+    ResultTypeEnum:
+      enum:
+        - product
+        - blog_post
+      type: string
+      description: |-
+        * `product` - product
+        * `blog_post` - blog_post
     ReviewStatus:
       enum:
         - NEW
@@ -39093,9 +38695,9 @@ components:
         - 'FALSE'
       type: string
       description: |-
-        * `NEW` - Νέο
-        * `TRUE` - Ναι
-        * `FALSE` - Όχι
+        * `NEW` - New
+        * `TRUE` - True
+        * `FALSE` - False
     SearchAnalyticsResponse:
       type: object
       description: Serializer for search analytics response.
@@ -39133,6 +38735,43 @@ components:
         - searchVolume
         - topQueries
         - zeroResultQueries
+    SearchClickRequestRequest:
+      type: object
+      description: Payload for attributing a result click to a search query.
+      properties:
+        queryId:
+          type: string
+          format: uuid
+          description: The query_id returned by the search response
+        resultId:
+          type: string
+          minLength: 1
+          description: ID of the clicked result (Product or BlogPost ID)
+          maxLength: 100
+        resultType:
+          allOf:
+            - $ref: '#/components/schemas/ResultTypeEnum'
+          description: |-
+            Type of the clicked result
+
+            * `product` - product
+            * `blog_post` - blog_post
+        position:
+          type: integer
+          minimum: 0
+          description: 0-indexed position of the result in the result list
+      required:
+        - position
+        - queryId
+        - resultId
+        - resultType
+    SearchClickResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+        - detail
     SearchVolume:
       type: object
       description: Serializer for search volume metrics.
@@ -39191,24 +38830,24 @@ components:
         - lost
       type: string
       description: |-
-        * `pending_creation` - Εκκρεμής δημιουργία
-        * `new` - Νέο
-        * `in_transit` - Σε μεταφορά
-        * `at_destination` - Στο κατάστημα παράδοσης
-        * `out_for_delivery` - Σε διανομή
-        * `delivered` - Παραδόθηκε
-        * `attempted` - Απόπειρα παράδοσης
-        * `returned` - Επιστράφηκε
-        * `canceled` - Ακυρώθηκε
-        * `lost` - Χάθηκε
+        * `pending_creation` - Pending creation
+        * `new` - New
+        * `in_transit` - In transit
+        * `at_destination` - At destination station
+        * `out_for_delivery` - Out for delivery
+        * `delivered` - Delivered
+        * `attempted` - Delivery attempted
+        * `returned` - Returned
+        * `canceled` - Canceled
+        * `lost` - Lost
     ShippingKind:
       enum:
         - home_delivery
         - pickup_point
       type: string
       description: |-
-        * `home_delivery` - Κατ' οίκον παράδοση
-        * `pickup_point` - Σημείο παραλαβής / locker
+        * `home_delivery` - Home delivery
+        * `pickup_point` - Pickup point / locker
     ShippingOption:
       type: object
       description: |-
@@ -39233,7 +38872,7 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           nullable: true
-          description: Null όταν ο πάροχος παραπέμπει στη γενική πάγια χρέωση.
+          description: Null when the provider defers to the global flat rate.
         currency:
           type: string
           maxLength: 3
@@ -39245,7 +38884,7 @@ components:
           type: string
           format: uri
           nullable: true
-          description: Απόλυτο URL για το λογότυπο μάρκας που ανέβασε ο χειριστής, υπολογισμένο ανά (πάροχο, τύπο) ώστε η γραμμή κατ' οίκον παράδοσης και η γραμμή σημείου παραλαβής του ίδιου μεταφορέα να μπορούν να εμφανίζουν διαφορετικές εικόνες. Null όταν δεν έχει μεταφορτωθεί λογότυπο — το κατάστημα τότε επιστρέφει στην ενσωματωμένη προεπιλογή του. Το ``settings.MEDIA_URL`` είναι απόλυτο σε κάθε περιβάλλον, οπότε αυτό είναι πάντα πλήρες URL όταν υπάρχει.
+          description: Absolute URL for the operator-uploaded brand logo, resolved per (provider, kind) so the home-delivery row and the pickup-point row of the same carrier can show different images. Null when no logo is uploaded — the storefront then falls back to its bundled default. ``settings.MEDIA_URL`` is absolute in every environment so this is always a full URL when present.
         metadata:
           type: object
           additionalProperties: {}
@@ -39268,35 +38907,30 @@ components:
           type: string
           readOnly: true
           title: Κωδικός
-          description: Σταθερό αναγνωριστικό που αντιστοιχεί στον καταχωρημένο προσαρμογέα μεταφορέα (π.χ. 'acs', 'boxnow').
+          description: Stable identifier matching the registered carrier adapter (e.g. 'acs', 'boxnow').
           pattern: ^[-a-zA-Z0-9_]+$
         name:
           type: string
           readOnly: true
-          title: Όνομα
-          description: Όνομα εμφάνισης προς τους πελάτες (π.χ. 'ACS Courier').
+          description: Display name shown to customers (e.g. 'ACS Courier').
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργό
-          description: Κύριος διακόπτης — όταν είναι False, ο πάροχος αποκρύπτεται από το checkout ανεξάρτητα από τις σημαίες δυνατοτήτων.
+          description: Master switch — when False the provider is hidden from checkout regardless of capability flags.
         supportsHomeDelivery:
           type: boolean
           readOnly: true
-          title: Υποστηρίζει Κατ' Οίκον Παράδοση
         supportsPickupPoint:
           type: boolean
           readOnly: true
-          title: Υποστηρίζει σημείο παραλαβής
         liveMode:
           type: boolean
           readOnly: true
-          description: False = διαπιστευτήρια sandbox / δοκιμής. Χρησιμοποιείται από το UI διαχείρισης για να προειδοποιεί τους χειριστές ότι τα vouchers δεν θα αποσταλούν πραγματικά.
+          description: False = sandbox / test credentials. Used by the admin UI to warn operators that vouchers won't actually ship.
         priority:
           type: integer
           readOnly: true
-          title: Προτεραιότητα
-          description: Σειρά ταξινόμησης στο checkout — οι μικρότεροι αριθμοί εμφανίζονται πρώτοι.
+          description: Sort order in checkout — lower numbers appear first.
         logo:
           type: string
           format: uri
@@ -39323,18 +38957,15 @@ components:
           description: Filename of the pickup-point logo (or empty).
         metadata:
           readOnly: true
-          title: Μεταδεδομένα
-          description: Διαμόρφωση ειδική για τον πάροχο (υποστηριζόμενες χώρες, σημαίες λειτουργιών, υποδείξεις branding).
+          description: Provider-specific configuration (supported countries, feature flags, branding hints).
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - code
         - createdAt
@@ -39363,12 +38994,12 @@ components:
         - 8
       type: integer
       description: |-
-        * `1` - Κατάστημα
-        * `2` - Συνεργαζόμενο κατάστημα (2)
-        * `3` - Συνεργαζόμενο κατάστημα (3)
+        * `1` - Shop
+        * `2` - Partner shop (2)
+        * `3` - Partner shop (3)
         * `4` - Xpress Point
         * `5` - Kiosk
-        * `7` - Smartpoint (χωρίς locker)
+        * `7` - Smartpoint (no locker)
         * `8` - Smartpoint locker
     SubscriptionStatus:
       enum:
@@ -39378,10 +39009,10 @@ components:
         - BOUNCED
       type: string
       description: |-
-        * `ACTIVE` - Ενεργή
-        * `PENDING` - Εκκρεμεί Επιβεβαίωση
-        * `UNSUBSCRIBED` - Διαγραφή
-        * `BOUNCED` - Επιστράφηκε
+        * `ACTIVE` - Active
+        * `PENDING` - Pending Confirmation
+        * `UNSUBSCRIBED` - Unsubscribed
+        * `BOUNCED` - Bounced
     SubscriptionTopic:
       type: object
       description: Serializer that saves :class:`TranslatedFieldsField` automatically.
@@ -39419,35 +39050,33 @@ components:
           readOnly: true
         slug:
           type: string
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
         subscriberCount:
           type: integer
           readOnly: true
@@ -39494,35 +39123,33 @@ components:
           readOnly: true
         slug:
           type: string
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
         subscriberCount:
           type: integer
           readOnly: true
@@ -39530,12 +39157,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -39575,35 +39200,33 @@ components:
         slug:
           type: string
           minLength: 1
-          description: Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+          description: Unique identifier for the topic (e.g., 'weekly-newsletter')
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         category:
           allOf:
             - $ref: '#/components/schemas/TopicCategory'
-          title: Κατηγορία
           description: |-
-            Κατηγορία του θέματος εγγραφής
+            Category of the subscription topic
 
-            * `MARKETING` - Καμπάνιες marketing
-            * `PRODUCT` - Ενημερώσεις προϊόντων
-            * `ACCOUNT` - Λογαριασμός Ανενεργός
-            * `SYSTEM` - Ειδοποιήσεις Συστήματος
+            * `MARKETING` - Marketing Campaigns
+            * `PRODUCT` - Product Updates
+            * `ACCOUNT` - Account Updates
+            * `SYSTEM` - System Notifications
             * `NEWSLETTER` - Newsletter
-            * `PROMOTIONAL` - Προωθητικό
-            * `OTHER` - Άλλο
+            * `PROMOTIONAL` - Promotional
+            * `OTHER` - Other
         isActive:
           type: boolean
-          title: Ενεργή
-          description: Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+          title: Active
+          description: Whether this topic is currently available for subscription
         isDefault:
           type: boolean
-          title: Προεπιλεγμένη συνδρομή
-          description: Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+          title: Default Subscription
+          description: Whether new users are automatically subscribed to this topic
         requiresConfirmation:
           type: boolean
-          title: Απαιτείται Επιβεβαίωση
-          description: Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+          description: Whether subscription to this topic requires email confirmation
       required:
         - slug
         - translations
@@ -39634,26 +39257,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: string
           readOnly: true
-          description: Πόσες φορές χρησιμοποιείται η ετικέτα
+          description: Number of times this tag is used
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39693,26 +39312,22 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
         sortOrder:
           type: integer
           readOnly: true
           nullable: true
-          title: Σειρά ταξινόμησης
         usageCount:
           type: string
           readOnly: true
-          description: Πόσες φορές χρησιμοποιείται η ετικέτα
+          description: Number of times this tag is used
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39720,7 +39335,7 @@ components:
         contentTypes:
           type: string
           readOnly: true
-          description: Τύποι περιεχομένου με τους οποίους χρησιμοποιείται αυτή η ετικέτα
+          description: Content types this tag is used with
       required:
         - contentTypes
         - createdAt
@@ -39754,7 +39369,6 @@ components:
                   type: string
         active:
           type: boolean
-          title: Ενεργή
       required:
         - translations
     TaggedItem:
@@ -39772,14 +39386,14 @@ components:
         contentTypeName:
           type: string
           readOnly: true
-          description: Όνομα τύπου περιεχομένου
+          description: Name of the content type
         objectId:
           type: integer
           maximum: 2147483647
           minimum: 0
         contentObject:
           type: object
-          description: Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+          description: Serialized representation of the related content object
           properties:
             id:
               type: integer
@@ -39802,12 +39416,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39837,14 +39449,14 @@ components:
         contentTypeName:
           type: string
           readOnly: true
-          description: Όνομα τύπου περιεχομένου
+          description: Name of the content type
         objectId:
           type: integer
           maximum: 2147483647
           minimum: 0
         contentObject:
           type: object
-          description: Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+          description: Serialized representation of the related content object
           properties:
             id:
               type: integer
@@ -39867,12 +39479,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -39893,7 +39503,7 @@ components:
         tagId:
           type: integer
           writeOnly: true
-          description: ID ετικέτας προς ανάθεση
+          description: ID of the tag to assign
         contentType:
           type: integer
         objectId:
@@ -40098,13 +39708,13 @@ components:
         - OTHER
       type: string
       description: |-
-        * `MARKETING` - Καμπάνιες marketing
-        * `PRODUCT` - Ενημερώσεις προϊόντων
-        * `ACCOUNT` - Λογαριασμός Ανενεργός
-        * `SYSTEM` - Ειδοποιήσεις Συστήματος
+        * `MARKETING` - Marketing Campaigns
+        * `PRODUCT` - Product Updates
+        * `ACCOUNT` - Account Updates
+        * `SYSTEM` - System Notifications
         * `NEWSLETTER` - Newsletter
-        * `PROMOTIONAL` - Προωθητικό
-        * `OTHER` - Άλλο
+        * `PROMOTIONAL` - Promotional
+        * `OTHER` - Other
     TransactionTypeEnum:
       enum:
         - EARN
@@ -40114,10 +39724,10 @@ components:
         - BONUS
       type: string
       description: |-
-        * `EARN` - Κερδίστε
-        * `REDEEM` - Εξαργύρωση
-        * `EXPIRE` - Λήξη
-        * `ADJUST` - Προσαρμογή
+        * `EARN` - Earn
+        * `REDEEM` - Redeem
+        * `EXPIRE` - Expire
+        * `ADJUST` - Adjust
         * `BONUS` - Bonus
     TrendingSearchItem:
       type: object
@@ -40168,9 +39778,9 @@ components:
       type: string
       description: |-
         * `apm` - APM
-        * `any_apm` - Οποιοδήποτε APM
-        * `warehouse` - Αποθήκη
-        * `depot` - Αποθήκη
+        * `any_apm` - Any APM
+        * `warehouse` - Warehouse
+        * `depot` - Depot
     UnsubscribeResponse:
       type: object
       properties:
@@ -40204,39 +39814,31 @@ components:
           readOnly: true
         title:
           type: string
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40244,31 +39846,27 @@ components:
           type: string
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         user:
           type: integer
           readOnly: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40297,39 +39895,31 @@ components:
           readOnly: true
         title:
           type: string
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40337,31 +39927,27 @@ components:
           type: string
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         user:
           type: integer
           readOnly: true
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40388,45 +39974,37 @@ components:
         title:
           type: string
           minLength: 1
-          title: Τίτλος
           maxLength: 255
         firstName:
           type: string
           minLength: 1
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
           minLength: 1
-          title: Επώνυμο
           maxLength: 255
         street:
           type: string
           minLength: 1
-          title: Οδός
           maxLength: 255
         streetNumber:
           type: string
           minLength: 1
-          title: Αριθμός
           maxLength: 255
         city:
           type: string
           minLength: 1
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
           minLength: 1
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         floor:
-          title: Όροφος
           oneOf:
             - $ref: '#/components/schemas/FloorEnum'
             - $ref: '#/components/schemas/BlankEnum'
         locationType:
-          title: Τύπος τοποθεσίας
           oneOf:
             - $ref: '#/components/schemas/LocationTypeEnum'
             - $ref: '#/components/schemas/BlankEnum'
@@ -40435,20 +40013,18 @@ components:
           minLength: 1
         notes:
           type: string
-          title: Σημειώσεις
           maxLength: 255
         isMain:
           type: boolean
           default: false
-          title: Κύριο
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
       required:
         - city
         - country
@@ -40508,15 +40084,13 @@ components:
         email:
           type: string
           format: email
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         id:
           type: integer
@@ -40536,91 +40110,86 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         linkedin:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         facebook:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         instagram:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         website:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         youtube:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         github:
           type: string
           nullable: true
           maxLength: 200
-          description: Σύνδεσμος URL ή κενή τιμή
+          description: URL link or empty string
           readOnly: true
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
         isActive:
           type: boolean
           readOnly: true
-          title: Ενεργή
+          title: Active
         isStaff:
           type: boolean
           readOnly: true
-          title: Προσωπικό
+          title: Staff
         isSuperuser:
           type: boolean
           readOnly: true
@@ -40630,12 +40199,10 @@ components:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
         uuid:
           type: string
           format: uuid
@@ -40678,33 +40245,26 @@ components:
             - $ref: '#/components/schemas/SubscriptionTopic'
           readOnly: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/SubscriptionStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/SubscriptionStatus'
         subscribedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εγγραφή στις
         unsubscribedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Διαγραφή στις
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -40731,33 +40291,26 @@ components:
             - $ref: '#/components/schemas/SubscriptionTopic'
           readOnly: true
         status:
-          allOf:
-            - $ref: '#/components/schemas/SubscriptionStatus'
-          title: Κατάσταση
+          $ref: '#/components/schemas/SubscriptionStatus'
         subscribedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Εγγραφή στις
         unsubscribedAt:
           type: string
           format: date-time
           readOnly: true
           nullable: true
-          title: Διαγραφή στις
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          title: Δημιουργήθηκε στις
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          title: Ενημερώθηκε στις
       required:
         - createdAt
         - id
@@ -40773,8 +40326,7 @@ components:
         topic:
           type: integer
         metadata:
-          title: Μεταδεδομένα
-          description: Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+          description: Additional subscription preferences or data
       required:
         - topic
     UserWriteRequest:
@@ -40784,15 +40336,13 @@ components:
           type: string
           format: email
           minLength: 1
-          title: Διεύθυνση Email
+          title: Διεύθυνση ηλεκτρονικού ταχυδρομείου
           maxLength: 254
         firstName:
           type: string
-          title: Όνομα
           maxLength: 255
         lastName:
           type: string
-          title: Επώνυμο
           maxLength: 255
         username:
           nullable: true
@@ -40814,38 +40364,34 @@ components:
           nullable: true
         city:
           type: string
-          title: Πόλη
           maxLength: 255
         zipcode:
           type: string
-          title: Ταχ. Κώδικας
+          title: Zip Code
           maxLength: 255
         address:
           type: string
-          title: Διεύθυνση
           maxLength: 255
         place:
           type: string
-          title: Τόπος
           maxLength: 255
         country:
           type: string
           minLength: 1
-          title: Κωδικός Χώρας (Alpha 2)
+          title: Country Code Alpha 2
           nullable: true
         region:
           type: string
           minLength: 1
-          title: Κωδικός περιφέρειας
+          title: Region Code
           nullable: true
         birthDate:
           type: string
           format: date
           nullable: true
-          title: Ημ/νία γέννησης
         twitter:
           nullable: true
-          title: Προφίλ Twitter
+          title: Twitter Profile
           oneOf:
             - type: string
               format: uri
@@ -40854,7 +40400,7 @@ components:
               maxLength: 0
         linkedin:
           nullable: true
-          title: Προφίλ LinkedIn
+          title: LinkedIn Profile
           oneOf:
             - type: string
               format: uri
@@ -40863,7 +40409,7 @@ components:
               maxLength: 0
         facebook:
           nullable: true
-          title: Προφίλ Facebook
+          title: Facebook Profile
           oneOf:
             - type: string
               format: uri
@@ -40872,7 +40418,7 @@ components:
               maxLength: 0
         instagram:
           nullable: true
-          title: Προφίλ Instagram
+          title: Instagram Profile
           oneOf:
             - type: string
               format: uri
@@ -40881,7 +40427,6 @@ components:
               maxLength: 0
         website:
           nullable: true
-          title: Ιστότοπος
           oneOf:
             - type: string
               format: uri
@@ -40890,7 +40435,7 @@ components:
               maxLength: 0
         youtube:
           nullable: true
-          title: Προφίλ Youtube
+          title: Youtube Profile
           oneOf:
             - type: string
               format: uri
@@ -40899,7 +40444,7 @@ components:
               maxLength: 0
         github:
           nullable: true
-          title: Προφίλ Github
+          title: Github Profile
           oneOf:
             - type: string
               format: uri
@@ -40908,12 +40453,11 @@ components:
               maxLength: 0
         bio:
           type: string
-          title: Βιογραφικό
         languageCode:
           type: string
           minLength: 1
-          title: Γλώσσα
-          description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+          title: Language
+          description: Preferred language for emails and UI messages.
           maxLength: 10
       required:
         - email
@@ -40923,7 +40467,7 @@ components:
         username:
           type: string
           minLength: 1
-          description: Νέο όνομα χρήστη
+          description: New username
           maxLength: 150
       required:
         - username
@@ -40932,7 +40476,7 @@ components:
       properties:
         detail:
           type: string
-          description: Μήνυμα επιτυχίας για ενημέρωση ονόματος χρήστη
+          description: Success message for username update
       required:
         - detail
     VariantAxis:

--- a/server/api/search/click.post.ts
+++ b/server/api/search/click.post.ts
@@ -1,0 +1,19 @@
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  try {
+    const body = await readValidatedBody(
+      event,
+      zApiV1SearchClickCreateBody.parse,
+    )
+    await $fetch(`${config.apiBaseUrl}/search/click`, {
+      method: 'POST',
+      body,
+      headers: createHeaders(null, null),
+    })
+    setResponseStatus(event, 202)
+    return null
+  }
+  catch (error) {
+    handleError(error)
+  }
+})

--- a/shared/openapi/types.gen.ts
+++ b/shared/openapi/types.gen.ts
@@ -42,47 +42,31 @@ export type AcsAddressValidationResponse = {
 }
 
 /**
- * * `1` - Προπληρωμένο
- * * `2` - Αντικαταβολή
+ * * `1` - Prepaid
+ * * `2` - Cash on delivery
  */
 export type AcsChargeType = 1 | 2
 
 export type AcsPickupList = {
   readonly id: number
   /**
-     * Αριθμός λίστας παραλαβής
+     * Pickup list number
      *
-     * PickupList_No που επιστρέφεται από το ACS_Issue_Pickup_List.
+     * PickupList_No returned by ACS_Issue_Pickup_List.
      */
   readonly pickupListNo: string
-  /**
-     * Εκδόθηκε στις
-     */
   readonly issuedAt: string
   /**
-     * Εκδόθηκε από
-     *
-     * Διαχειριστής που ενεργοποίησε τη χειροκίνητη έκδοση. Null όταν η λίστα εκδόθηκε από την καθημερινή εργασία Celery beat.
+     * Admin who triggered the manual issue. Null when the daily Celery beat task issued the list.
      */
   readonly issuedBy: number | null
   readonly issuedByUsername: string | null
   /**
-     * Κωδικός χρέωσης
-     *
-     * Billing_Code που καταγράφεται τη στιγμή της έκδοσης, ώστε τα ιστορικά manifest να παραμένουν επανεκτυπώσιμα ακόμη κι αν αλλάξει η μεταβλητή περιβάλλοντος.
+     * Billing_Code captured at issuance time so historical manifests stay reprintable even if the env var changes.
      */
   readonly billingCode: string
-  /**
-     * Πλήθος vouchers
-     */
   readonly voucherCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -93,92 +77,61 @@ export type AcsShipmentDetail = {
   readonly id: number
   readonly uuid: string
   /**
-     * Αριθμός voucher
+     * Voucher number
      *
-     * 10ψήφιο voucher ACS (Voucher_No από το ACS_Create_Voucher).
+     * 10-digit ACS voucher (Voucher_No from ACS_Create_Voucher).
      */
   readonly voucherNo: string | null
-  /**
-     * Κατάσταση αποστολής
-     */
   shipmentState: ShipmentStateEnum
   /**
-     * Ετικέτα σε αναγνώσιμη μορφή για την τιμή shipment_state
+     * Human-readable label for the shipment_state choice
      */
   readonly shipmentStateDisplay: string
-  /**
-     * Τρόπος παράδοσης
-     */
   deliveryKind: ShippingKind
   /**
-     * Βάρος (γραμμάρια)
+     * Weight (grams)
      *
-     * Εσωτερικά γραμμάρια· μετατρέπονται σε κιλά (>= 0,5) κατά την κλήση API σύμφωνα με τις απαιτήσεις βάρους της ACS.
+     * Internal grams; converted to kilograms (>= 0.5) at API call time per ACS Weight requirements.
      */
   readonly weightGrams: number
-  /**
-     * Ποσότητα ειδών
-     */
   readonly itemQuantity: number
-  /**
-     * Τύπος χρέωσης
-     */
   chargeType: AcsChargeType
   /**
-     * Προϊόντα παράδοσης
-     *
-     * Κωδικοί Acs_Delivery_Products διαχωρισμένοι με κόμμα (COD, REC, SAT, RDO …).
+     * Comma-separated Acs_Delivery_Products codes (COD, REC, SAT, RDO …).
      */
   readonly deliveryProducts: string
-  /**
-     * Τελευταίο συμβάν
-     */
   readonly lastEventAt: string | null
   /**
-     * Τελευταία ανάκτηση
-     *
-     * Χρησιμοποιείται από το poll_acs_tracking_batch για κατανομή φορτίου και παράλειψη αποστολών που ελέγχθηκαν τα τελευταία 15 λεπτά.
+     * Used by poll_acs_tracking_batch to spread load and skip shipments polled within the last 15 minutes.
      */
   readonly lastPolledAt: string | null
-  /**
-     * Ημερομηνία παράδοσης
-     */
   readonly deliveryDate: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   /**
-     * Εξωτερικό ID καταστήματος προορισμού
+     * Destination station external ID
      *
-     * Μη κανονικοποιημένο ACS_SHOP_STATION_ID — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή AcsStation.
+     * Denormalised ACS_SHOP_STATION_ID — preserved even if the AcsStation row is deleted.
      */
   readonly stationDestinationExternalId: string
   /**
-     * Υποκατάστημα προορισμού
+     * Destination branch
      *
-     * Τιμή Acs_Station_Branch_Destination.
+     * Acs_Station_Branch_Destination value.
      */
   readonly stationBranchDestination: string
   /**
-     * Στοιχεία καταστήματος προορισμού ACS (παραλαβές Smartpoint).
+     * Destination ACS station details (Smartpoint pickups).
      */
   station: AcsStation | null
   /**
-     * Τελευταία 50 συμβάντα παρακολούθησης ταξινομημένα κατά event_time φθίνουσα.
+     * Last 50 tracking events ordered by event_time desc.
      */
   readonly events: Array<AcsTrackingEvent>
   /**
-     * Σχετικό URL για λήψη του PDF voucher μέσω του proxy Django.
+     * Relative URL to download the voucher PDF via the Django proxy.
      */
   readonly labelUrl: string | null
-  /**
-     * Αίτημα ακύρωσης στις
-     */
   readonly cancelRequestedAt: string | null
 }
 
@@ -192,75 +145,40 @@ export type AcsStation = {
   readonly id: number
   readonly uuid: string
   /**
-     * Εξωτερικό ID
-     *
-     * ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το 'ATH')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.
+     * ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under 'ATH'); the (external_id, branch_code) pair is the locker's identity.
      */
   readonly externalId: string
   /**
-     * Κωδικός υποκαταστήματος
-     *
-     * ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+     * ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
      */
   readonly branchCode: string
   /**
-     * Είδος καταστήματος
+     * ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
      *
-     * ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
-     *
-     * * `1` - Κατάστημα
-     * * `2` - Συνεργαζόμενο κατάστημα (2)
-     * * `3` - Συνεργαζόμενο κατάστημα (3)
+     * * `1` - Shop
+     * * `2` - Partner shop (2)
+     * * `3` - Partner shop (3)
      * * `4` - Xpress Point
      * * `5` - Kiosk
-     * * `7` - Smartpoint (χωρίς locker)
+     * * `7` - Smartpoint (no locker)
      * * `8` - Smartpoint locker
      */
   shopKind: ShopKindEnum
-  /**
-     * Όνομα
-     */
   readonly name: string
-  /**
-     * Διεύθυνση γραμμή 1
-     */
   readonly addressLine1: string
-  /**
-     * Πόλη
-     */
   readonly city: string
-  /**
-     * Ταχυδρομικός κώδικας
-     */
   readonly postalCode: string
   /**
-     * Κωδικός χώρας
-     *
-     * ISO 3166-1 alpha-2 κωδικός χώρας.
+     * ISO 3166-1 alpha-2 country code.
      */
   readonly countryCode: string
   readonly lat: string | null
   readonly lng: string | null
   readonly maxWeightKg: string
-  /**
-     * Ωράριο λειτουργίας
-     */
   readonly workingHours: string
-  /**
-     * Ενεργό
-     */
   readonly isActive: boolean
-  /**
-     * Τελευταίος συγχρονισμός
-     */
   readonly lastSyncedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -274,83 +192,42 @@ export type AcsStationDetail = {
   readonly id: number
   readonly uuid: string
   /**
-     * Εξωτερικό ID
-     *
-     * ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το 'ATH')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.
+     * ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under 'ATH'); the (external_id, branch_code) pair is the locker's identity.
      */
   readonly externalId: string
   /**
-     * Κωδικός υποκαταστήματος
-     *
-     * ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.
+     * ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.
      */
   readonly branchCode: string
   /**
-     * Είδος καταστήματος
+     * ACS_SHOP_KIND — 1 shop, 7/8 Smartpoint locker.
      *
-     * ACS_SHOP_KIND — 1 κατάστημα, 7/8 locker Smartpoint.
-     *
-     * * `1` - Κατάστημα
-     * * `2` - Συνεργαζόμενο κατάστημα (2)
-     * * `3` - Συνεργαζόμενο κατάστημα (3)
+     * * `1` - Shop
+     * * `2` - Partner shop (2)
+     * * `3` - Partner shop (3)
      * * `4` - Xpress Point
      * * `5` - Kiosk
-     * * `7` - Smartpoint (χωρίς locker)
+     * * `7` - Smartpoint (no locker)
      * * `8` - Smartpoint locker
      */
   shopKind: ShopKindEnum
-  /**
-     * Όνομα
-     */
   readonly name: string
-  /**
-     * Διεύθυνση γραμμή 1
-     */
   readonly addressLine1: string
-  /**
-     * Πόλη
-     */
   readonly city: string
-  /**
-     * Ταχυδρομικός κώδικας
-     */
   readonly postalCode: string
   /**
-     * Κωδικός χώρας
-     *
-     * ISO 3166-1 alpha-2 κωδικός χώρας.
+     * ISO 3166-1 alpha-2 country code.
      */
   readonly countryCode: string
   readonly lat: string | null
   readonly lng: string | null
   readonly maxWeightKg: string
-  /**
-     * Ωράριο λειτουργίας
-     */
   readonly workingHours: string
-  /**
-     * Ενεργό
-     */
   readonly isActive: boolean
-  /**
-     * Τελευταίος συγχρονισμός
-     */
   readonly lastSyncedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Διεύθυνση γραμμή 2
-     */
   readonly addressLine2: string
-  /**
-     * Περιοχή
-     */
   readonly region: string
   /**
      * Τηλέφωνο
@@ -361,33 +238,23 @@ export type AcsStationDetail = {
 export type AcsTrackingEvent = {
   readonly id: number
   /**
-     * Ώρα συμβάντος
-     *
-     * Checkpoint_Date_Time από το ACS_TrackingDetails.
+     * Checkpoint_Date_Time from ACS_TrackingDetails.
      */
   readonly eventTime: string
   /**
-     * Ενέργεια σημείου ελέγχου
-     *
-     * Checkpoint_Action_Description — κείμενο στα ελληνικά σε αναγνώσιμη μορφή που περιγράφει το συμβάν.
+     * Checkpoint_Action_Description — human-readable Greek text describing the event.
      */
   readonly checkpointAction: string
   /**
-     * Σημείο ελέγχου
-     *
      * Checkpoint_Location_Description.
      */
   readonly checkpointLocation: string
   /**
-     * Σημειώσεις
-     *
-     * Πεδίο σχολίων ACS.
+     * ACS Comments field.
      */
   readonly notes: string
   /**
-     * Παραλήφθηκε στις
-     *
-     * Πραγματικός χρόνος κατά τον οποίο η εργασία παρακολούθησης παρατήρησε αυτό το συμβάν.
+     * Wall-clock time when the polling task observed this event.
      */
   readonly receivedAt: string
 }
@@ -471,23 +338,11 @@ export type Attribute = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   readonly valuesCount: number
   readonly usageCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -513,22 +368,10 @@ export type AttributeValue = {
       value?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   readonly usageCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -553,16 +396,10 @@ export type BlogAuthor = {
   readonly uuid: string
   readonly user: number
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly website: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly numberOfPosts: number
   totalLikesReceived: number | 0
@@ -587,16 +424,10 @@ export type BlogAuthorDetail = {
   readonly uuid: string
   user: UserDetails
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly website: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly numberOfPosts: number
   totalLikesReceived: number | 0
@@ -620,9 +451,6 @@ export type BlogAuthorWriteRequest = {
     }
   }
   user: number
-  /**
-     * Ιστότοπος
-     */
   website?: string | string
 }
 
@@ -648,9 +476,6 @@ export type BlogCategory = {
   slug: string
   parent?: number | null
   readonly level: number
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
      * Return post count from annotation if available, otherwise query.
@@ -665,13 +490,7 @@ export type BlogCategory = {
      */
   readonly hasChildren: boolean
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -697,9 +516,6 @@ export type BlogCategoryDetail = {
   slug: string
   parent?: number | null
   readonly level: number
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
      * Return post count from annotation if available, otherwise query.
@@ -714,13 +530,7 @@ export type BlogCategoryDetail = {
      */
   readonly hasChildren: boolean
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly children: Array<BlogCategory>
   readonly ancestors: Array<BlogCategory>
@@ -734,29 +544,29 @@ export type BlogCategoryDetail = {
 
 export type BlogCategoryReorderItemRequest = {
   /**
-     * ID κατηγορίας
+     * Category ID
      */
   id: number
   /**
-     * Νέα τιμή σειράς ταξινόμησης
+     * New sort order value
      */
   sortOrder: number
 }
 
 export type BlogCategoryReorderRequestRequest = {
   /**
-     * Λίστα κατηγοριών με νέες σειρές ταξινόμησης
+     * List of categories with new sort orders
      */
   categories: Array<BlogCategoryReorderItemRequest>
 }
 
 export type BlogCategoryReorderResponse = {
   /**
-     * Αριθμός ενημερωμένων κατηγοριών
+     * Number of categories updated
      */
   updatedCount: number
   /**
-     * Μήνυμα επιτυχίας
+     * Success message
      */
   message: string
 }
@@ -805,39 +615,30 @@ export type BlogComment = {
   }
   user: UserDetails
   /**
-     * Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+     * First 150 characters of the comment content
      */
   readonly contentPreview: string | null
   /**
-     * Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+     * Whether this comment is a reply to another comment
      */
   readonly isReply: boolean
   readonly parent: number | null
   /**
-     * Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+     * Whether this comment has approved replies
      */
   readonly hasReplies: boolean
-  /**
-     * Εγκεκριμένο
-     */
   readonly approved: boolean
   /**
-     * Αν αυτό το σχόλιο έχει επεξεργαστεί
+     * Whether this comment has been edited
      */
   readonly isEdited: boolean
   readonly likesCount: number
   readonly repliesCount: number
   /**
-     * Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+     * Whether the current user has liked this comment
      */
   readonly userHasLiked: boolean
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -860,47 +661,38 @@ export type BlogCommentDetail = {
   }
   user: UserDetails
   /**
-     * Οι πρώτοι 150 χαρακτήρες του περιεχομένου του σχολίου
+     * First 150 characters of the comment content
      */
   readonly contentPreview: string | null
   /**
-     * Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο
+     * Whether this comment is a reply to another comment
      */
   readonly isReply: boolean
   readonly parent: number | null
   /**
-     * Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις
+     * Whether this comment has approved replies
      */
   readonly hasReplies: boolean
-  /**
-     * Εγκεκριμένο
-     */
   readonly approved: boolean
   /**
-     * Αν αυτό το σχόλιο έχει επεξεργαστεί
+     * Whether this comment has been edited
      */
   readonly isEdited: boolean
   readonly likesCount: number
   readonly repliesCount: number
   /**
-     * Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο
+     * Whether the current user has liked this comment
      */
   readonly userHasLiked: boolean
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   /**
-     * Βασικές πληροφορίες για το άρθρο
+     * Basic information about the blog post
      */
   post: BlogPost
   /**
-     * Γονικό σχόλιο, αν πρόκειται για απάντηση
+     * Parent comment if this is a reply
      */
   readonly parentComment: {
     id: number
@@ -909,11 +701,11 @@ export type BlogCommentDetail = {
     createdAt: string
   } | null
   /**
-     * Άμεσα εγκεκριμένα θυγατρικά σχόλια (απαντήσεις)
+     * Direct approved child comments (replies)
      */
   readonly childrenComments: Array<BlogComment>
   /**
-     * Διαδρομή από το ριζικό σχόλιο έως αυτό
+     * Path from root comment to this comment
      */
   readonly ancestorsPath: Array<{
     id: number
@@ -921,7 +713,7 @@ export type BlogCommentDetail = {
     user: UserDetails
   }>
   /**
-     * Πληροφορίες θέσης στο δέντρο σχολίων
+     * Position information in the comment tree
      */
   readonly treePosition: {
     level: number
@@ -933,14 +725,14 @@ export type BlogCommentDetail = {
 
 export type BlogCommentLikedCommentsRequestRequest = {
   /**
-     * Λίστα ID σχολίων για έλεγχο κατάστασης επισήμανσης
+     * List of comment IDs to check like status for
      */
   commentIds: Array<number>
 }
 
 export type BlogCommentLikedCommentsResponse = {
   /**
-     * Λίστα ID σχολίων που έχει επισημάνει ο τρέχων χρήστης
+     * List of comment IDs that are liked by the current user
      */
   likedCommentIds: Array<number>
 }
@@ -992,13 +784,7 @@ export type BlogPost = {
   author: number
   category: number
   tags: Array<number>
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Προβολές
-     */
   readonly viewCount: number
   /**
      * Return likes count from annotation or query database.
@@ -1012,21 +798,9 @@ export type BlogPost = {
      * Return tags count from annotation or query database.
      */
   readonly tagsCount: number
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Δημοσιεύθηκε στις
-     */
   readonly publishedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly mainImagePath: string
   readonly readingTime: number
@@ -1061,13 +835,7 @@ export type BlogPostDetail = {
   author: BlogAuthorDetail
   category: BlogCategoryDetail
   readonly tags: Array<BlogTagDetail>
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Προβολές
-     */
   readonly viewCount: number
   /**
      * Return likes count from annotation or query database.
@@ -1081,55 +849,50 @@ export type BlogPostDetail = {
      * Return tags count from annotation or query database.
      */
   readonly tagsCount: number
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Δημοσιεύθηκε στις
-     */
   readonly publishedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly mainImagePath: string
   readonly readingTime: number
   readonly contentPreview: string
   readonly userHasLiked: boolean
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
 export type BlogPostLikedPostsRequestRequest = {
   /**
-     * Λίστα ID άρθρων για έλεγχο επισημάνσεων
+     * List of post IDs to check for likes
      */
   postIds: Array<number>
 }
 
 export type BlogPostLikedPostsResponse = {
   /**
-     * Λίστα ID άρθρων με επισήμανση
+     * List of liked post IDs
      */
   postIds: Array<number>
 }
 
+/**
+ * Common disclosure fields every search response carries.
+ *
+ * ``query_id`` attributes later clicks to this query (see the
+ * ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+ * query the zero-result fallback actually matched, so clients can
+ * disclose "showing results for …" instead of silently swapping.
+ */
 export type BlogPostMeiliSearchResponse = {
+  /**
+     * Identifier for this search, used to attribute clicks
+     */
+  queryId: string
+  /**
+     * The relaxed query used by the zero-result fallback, or null when results matched the original query
+     */
+  relaxedQuery: string | null
   limit: number
   offset: number
   estimatedTotalHits: number
@@ -1176,25 +939,10 @@ export type BlogPostWriteRequest = {
   category: number
   tags?: Array<number>
   author: number
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -1214,25 +962,13 @@ export type BlogTag = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
-     * Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+     * Number of blog posts using this tag
      */
   readonly postsCount: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -1253,25 +989,13 @@ export type BlogTagDetail = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
-     * Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα
+     * Number of blog posts using this tag
      */
   readonly postsCount: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -1291,9 +1015,6 @@ export type BlogTagWriteRequest = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -1302,15 +1023,15 @@ export type BlogTagWriteRequest = {
  */
 export type BoxNowCustomerRequest = {
   /**
-     * Πλήρες όνομα πελάτη
+     * Customer full name
      */
   name?: string
   /**
-     * Email πελάτη
+     * Customer email address
      */
   email?: string
   /**
-     * Τηλέφωνο πελάτη
+     * Customer phone number
      */
   phoneNumber?: string
 }
@@ -1320,11 +1041,11 @@ export type BoxNowCustomerRequest = {
  */
 export type BoxNowEventLocationRequest = {
   /**
-     * Όνομα locker ή hub σε αναγνώσιμη μορφή
+     * Human-readable locker or hub name
      */
   displayName?: string
   /**
-     * Ταχυδρομικός κώδικας της τοποθεσίας του συμβάντος
+     * Postal code of the event location
      */
   postalCode?: string
 }
@@ -1338,74 +1059,38 @@ export type BoxNowEventLocationRequest = {
 export type BoxNowLocker = {
   readonly id: number
   /**
-     * Εξωτερικό ID
-     *
      * BoxNow APM identifier (string)
      */
   readonly externalId: string
-  /**
-     * Τύπος
-     */
   type: TypeEnum
-  /**
-     * URL εικόνας
-     */
   readonly imageUrl: string | null
   /**
-     * Γεωγραφικό πλάτος
+     * Latitude
      */
   readonly lat: number
   /**
-     * Γεωγραφικό μήκος
+     * Longitude
      */
   readonly lng: number
-  /**
-     * Τίτλος
-     */
   readonly title: string
-  /**
-     * Όνομα
-     */
   readonly name: string
-  /**
-     * Διεύθυνση γραμμή 1
-     */
   readonly addressLine1: string
-  /**
-     * Διεύθυνση γραμμή 2
-     */
   readonly addressLine2: string
-  /**
-     * Ταχ. Κώδικας
-     */
   readonly postalCode: string
   /**
-     * Κωδικός χώρας
-     *
-     * ISO 3166-1 alpha-2 κωδικός χώρας
+     * ISO 3166-1 alpha-2 country code
      */
   readonly countryCode: string
   /**
      * Σημείωση
      */
   readonly note: string
-  /**
-     * Ενεργό
-     */
   readonly isActive: boolean
   /**
-     * Τελευταίος συγχρονισμός
-     *
-     * Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+     * Timestamp of the most recent sync from BoxNow API
      */
   readonly lastSyncedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -1419,74 +1104,38 @@ export type BoxNowLocker = {
 export type BoxNowLockerDetail = {
   readonly id: number
   /**
-     * Εξωτερικό ID
-     *
      * BoxNow APM identifier (string)
      */
   readonly externalId: string
-  /**
-     * Τύπος
-     */
   type: TypeEnum
-  /**
-     * URL εικόνας
-     */
   readonly imageUrl: string | null
   /**
-     * Γεωγραφικό πλάτος
+     * Latitude
      */
   readonly lat: number
   /**
-     * Γεωγραφικό μήκος
+     * Longitude
      */
   readonly lng: number
-  /**
-     * Τίτλος
-     */
   readonly title: string
-  /**
-     * Όνομα
-     */
   readonly name: string
-  /**
-     * Διεύθυνση γραμμή 1
-     */
   readonly addressLine1: string
-  /**
-     * Διεύθυνση γραμμή 2
-     */
   readonly addressLine2: string
-  /**
-     * Ταχ. Κώδικας
-     */
   readonly postalCode: string
   /**
-     * Κωδικός χώρας
-     *
-     * ISO 3166-1 alpha-2 κωδικός χώρας
+     * ISO 3166-1 alpha-2 country code
      */
   readonly countryCode: string
   /**
      * Σημείωση
      */
   readonly note: string
-  /**
-     * Ενεργό
-     */
   readonly isActive: boolean
   /**
-     * Τελευταίος συγχρονισμός
-     *
-     * Χρονοσήμανση του πιο πρόσφατου συγχρονισμού από το API του BoxNow
+     * Timestamp of the most recent sync from BoxNow API
      */
   readonly lastSyncedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -1499,23 +1148,23 @@ export type BoxNowLockerDetail = {
  */
 export type BoxNowNearestLockerRequestRequest = {
   /**
-     * Όνομα πόλης για αναζήτηση πλησιέστερου locker
+     * City name for nearest-locker lookup
      */
   city: string
   /**
-     * Οδός και αριθμός
+     * Street name and number
      */
   street: string
   /**
-     * Ταχυδρομικός κώδικας
+     * Postal / ZIP code
      */
   postalCode: string
   /**
-     * Ετικέτα γλώσσας IETF / κωδικός περιφέρειας (προεπιλογή: el-GR)
+     * IETF language tag / region code (default: el-GR)
      */
   region?: string
   /**
-     * Απαιτούμενο μέγεθος θυρίδας: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο
+     * Required compartment size: 1=Small, 2=Medium, 3=Large
      */
   compartmentSize?: number
 }
@@ -1530,59 +1179,59 @@ export type BoxNowNearestLockerRequestRequest = {
  */
 export type BoxNowNearestLockerResponse = {
   /**
-     * Αναγνωριστικό APM BoxNow
+     * BoxNow APM identifier
      */
   readonly id: string
   /**
-     * Τύπος locker (π.χ. apm, warehouse)
+     * Locker type (e.g. apm, warehouse)
      */
   readonly type: string
   /**
-     * URL εικόνας locker
+     * URL of locker image
      */
   readonly image: string
   /**
-     * Γεωγραφικό πλάτος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+     * Latitude (string as returned by BoxNow)
      */
   readonly lat: string
   /**
-     * Γεωγραφικό μήκος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)
+     * Longitude (string as returned by BoxNow)
      */
   readonly lng: string
   /**
-     * Σύντομος τίτλος εμφάνισης
+     * Short display title
      */
   readonly title: string
   /**
-     * Πλήρες όνομα locker
+     * Full locker name
      */
   readonly name: string
   /**
-     * Ταχ. κώδικας του locker
+     * Postal code of the locker
      */
   readonly postalCode: string
   /**
-     * ISO 3166-1 alpha-2 κωδικός χώρας
+     * ISO 3166-1 alpha-2 country code
      */
   readonly country: string
   /**
-     * Λειτουργική σημείωση από BoxNow
+     * Operational note from BoxNow
      */
   readonly note: string
   /**
-     * Κύρια γραμμή διεύθυνσης
+     * Primary address line
      */
   readonly addressLine1: string
   /**
-     * Δευτερεύουσα γραμμή διεύθυνσης
+     * Secondary address line
      */
   readonly addressLine2: string
   /**
-     * Ετικέτα περιφέρειας IETF που επιστρέφεται από το BoxNow
+     * IETF region tag returned by BoxNow
      */
   readonly region: string
   /**
-     * Απόσταση από τη δεδομένη διεύθυνση σε χιλιόμετρα
+     * Distance from the supplied address in kilometres
      */
   readonly distance: number
 }
@@ -1596,87 +1245,67 @@ export type BoxNowNearestLockerResponse = {
 export type BoxNowParcelEvent = {
   readonly id: number
   /**
-     * ID μηνύματος webhook
-     *
-     * Πεδίο 'id' του CloudEvents — κλειδί ιδεμποτεντίας
+     * CloudEvents 'id' field — idempotency key
      */
   readonly webhookMessageId: string
   /**
-     * Τύπος συμβάντος
+     * BoxNow event mapped from the webhook 'event' field
      *
-     * Συμβάν BoxNow αντιστοιχισμένο από το πεδίο 'event' του webhook
-     *
-     * * `pending_creation` - Εκκρεμής δημιουργία
-     * * `new` - Νέο
-     * * `in_depot` - Σε αποθήκη
-     * * `final_destination` - Στο locker
-     * * `delivered` - Παραδόθηκε
-     * * `returned` - Επιστράφηκε
-     * * `expired` - Έληξε
-     * * `canceled` - Ακυρώθηκε
-     * * `accepted_for_return` - Αποδεκτό για επιστροφή
-     * * `accepted_to_locker` - Αποδεκτό σε locker
-     * * `missing` - Λείπει
-     * * `lost` - Χάθηκε
+     * * `pending_creation` - Pending creation
+     * * `new` - New
+     * * `in_depot` - In depot
+     * * `final_destination` - At locker
+     * * `delivered` - Delivered
+     * * `returned` - Returned
+     * * `expired` - Expired
+     * * `canceled` - Canceled
+     * * `accepted_for_return` - Accepted for return
+     * * `accepted_to_locker` - Accepted to locker
+     * * `missing` - Missing
+     * * `lost` - Lost
      */
   eventType: BoxNowParcelState
   /**
-     * Ετικέτα σε αναγνώσιμη μορφή για την τιμή event_type
+     * Human-readable label for the event_type choice
      */
   readonly eventTypeDisplay: string
   /**
-     * Κατάσταση Δέματος
-     *
-     * Ακατέργαστη τιμή 'data.parcelState' από το payload του webhook BoxNow
+     * Raw 'data.parcelState' value from BoxNow webhook payload
      */
   readonly parcelState: string
   /**
-     * Ώρα συμβάντος
-     *
-     * Χρονοσήμανση από το 'data.time' στο payload του webhook
+     * Timestamp from 'data.time' in the webhook payload
      */
   readonly eventTime: string
   /**
-     * Εμφανιζόμενο όνομα
-     *
      * data.eventLocation.displayName
      */
   readonly displayName: string
   /**
-     * Ταχ. Κώδικας
-     *
      * data.eventLocation.postalCode
      */
   readonly postalCode: string
-  /**
-     * Πρόσθετες Πληροφορίες
-     */
   readonly additionalInformation: string
   /**
-     * Παραλήφθηκε στις
-     *
-     * Χρονοσήμανση λήψης του webhook από το GrooveShop (διαφορετική από το event_time)
+     * Timestamp when GrooveShop received the webhook (separate from event_time)
      */
   readonly receivedAt: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
 }
 
 /**
- * * `pending_creation` - Εκκρεμής δημιουργία
- * * `new` - Νέο
- * * `in_depot` - Σε αποθήκη
- * * `final_destination` - Στο locker
- * * `delivered` - Παραδόθηκε
- * * `returned` - Επιστράφηκε
- * * `expired` - Έληξε
- * * `canceled` - Ακυρώθηκε
- * * `accepted_for_return` - Αποδεκτό για επιστροφή
- * * `accepted_to_locker` - Αποδεκτό σε locker
- * * `missing` - Λείπει
- * * `lost` - Χάθηκε
+ * * `pending_creation` - Pending creation
+ * * `new` - New
+ * * `in_depot` - In depot
+ * * `final_destination` - At locker
+ * * `delivered` - Delivered
+ * * `returned` - Returned
+ * * `expired` - Expired
+ * * `canceled` - Canceled
+ * * `accepted_for_return` - Accepted for return
+ * * `accepted_to_locker` - Accepted to locker
+ * * `missing` - Missing
+ * * `lost` - Lost
  */
 export type BoxNowParcelState = 'pending_creation' | 'new' | 'in_depot' | 'final_destination' | 'delivered' | 'returned' | 'expired' | 'canceled' | 'accepted_for_return' | 'accepted_to_locker' | 'missing' | 'lost'
 
@@ -1698,80 +1327,48 @@ export type BoxNowShipmentDetail = {
   readonly id: number
   readonly uuid: string
   /**
-     * Αναγνωριστικό αιτήματος παράδοσης
-     *
-     * ID αιτήματος παράδοσης BoxNow που επιστρέφεται από το POST /api/v1/delivery-requests
+     * BoxNow delivery-request ID returned from POST /api/v1/delivery-requests
      */
   readonly deliveryRequestId: string | null
   /**
-     * ID δέματος
-     *
-     * 10ψήφιος αριθμός BoxNow voucher
+     * 10-digit BoxNow voucher number
      */
   readonly parcelId: string | null
   /**
-     * Εξωτερικό ID locker
-     *
-     * Μη κανονικοποιημένο ID APM BoxNow — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή BoxNowLocker
+     * Denormalised BoxNow APM ID — preserved even if the BoxNowLocker row is deleted
      */
   readonly lockerExternalId: string
-  /**
-     * Κατάσταση Δέματος
-     */
   parcelState: BoxNowParcelState
   /**
-     * Ετικέτα σε αναγνώσιμη μορφή για την τιμή parcel_state
+     * Human-readable label for the parcel_state choice
      */
   readonly parcelStateDisplay: string
-  /**
-     * Μέγεθος θυρίδας
-     */
   compartmentSize: CompartmentSizeEnum
-  /**
-     * Τρόπος πληρωμής
-     */
   paymentMode: PaymentModeEnum
-  /**
-     * Τελευταίο συμβάν
-     */
   readonly lastEventAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   /**
-     * Ενσωματωμένα στοιχεία locker BoxNow
+     * Nested BoxNow locker details
      */
   locker: BoxNowLocker | null
   /**
-     * Τελευταία 20 συμβάντα δέματος ταξινομημένα κατά event_time φθίνουσα
+     * Last 20 parcel events ordered by event_time desc
      */
   readonly events: Array<BoxNowParcelEvent>
   /**
-     * Σχετικό URL για λήψη του PDF ετικέτας δέματος μέσω του endpoint proxy Django
+     * Relative URL to download the parcel label PDF via the Django proxy endpoint
      */
   readonly labelUrl: string | null
   /**
-     * Βάρος (γραμμάρια)
+     * Weight (grams)
      */
   readonly weightGrams: number
   /**
-     * Ποσό προς Είσπραξη
-     *
-     * Ποσό που εισπράττεται κατά την παράδοση (PoG / COD). Πάντα 0 στη Φάση 1.
+     * Amount collected at delivery (PoG / COD). Always 0 in Phase 1.
      */
   readonly amountToBeCollected: number
-  /**
-     * Επιτρέπεται επιστροφή
-     */
   readonly allowReturn: boolean
-  /**
-     * Ημερομηνία αιτήματος ακύρωσης
-     */
   readonly cancelRequestedAt: string | null
 }
 
@@ -1785,43 +1382,43 @@ export type BoxNowShipmentDetail = {
  */
 export type BoxNowWebhookDataRequest = {
   /**
-     * 10ψήφιος αριθμός voucher/δέματος BoxNow
+     * 10-digit BoxNow voucher/parcel number
      */
   parcelId: string
   /**
-     * Λεξιλόγιο κατάστασης δέματος BoxNow (data.parcelState)
+     * BoxNow parcel state vocabulary (data.parcelState)
      */
   parcelState: string
   /**
-     * Προαιρετικός αριθμός αναφοράς εμπόρου
+     * Optional merchant reference number
      */
   parcelReferenceNumber?: string
   /**
-     * Προαιρετικό όνομα δέματος
+     * Optional descriptive parcel name
      */
   parcelName?: string
   /**
-     * Αριθμός παραγγελίας εμπόρου που αποστέλλεται κατά τη δημιουργία αιτήματος παράδοσης
+     * Merchant order number sent during delivery-request creation
      */
   orderNumber: string
   /**
-     * Συμβολοσειρά τύπου συμβάντος BoxNow (π.χ. 'in-depot', 'final-destination', 'delivered')
+     * BoxNow event type string (e.g. 'in-depot', 'final-destination', 'delivered')
      */
   event: string
   /**
-     * Πλαίσιο τοποθεσίας συμβάντος
+     * Location context for this event
      */
   eventLocation?: BoxNowEventLocationRequest
   /**
-     * Στοιχεία πελάτη που σχετίζονται με το δέμα
+     * Customer details associated with the parcel
      */
   customer?: BoxNowCustomerRequest
   /**
-     * Ελεύθερο κείμενο με επιπλέον πληροφορίες από το BoxNow
+     * Free-text additional information from BoxNow
      */
   additionalInformation?: string
   /**
-     * Χρονοσήμανση όταν συνέβη το συμβάν στο BoxNow
+     * Timestamp when the event occurred at BoxNow
      */
   time: string
 }
@@ -1836,39 +1433,39 @@ export type BoxNowWebhookDataRequest = {
  */
 export type BoxNowWebhookEnvelopeRequest = {
   /**
-     * Έκδοση προδιαγραφής CloudEvents (αναμενόμενη: '1.0')
+     * CloudEvents specification version (expected: '1.0')
      */
   specversion: string
   /**
-     * Τύπος συμβάντος (αναμενόμενος: 'gr.boxnow.parcel_event_change')
+     * Event type (expected: 'gr.boxnow.parcel_event_change')
      */
   type: string
   /**
-     * URL προέλευσης πηγής συμβάντος
+     * Origin URL of the event source
      */
   source: string
   /**
-     * Θέμα του συμβάντος (συνήθως το ID δέματος)
+     * Subject of the event (typically the parcel ID)
      */
   subject: string
   /**
-     * Μοναδικό ID CloudEvents· χρησιμοποιείται ως κλειδί ιδεμποτεντίας (αποθηκεύεται ως webhook_message_id)
+     * Unique CloudEvents ID; used as idempotency key (stored as webhook_message_id)
      */
   id: string
   /**
-     * Χρονοσήμανση δημιουργίας του φακέλου
+     * Timestamp the envelope was generated
      */
   time: string
   /**
-     * Τύπος MIME του πεδίου data (αναμενόμενος: 'application/json')
+     * MIME type of the data field (expected: 'application/json')
      */
   datacontenttype: string
   /**
-     * Δεκαεξαδικό digest HMAC-SHA256 του ακατέργαστου JSON αντικειμένου 'data'· χρησιμοποιείται για επαλήθευση υπογραφής
+     * HMAC-SHA256 hex digest of the raw 'data' JSON object; used for signature verification
      */
   datasignature: string
   /**
-     * Payload συμβάντος δέματος
+     * Parcel event payload
      */
   data: BoxNowWebhookDataRequest
 }
@@ -1880,11 +1477,11 @@ export type BulkSubscriptionFailure = {
 
 export type BulkSubscriptionRequest = {
   /**
-     * Λίστα ID θεμάτων για εγγραφή/διαγραφή
+     * List of topic IDs to subscribe/unsubscribe
      */
   topicIds: Array<number>
   /**
-     * Ενέργεια προς εκτέλεση σε θέματα
+     * Action to perform on the topics
      *
      * * `subscribe` - subscribe
      * * `unsubscribe` - unsubscribe
@@ -1932,24 +1529,15 @@ export type Cart = {
      */
   readonly totalItemsUnique: number
   /**
-     * Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+     * Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
      */
   readonly totalWeightGrams: number
   /**
-     * Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+     * ISO 4217 currency code for all monetary values in this cart
      */
   readonly currency: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Τελευταία δραστηριότητα
-     */
   readonly lastActivity: string
 }
 
@@ -1969,26 +1557,26 @@ export type Cart = {
  */
 export type CartCreatePaymentIntentRequestRequest = {
   /**
-     * ID της επιλεγμένης μεθόδου πληρωμής (πρέπει να είναι online Stripe).
+     * ID of the selected PayWay (must be online Stripe).
      */
   payWayId: number
   /**
-     * Τύπος εκπλήρωσης για τον μεταφορέα (home_delivery ή pickup_point). Απαιτείται ώστε να τηρούνται οι επιμέρους σημαίες λειτουργίας (π.χ. ACS_SMARTPOINT_ENABLED) και ο έλεγχος PICKUP_POINT του BoxNow.
+     * Fulfilment kind for the carrier (home_delivery or pickup_point). Required so the per-kind feature flags (e.g. ACS_SMARTPOINT_ENABLED) and BoxNow's PICKUP_POINT gate are honoured.
      *
      * * `home_delivery` - home_delivery
      * * `pickup_point` - pickup_point
      */
   shippingKind: CartCreatePaymentIntentRequestShippingKindEnum
   /**
-     * Κωδικός μεταφορέα που αντιστοιχεί σε καταχωρημένο προσαρμογέα αποστολής (π.χ. 'acs', 'boxnow'). Απαιτείται για ``pickup_point``· παραλείψτε/αφήστε κενό για ``home_delivery`` (το backend χρησιμοποιεί τη γενική πάγια χρέωση, αντίστοιχη με αυτή που θα υπολογίσει η επαλήθευση δημιουργίας παραγγελίας για το ίδιο αίτημα).
+     * Carrier code matching a registered shipping adapter (e.g. 'acs', 'boxnow'). Required for ``pickup_point``; omit/empty for ``home_delivery`` (the backend uses the generic flat rate, matching what the order-create verification will compute for the same body).
      */
   shippingProviderCode?: string
   /**
-     * Προαιρετικός κωδικός χώρας ISO 3166-1 alpha-2 — καθορίζει τον συντελεστή αποστολής σε επίπεδο χώρας. Πρέπει να ταιριάζει με αυτόν που θα φέρει το αίτημα δημιουργίας παραγγελίας.
+     * Optional ISO 3166-1 alpha-2 country code — drives the country-level shipping multiplier. Match what the order-create body will carry.
      */
   countryId?: string
   /**
-     * Προαιρετικός κωδικός περιφέρειας — καθορίζει την προσαρμογή αποστολής σε επίπεδο περιφέρειας.
+     * Optional region code — drives the region-level shipping adjustment.
      */
   regionId?: string
 }
@@ -2022,27 +1610,18 @@ export type CartDetail = {
      */
   readonly totalItemsUnique: number
   /**
-     * Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.
+     * Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.
      */
   readonly totalWeightGrams: number
   /**
-     * Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού
+     * ISO 4217 currency code for all monetary values in this cart
      */
   readonly currency: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Τελευταία δραστηριότητα
-     */
   readonly lastActivity: string
   /**
-     * Προτάσεις προϊόντων βάσει περιεχομένου καλαθιού
+     * Product recommendations based on cart contents
      */
   readonly recommendations: Array<Product>
 }
@@ -2051,12 +1630,9 @@ export type CartItem = {
   readonly id: number
   readonly cartId: string
   product: Product
-  /**
-     * Ποσότητα
-     */
   quantity?: number
   /**
-     * Πληροφορίες βάρους για υπολογισμούς αποστολής
+     * Weight information for shipping calculations
      */
   readonly weightInfo: {
     unitWeight: number
@@ -2072,22 +1648,13 @@ export type CartItem = {
   readonly vatValue: number
   readonly totalPrice: number
   readonly totalDiscountValue: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type CartItemCreateRequest = {
   product: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
@@ -2095,12 +1662,9 @@ export type CartItemDetail = {
   readonly id: number
   readonly cartId: string
   product: Product
-  /**
-     * Ποσότητα
-     */
   quantity?: number
   /**
-     * Πληροφορίες βάρους για υπολογισμούς αποστολής
+     * Weight information for shipping calculations
      */
   readonly weightInfo: {
     unitWeight: number
@@ -2116,25 +1680,16 @@ export type CartItemDetail = {
   readonly vatValue: number
   readonly totalPrice: number
   readonly totalDiscountValue: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   /**
-     * Σχετικά προϊόντα που ίσως ενδιαφέρουν τον πελάτη
+     * Related products that might interest the customer
      */
   readonly recommendations: Array<Product>
 }
 
 export type CartItemUpdateRequest = {
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
@@ -2143,19 +1698,19 @@ export type CartItemUpdateRequest = {
  */
 export type CartPaymentIntentResponse = {
   /**
-     * Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+     * Stripe PaymentIntent client secret for frontend confirmation
      */
   clientSecret: string
   /**
-     * ID του Stripe PaymentIntent προς αποθήκευση στην παραγγελία
+     * Stripe PaymentIntent ID to be stored on the order
      */
   paymentIntentId: string
   /**
-     * Συνολικό ποσό χρέωσης (καλάθι + αποστολή + έξοδα πληρωμής)
+     * Total charge amount (cart + shipping + payment fee)
      */
   amount: number
   /**
-     * Κωδικός νομίσματος ISO 4217 (π.χ. EUR)
+     * ISO 4217 currency code (e.g. EUR)
      */
   currency: string
 }
@@ -2180,19 +1735,19 @@ export type ConfirmAgentPaymentResponse = {
      */
   paymentId: string
   /**
-     * Κατάσταση πληρωμής
+     * Payment status
      */
   status: string
   /**
-     * Ποσό πληρωμής
+     * Payment amount
      */
   amount: string
   /**
-     * Νόμισμα πληρωμής
+     * Payment currency
      */
   currency: string
   /**
-     * Όνομα παρόχου πληρωμών
+     * Payment provider name
      */
   provider: string
 }
@@ -2209,35 +1764,17 @@ export type ConfirmResponseRequest = {
 
 export type ContactWrite = {
   readonly id: number
-  /**
-     * Όνομα
-     */
   name: string
   email: string
-  /**
-     * Μήνυμα
-     */
   message: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type ContactWriteRequest = {
-  /**
-     * Όνομα
-     */
   name: string
   email: string
-  /**
-     * Μήνυμα
-     */
   message: string
 }
 
@@ -2257,32 +1794,20 @@ export type Country = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly mainImagePath: string
@@ -2304,32 +1829,20 @@ export type CountryDetail = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly mainImagePath: string
@@ -2352,20 +1865,17 @@ export type CountryWriteRequest = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
 }
 
@@ -2388,7 +1898,7 @@ export type CreateCheckoutSessionResponse = {
 
 export type CreatePaymentIntentRequestRequest = {
   /**
-     * Επιπλέον δεδομένα πληρωμής που απαιτούνται από τον πάροχο πληρωμών
+     * Additional payment data required by the payment provider
      */
   paymentData?: {
     [key: string]: string
@@ -2397,35 +1907,35 @@ export type CreatePaymentIntentRequestRequest = {
 
 export type CreatePaymentIntentResponse = {
   /**
-     * ID payment intent από τον πάροχο πληρωμών
+     * Payment intent ID from the payment provider
      */
   paymentId: string
   /**
-     * Κατάσταση πληρωμής
+     * Payment status
      */
   status: string
   /**
-     * Ποσό πληρωμής
+     * Payment amount
      */
   amount: string
   /**
-     * Νόμισμα πληρωμής
+     * Payment currency
      */
   currency: string
   /**
-     * Όνομα παρόχου πληρωμών
+     * Payment provider name
      */
   provider: string
   /**
-     * Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend
+     * Stripe PaymentIntent client secret for frontend confirmation
      */
   clientSecret?: string
   /**
-     * Αν η πληρωμή απαιτεί επιπλέον ενέργεια (3D Secure κ.λπ.)
+     * Whether the payment requires additional action (3D Secure, etc.)
      */
   requiresAction?: boolean
   /**
-     * Επόμενη ενέργεια που απαιτείται για την ολοκλήρωση της πληρωμής
+     * Next action required for payment completion
      */
   nextAction?: {
     [key: string]: unknown
@@ -2461,7 +1971,7 @@ export type DateRange = {
  */
 export type DeleteAccountRequestRequest = {
   /**
-     * Πρέπει να ισούται ακριβώς με τη συμβολοσειρά "DELETE".
+     * Must equal the literal string "DELETE".
      */
   confirmation: string
 }
@@ -2500,6 +2010,14 @@ export type FacetStatsItem = {
  * Serializer for federated search response.
  */
 export type FederatedSearchResponse = {
+  /**
+     * Identifier for this search, used to attribute clicks
+     */
+  queryId: string
+  /**
+     * The relaxed query used by the zero-result fallback, or null when results matched the original query
+     */
+  relaxedQuery: string | null
   /**
      * Maximum number of results requested
      */
@@ -2577,14 +2095,14 @@ export type FederationMetadata = {
 }
 
 /**
- * * `BASEMENT` - Υπόγειο
- * * `GROUND_FLOOR` - Ισόγειο
- * * `FIRST_FLOOR` - 1ος όροφος
- * * `SECOND_FLOOR` - 2ος όροφος
- * * `THIRD_FLOOR` - 3ος όροφος
- * * `FOURTH_FLOOR` - 4ος όροφος
- * * `FIFTH_FLOOR` - 5ος όροφος
- * * `SIXTH_FLOOR_PLUS` - 6ος όροφος +
+ * * `BASEMENT` - Basement
+ * * `GROUND_FLOOR` - Ground Floor
+ * * `FIRST_FLOOR` - First Floor
+ * * `SECOND_FLOOR` - Second Floor
+ * * `THIRD_FLOOR` - Third Floor
+ * * `FOURTH_FLOOR` - Fourth Floor
+ * * `FIFTH_FLOOR` - Fifth Floor
+ * * `SIXTH_FLOOR_PLUS` - Sixth Floor Plus
  */
 export type FloorEnum = 'BASEMENT' | 'GROUND_FLOOR' | 'FIRST_FLOOR' | 'SECOND_FLOOR' | 'THIRD_FLOOR' | 'FOURTH_FLOOR' | 'FIFTH_FLOOR' | 'SIXTH_FLOOR_PLUS'
 
@@ -2594,11 +2112,11 @@ export type FloorEnum = 'BASEMENT' | 'GROUND_FLOOR' | 'FIRST_FLOOR' | 'SECOND_FL
 export type FreeShippingInfo = {
   providers: Array<FreeShippingProviderEntry>
   /**
-     * Χαμηλότερο όριο μεταξύ των ενεργών παρόχων — ο κύριος αριθμός 'δωρεάν αποστολή από X €'. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+     * Lowest threshold across active providers — the headline 'free shipping from X €' number. Null when no active provider advertises a threshold.
      */
   minThreshold: number | null
   /**
-     * Υψηλότερο όριο μεταξύ των ενεργών παρόχων — το υποσύνολο στο οποίο κάθε μεταφορέας αποστέλλει δωρεάν. Null όταν κανένας ενεργός πάροχος δεν δηλώνει όριο.
+     * Highest threshold across active providers — the subtotal at which every carrier ships free. Null when no active provider advertises a threshold.
      */
   maxThreshold: number | null
   currency: string
@@ -2612,7 +2130,7 @@ export type FreeShippingProviderEntry = {
   providerName: string
   kind: ShippingKind
   /**
-     * Υποσύνολο καλαθιού στο νόμισμα της απόκρισης πάνω από το οποίο αυτός ο συνδυασμός (πάροχος, τύπος) αποστέλλει δωρεάν.
+     * Cart subtotal in the response's currency above which this (provider, kind) ships free.
      */
   threshold: number
   priority: number
@@ -2625,16 +2143,16 @@ export type HealthCheckResponse = {
 }
 
 /**
- * * `MAIN` - Κύρια εικόνα
- * * `BANNER` - Banner
- * * `ICON` - Εικονίδιο
- * * `THUMBNAIL` - Μικρογραφία
- * * `GALLERY` - Εικόνα συλλογής
- * * `BACKGROUND` - Εικόνα φόντου
- * * `HERO` - Κεντρική εικόνα
- * * `FEATURE` - Κεντρική Εικόνα
- * * `PROMOTIONAL` - Προωθητική εικόνα
- * * `SEASONAL` - Εποχιακή εικόνα
+ * * `MAIN` - Main Image
+ * * `BANNER` - Banner Image
+ * * `ICON` - Icon Image
+ * * `THUMBNAIL` - Thumbnail Image
+ * * `GALLERY` - Gallery Image
+ * * `BACKGROUND` - Background Image
+ * * `HERO` - Hero Image
+ * * `FEATURE` - Feature Image
+ * * `PROMOTIONAL` - Promotional Image
+ * * `SEASONAL` - Seasonal Image
  */
 export type ImageTypeEnum = 'MAIN' | 'BANNER' | 'ICON' | 'THUMBNAIL' | 'GALLERY' | 'BACKGROUND' | 'HERO' | 'FEATURE' | 'PROMOTIONAL' | 'SEASONAL'
 
@@ -2643,15 +2161,11 @@ export type ImageTypeEnum = 'MAIN' | 'BANNER' | 'ICON' | 'THUMBNAIL' | 'GALLERY'
  */
 export type InvoiceDownloadResponse = {
   /**
-     * Αριθμός τιμολογίου
-     *
-     * Διαδοχικό αναγνωριστικό στη μορφή ``INV-{YEAR}-{NNNNNN}``. Δεν επιτρέπονται κενά βάσει της ελληνικής φορολογικής νομοθεσίας.
+     * Sequential identifier in the form ``INV-{YEAR}-{NNNNNN}``. Gaps are not allowed by Greek tax law.
      */
   readonly invoiceNumber: string
   /**
-     * Ημερομηνία έκδοσης
-     *
-     * Φορολογική ημερομηνία έκδοσης. Αμετάβλητη μόλις εκδοθεί το τιμολόγιο — χρησιμοποιείται για διαδοχική αρίθμηση και αναφορές.
+     * Fiscal date of issue. Immutable once the invoice is rendered — used for sequential numbering and reporting.
      */
   readonly issueDate: string
   /**
@@ -2668,22 +2182,17 @@ export type InvoiceDownloadResponse = {
   readonly subtotal: string | null
   readonly totalVat: string | null
   readonly total: string | null
-  /**
-     * Νόμισμα
-     */
   readonly currency: string
   /**
-     * Ανάλυση ΦΠΑ
-     *
-     * Λίστα σε cache από γραμμές ``{rate, subtotal, vat, gross}`` — παγιωμένη τη στιγμή της έκδοσης, ώστε η εκ νέου απόδοση του τιμολογίου να δίνει πάντα τον ίδιο πίνακα ΦΠΑ ακόμη κι αν αλλάξουν οι συντελεστές των προϊόντων.
+     * Cached list of ``{rate, subtotal, vat, gross}`` rows — frozen at issue time so re-rendering the invoice always yields the same VAT table even if product rates change.
      */
   readonly vatBreakdown: unknown
 }
 
 /**
- * * `HOME` - Σπίτι
- * * `OFFICE` - Γραφείο
- * * `OTHER` - Άλλο
+ * * `HOME` - Αρχική
+ * * `OFFICE` - Office
+ * * `OTHER` - Other
  */
 export type LocationTypeEnum = 'HOME' | 'OFFICE' | 'OTHER'
 
@@ -2735,20 +2244,13 @@ export type LoyaltyTier = {
     }
   }
   /**
-     * Απαιτούμενο επίπεδο
-     *
-     * Ελάχιστο επίπεδο για την επίτευξη αυτού του tier
+     * Minimum level to achieve this tier
      */
   readonly requiredLevel: number
   /**
-     * Πολλαπλασιαστής πόντων
-     *
-     * Πολλαπλασιαστής που εφαρμόζεται στους πόντους που κερδίζουν οι χρήστες σε αυτό το tier
+     * Multiplier applied to earned points for users in this tier
      */
   readonly pointsMultiplier: number
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
   readonly mainImagePath: string
   readonly iconFilename: string
@@ -2774,81 +2276,61 @@ export type Notification = {
   }
   readonly id: number
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly link: string | null
-  /**
-     * Είδος
-     */
   kind?: NotificationKindEnum
-  /**
-     * Κατηγορία
-     */
   category?: NotificationCategory
-  /**
-     * Προτεραιότητα
-     */
   priority?: PriorityEnum
   /**
-     * Τύπος ειδοποίησης
+     * Fine-grained event identifier. See ``notification.enum.NotificationTypeEnum`` for the full catalogue. Left blank for ad-hoc admin broadcasts.
      *
-     * Λεπτομερές αναγνωριστικό συμβάντος. Δείτε ``notification.enum.NotificationTypeEnum`` για τον πλήρη κατάλογο. Αφήνεται κενό για περιστασιακές ανακοινώσεις διαχειριστή.
-     *
-     * * `order_created` - Η παραγγελία δημιουργήθηκε
-     * * `order_processing` - Επεξεργασία παραγγελίας
-     * * `order_shipped` - Η παραγγελία απεστάλη
-     * * `order_delivered` - Η παραγγελία παραδόθηκε
-     * * `order_completed` - Η παραγγελία ολοκληρώθηκε
-     * * `order_canceled` - Η παραγγελία ακυρώθηκε
-     * * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-     * * `shipment_dispatched` - Αποστολή απεστάλη
-     * * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-     * * `payment_failed` - Η πληρωμή απέτυχε
-     * * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-     * * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-     * * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-     * * `comment_liked` - Επισήμανση σχολίου blog
-     * * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-     * * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-     * * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+     * * `order_created` - Order created
+     * * `order_processing` - Order processing
+     * * `order_shipped` - Order shipped
+     * * `order_delivered` - Order delivered
+     * * `order_completed` - Order completed
+     * * `order_canceled` - Order canceled
+     * * `order_refunded` - Order refunded
+     * * `shipment_dispatched` - Shipment dispatched
+     * * `payment_confirmed` - Payment confirmed
+     * * `payment_failed` - Payment failed
+     * * `price_drop_favourite` - Price drop (favourited product)
+     * * `restock_favourite` - Back in stock (favourited product)
+     * * `loyalty_tier_up` - Loyalty tier promotion
+     * * `comment_liked` - Blog comment liked
+     * * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+     * * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+     * * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
      */
   notificationType?: NotificationTypeEnum | BlankEnum
-  /**
-     * Ημερομηνία Λήξης
-     */
   expiryDate?: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 /**
- * * `ORDER` - Παραγγελία
- * * `PAYMENT` - Πληρωμή
- * * `SHIPPING` - Μεταφορικά
- * * `CART` - Καλάθι
- * * `PRODUCT` - Προϊόν
- * * `ACCOUNT` - Λογαριασμός Ανενεργός
- * * `SECURITY` - Ασφάλεια
- * * `PROMOTION` - Προσφορά
- * * `SYSTEM` - Σύστημα
- * * `REVIEW` - Εξέταση
- * * `WISHLIST` - Λίστα επιθυμιών
- * * `SUPPORT` - Υποστήριξη
+ * * `ORDER` - Ταξινόμηση
+ * * `PAYMENT` - Payment
+ * * `SHIPPING` - Shipping
+ * * `CART` - Cart
+ * * `PRODUCT` - Product
+ * * `ACCOUNT` - Account
+ * * `SECURITY` - Security
+ * * `PROMOTION` - Promotion
+ * * `SYSTEM` - System
+ * * `REVIEW` - Review
+ * * `WISHLIST` - Wishlist
+ * * `SUPPORT` - Support
  * * `NEWSLETTER` - Newsletter
- * * `RECOMMENDATION` - Σύσταση
+ * * `RECOMMENDATION` - Recommendation
  */
 export type NotificationCategory = 'ORDER' | 'PAYMENT' | 'SHIPPING' | 'CART' | 'PRODUCT' | 'ACCOUNT' | 'SECURITY' | 'PROMOTION' | 'SYSTEM' | 'REVIEW' | 'WISHLIST' | 'SUPPORT' | 'NEWSLETTER' | 'RECOMMENDATION'
 
 export type NotificationCountResponse = {
   /**
-     * Αριθμός μη ορατών ειδοποιήσεων
+     * Number of unseen notifications
      */
   count: number
 }
@@ -2859,38 +2341,38 @@ export type NotificationIdsRequest = {
 
 /**
  * * `ERROR` - Σφάλμα
- * * `SUCCESS` - Επιτυχία
- * * `INFO` - Πληροφορία
- * * `WARNING` - Προειδοποίηση
- * * `DANGER` - Κίνδυνος
+ * * `SUCCESS` - Success
+ * * `INFO` - Info
+ * * `WARNING` - Warning
+ * * `DANGER` - Danger
  */
 export type NotificationKindEnum = 'ERROR' | 'SUCCESS' | 'INFO' | 'WARNING' | 'DANGER'
 
 export type NotificationSuccessResponse = {
   /**
-     * Αν η λειτουργία ήταν επιτυχής
+     * Whether the operation was successful
      */
   success?: boolean
 }
 
 /**
- * * `order_created` - Η παραγγελία δημιουργήθηκε
- * * `order_processing` - Επεξεργασία παραγγελίας
- * * `order_shipped` - Η παραγγελία απεστάλη
- * * `order_delivered` - Η παραγγελία παραδόθηκε
- * * `order_completed` - Η παραγγελία ολοκληρώθηκε
- * * `order_canceled` - Η παραγγελία ακυρώθηκε
- * * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
- * * `shipment_dispatched` - Αποστολή απεστάλη
- * * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
- * * `payment_failed` - Η πληρωμή απέτυχε
- * * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
- * * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
- * * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
- * * `comment_liked` - Επισήμανση σχολίου blog
- * * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
- * * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
- * * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+ * * `order_created` - Order created
+ * * `order_processing` - Order processing
+ * * `order_shipped` - Order shipped
+ * * `order_delivered` - Order delivered
+ * * `order_completed` - Order completed
+ * * `order_canceled` - Order canceled
+ * * `order_refunded` - Order refunded
+ * * `shipment_dispatched` - Shipment dispatched
+ * * `payment_confirmed` - Payment confirmed
+ * * `payment_failed` - Payment failed
+ * * `price_drop_favourite` - Price drop (favourited product)
+ * * `restock_favourite` - Back in stock (favourited product)
+ * * `loyalty_tier_up` - Loyalty tier promotion
+ * * `comment_liked` - Blog comment liked
+ * * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+ * * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+ * * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
  */
 export type NotificationTypeEnum = 'order_created' | 'order_processing' | 'order_shipped' | 'order_delivered' | 'order_completed' | 'order_canceled' | 'order_refunded' | 'shipment_dispatched' | 'payment_confirmed' | 'payment_failed' | 'price_drop_favourite' | 'restock_favourite' | 'loyalty_tier_up' | 'comment_liked' | 'BOXNOW_PARCEL_AT_LOCKER' | 'BOXNOW_PARCEL_DELIVERED' | 'ACS_OUT_FOR_DELIVERY'
 
@@ -2898,28 +2380,16 @@ export type NotificationUser = {
   readonly id: number
   readonly user: number
   readonly notification: number
-  /**
-     * Ορατό
-     */
   seen?: boolean
-  /**
-     * Ορατό στις
-     */
   seenAt?: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type NotificationUserActionRequest = {
   /**
-     * Λίστα ID χρηστών ειδοποίησης προς σήμανση ως ορατά/μη ορατά
+     * List of notification user IDs to mark as seen/unseen
      */
   notificationUserIds: Array<number>
 }
@@ -2928,29 +2398,14 @@ export type NotificationUserDetail = {
   readonly id: number
   user: UserDetails
   notification: Notification
-  /**
-     * Ορατό
-     */
   seen?: boolean
-  /**
-     * Ορατό στις
-     */
   seenAt?: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type NotificationUserWriteRequest = {
-  /**
-     * Ορατό
-     */
   seen?: boolean
 }
 
@@ -2958,100 +2413,46 @@ export type Order = {
   readonly id: number
   user?: number | null
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
   payWay: number | null
-  /**
-     * Κατάσταση
-     */
   status?: OrderStatus
   readonly statusDisplay: string
-  /**
-     * Κατάσταση ενημερώθηκε στις
-     */
   readonly statusUpdatedAt: string | null
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
   email: string
-  /**
-     * Τ.Κ.
-     */
   zipcode: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city: string
   phone: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   readonly paidAmount: number
   items: Array<OrderItemDetail>
   readonly shippingPrice: number
   readonly paymentMethodFee: number
-  /**
-     * Τύπος Εγγράφου
-     */
   documentType?: OrderDocumentType
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly totalPriceItems: number
   readonly totalPriceExtra: number
   readonly fullAddress: string
-  /**
-     * ID πληρωμής
-     */
   paymentId?: string | null
-  /**
-     * Κατάσταση πληρωμής
-     */
   paymentStatus?: PaymentStatusEnum | BlankEnum
   /**
      * Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
      */
   readonly paymentStatusDisplay: string
-  /**
-     * Μέθοδος πληρωμής
-     */
   paymentMethod?: string
   /**
      * True when the order's PayWay charges the shopper online (Stripe, Viva); false for cash-on-delivery / bank transfer. Surfaced on both list + detail so both views can suppress misleading 'outstanding amount' warnings for COD orders where the shopper intentionally paid €0 at checkout.
@@ -3062,8 +2463,8 @@ export type Order = {
 }
 
 /**
- * * `RECEIPT` - Απόδειξη
- * * `INVOICE` - Τιμολόγιο
+ * * `RECEIPT` - Receipt
+ * * `INVOICE` - Invoice
  */
 export type OrderCreateDocumentType = 'RECEIPT' | 'INVOICE'
 
@@ -3079,120 +2480,120 @@ export type OrderCreateDocumentType = 'RECEIPT' | 'INVOICE'
  */
 export type OrderCreateFromCartRequest = {
   /**
-     * ID μεθόδου πληρωμής
+     * Payment method ID
      */
   payWayId: number
   /**
-     * ID payment intent από τον πάροχο πληρωμών (υποχρεωτικό για online πληρωμές)
+     * Payment intent ID from payment provider (required for online payments)
      */
   paymentIntentId?: string | null
   /**
-     * Όνομα πελάτη
+     * Customer first name
      */
   firstName: string
   /**
-     * Επώνυμο πελάτη
+     * Customer last name
      */
   lastName: string
   /**
-     * Email πελάτη
+     * Customer email address
      */
   email: string
   /**
-     * Όνομα οδού
+     * Street name
      */
   street: string
   /**
-     * Αριθμός οδού
+     * Street number
      */
   streetNumber?: string
   /**
-     * Όνομα πόλης
+     * City name
      */
   city: string
   /**
-     * Ταχυδρομικός κώδικας
+     * Postal/ZIP code
      */
   zipcode: string
   /**
-     * Κωδικός χώρας alpha-2 (π.χ. 'GR', 'US')
+     * Country alpha-2 code (e.g., 'GR', 'US')
      */
   countryId: string
   /**
-     * Αλφαριθμητικός κωδικός περιφέρειας
+     * Region alpha code
      */
   regionId?: string | null
   /**
-     * Τηλέφωνο πελάτη
+     * Customer phone number
      */
   phone: string
   /**
-     * Σημειώσεις πελάτη ή ειδικές οδηγίες
+     * Customer notes or special instructions
      */
   customerNotes?: string
   /**
-     * Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)
+     * Floor number or label (e.g. FIRST_FLOOR)
      */
   floor?: string
   /**
-     * Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)
+     * Location type, e.g. HOME or OFFICE (optional)
      */
   locationType?: string
   /**
-     * ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.
+     * Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.
      */
   billingVatId?: string
   /**
-     * Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.
+     * ISO 3166-1 alpha-2 country code for the buyer's tax identity. Defaults to the order country when blank.
      */
   billingCountry?: string
   /**
-     * RECEIPT (Α.Λ.Π., Tier A — λιανική) ή INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Η επιλογή INVOICE απαιτεί έγκυρο ``billing_vat_id``.
+     * RECEIPT (Α.Λ.Π., Tier A — retail) or INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Selecting INVOICE requires a valid ``billing_vat_id``.
      *
-     * * `RECEIPT` - Απόδειξη
-     * * `INVOICE` - Τιμολόγιο
+     * * `RECEIPT` - Receipt
+     * * `INVOICE` - Invoice
      */
   documentType?: OrderCreateDocumentType
   /**
-     * Αριθμός πόντων πιστότητας προς εξαργύρωση για έκπτωση σε αυτή την παραγγελία
+     * Number of loyalty points to redeem for discount on this order
      */
   loyaltyPointsToRedeem?: number | null
   /**
-     * ID locker APM BoxNow από το widget
+     * BoxNow APM locker ID from the widget
      */
   boxnowLockerId?: string
   /**
-     * Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο
+     * BoxNow compartment size: 1=Small, 2=Medium, 3=Large
      */
   boxnowCompartmentSize?: number
   /**
-     * Κωδικός μεταφορέα από /api/v1/shipping/options (π.χ. 'acs').
+     * Carrier code from /api/v1/shipping/options (e.g. 'acs').
      */
   shippingProviderCode?: string | string
   /**
-     * Γενικός τύπος εκπλήρωσης, ανεξάρτητος από τον πάροχο.
+     * Generic fulfilment kind, independent of provider.
      *
-     * * `home_delivery` - Κατ' οίκον παράδοση
-     * * `pickup_point` - Σημείο παραλαβής / locker
+     * * `home_delivery` - Home delivery
+     * * `pickup_point` - Pickup point / locker
      */
   shippingKind?: ShippingKind
   /**
-     * Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).
+     * ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).
      */
   acsStationExternalId?: string
   /**
-     * Τιμή ACS_Station_Branch_Destination.
+     * ACS_Station_Branch_Destination value.
      */
   acsStationBranch?: string
   /**
-     * Προαιρετική παράκαμψη του ACS Charge_Type ανά παραγγελία. Αφήστε το κενό για χρήση της προεπιλογής σε επίπεδο μεταφορέα (COD σε σύμβαση μόνο-COD). Ο ορισμός εδώ έχει νόημα μόνο αν η εμπορική σύμβαση με την ACS επιτρέπει την επιλεγμένη τιμή — μη έγκυροι συνδυασμοί απορρίπτονται από το ACS_Create_Voucher.
+     * Optional per-order ACS Charge_Type override. Leave unset to use the carrier-level default (COD on a COD-only contract). Setting this here only makes sense if the ACS commercial contract permits the chosen value — invalid combinations are rejected by ACS_Create_Voucher.
      *
-     * * `1` - Προπληρωμένο
-     * * `2` - Αντικαταβολή
+     * * `1` - Prepaid
+     * * `2` - Cash on delivery
      */
   acsChargeType?: AcsChargeType
   /**
-     * Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.
+     * Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.
      */
   acsItemQuantity?: number
 }
@@ -3201,100 +2602,46 @@ export type OrderDetail = {
   readonly id: number
   user?: number | null
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
   payWay: number | null
-  /**
-     * Κατάσταση
-     */
   status?: OrderStatus
   readonly statusDisplay: string
-  /**
-     * Κατάσταση ενημερώθηκε στις
-     */
   readonly statusUpdatedAt: string | null
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
   email: string
-  /**
-     * Τ.Κ.
-     */
   zipcode: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city: string
   readonly phone: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   readonly paidAmount: number
   items: Array<OrderItemDetail>
   readonly shippingPrice: number
   readonly paymentMethodFee: number
-  /**
-     * Τύπος Εγγράφου
-     */
   documentType?: OrderDocumentType
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly totalPriceItems: number
   readonly totalPriceExtra: number
   readonly fullAddress: string
-  /**
-     * ID πληρωμής
-     */
   paymentId?: string | null
-  /**
-     * Κατάσταση πληρωμής
-     */
   paymentStatus?: PaymentStatusEnum | BlankEnum
   /**
      * Localised label for ``payment_status`` (mirrors ``status_display``). Frontend renders this rather than the raw enum value so Greek/English/German locales all work without per-locale string maps in the UI.
      */
   readonly paymentStatusDisplay: string
-  /**
-     * Μέθοδος πληρωμής
-     */
   paymentMethod?: string
   /**
      * True when the order's PayWay charges the shopper online (Stripe, Viva); false for cash-on-delivery / bank transfer. Surfaced on both list + detail so both views can suppress misleading 'outstanding amount' warnings for COD orders where the shopper intentionally paid €0 at checkout.
@@ -3369,13 +2716,7 @@ export type OrderDetail = {
       error?: string | null
     } | null
   } | null
-  /**
-     * Αριθμός Παρακολούθησης
-     */
   trackingNumber?: string
-  /**
-     * Εταιρεία μεταφοράς
-     */
   shippingCarrier?: string
   readonly customerFullName: string
   readonly isCompleted: boolean
@@ -3393,12 +2734,12 @@ export type OrderDetail = {
 }
 
 /**
- * * `RECEIPT` - Απόδειξη
- * * `INVOICE` - Τιμολόγιο
- * * `PROFORMA` - Προτιμολόγιο
- * * `SHIPPING_LABEL` - Ετικέτα αποστολής
- * * `RETURN_LABEL` - Ετικέτα επιστροφής
- * * `CREDIT_NOTE` - Πιστωτικό
+ * * `RECEIPT` - Receipt
+ * * `INVOICE` - Invoice
+ * * `PROFORMA` - Proforma Invoice
+ * * `SHIPPING_LABEL` - Shipping Label
+ * * `RETURN_LABEL` - Return Label
+ * * `CREDIT_NOTE` - Credit Note
  */
 export type OrderDocumentType = 'RECEIPT' | 'INVOICE' | 'PROFORMA' | 'SHIPPING_LABEL' | 'RETURN_LABEL' | 'CREDIT_NOTE'
 
@@ -3408,39 +2749,18 @@ export type OrderItem = {
   order: number
   product: number
   readonly price: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Έχει επιστραφεί
-     */
   readonly isRefunded: boolean
-  /**
-     * Επιστραφείσα ποσότητα
-     */
   readonly refundedQuantity: number
   readonly netQuantity: number
   readonly totalPrice: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
 export type OrderItemCreateRequest = {
   product: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Σημειώσεις
-     */
   notes?: string
 }
 
@@ -3450,51 +2770,27 @@ export type OrderItemDetail = {
   order: number
   product: Product
   readonly price: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Έχει επιστραφεί
-     */
   readonly isRefunded: boolean
-  /**
-     * Επιστραφείσα ποσότητα
-     */
   readonly refundedQuantity: number
   readonly netQuantity: number
   readonly totalPrice: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Αρχική ποσότητα
-     */
   readonly originalQuantity: number | null
   readonly refundedAmount: number
   readonly netPrice: number
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
-  /**
-     * Σημειώσεις
-     */
   notes?: string
 }
 
 export type OrderItemRefundRequest = {
   /**
-     * Ποσότητα προς επιστροφή. Αν δεν δοθεί, επιστρέφονται όλα.
+     * Quantity to refund. If not provided, refunds all.
      */
   quantity?: number
   /**
-     * Προαιρετική αιτία επιστροφής
+     * Optional reason for the refund
      */
   reason?: string
 }
@@ -3508,78 +2804,42 @@ export type OrderItemRefundResponse = {
 export type OrderItemWriteRequest = {
   order: number
   product: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Σημειώσεις
-     */
   notes?: string
 }
 
 /**
- * * `PENDING` - Εκκρεμεί
- * * `PROCESSING` - Σε επεξεργασία
- * * `SHIPPED` - Απεστάλη
- * * `DELIVERED` - Παραδόθηκε
- * * `COMPLETED` - Ολοκληρώθηκε
- * * `CANCELED` - Ακυρώθηκε
- * * `RETURNED` - Επιστράφηκε
- * * `REFUNDED` - Επιστροφή Χρημάτων
+ * * `PENDING` - Pending
+ * * `PROCESSING` - Processing
+ * * `SHIPPED` - Shipped
+ * * `DELIVERED` - Delivered
+ * * `COMPLETED` - Completed
+ * * `CANCELED` - Canceled
+ * * `RETURNED` - Returned
+ * * `REFUNDED` - Refunded
  */
 export type OrderStatus = 'PENDING' | 'PROCESSING' | 'SHIPPED' | 'DELIVERED' | 'COMPLETED' | 'CANCELED' | 'RETURNED' | 'REFUNDED'
 
 export type OrderWriteRequest = {
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
   email: string
-  /**
-     * Τ.Κ.
-     */
   zipcode: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city: string
   phone: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   items: Array<OrderItemCreateRequest>
 }
@@ -4042,9 +3302,6 @@ export type PatchedBlogAuthorWriteRequest = {
     }
   }
   user?: number
-  /**
-     * Ιστότοπος
-     */
   website?: string | string
 }
 
@@ -4118,25 +3375,10 @@ export type PatchedBlogPostWriteRequest = {
   category?: number
   tags?: Array<number>
   author?: number
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -4155,16 +3397,10 @@ export type PatchedBlogTagWriteRequest = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
 export type PatchedCartItemUpdateRequest = {
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
@@ -4184,93 +3420,51 @@ export type PatchedCountryWriteRequest = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2?: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3?: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
 }
 
 export type PatchedNotificationUserWriteRequest = {
-  /**
-     * Ορατό
-     */
   seen?: boolean
 }
 
 export type PatchedOrderItemWriteRequest = {
   order?: number
   product?: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Σημειώσεις
-     */
   notes?: string
 }
 
 export type PatchedOrderWriteRequest = {
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street?: string
-  /**
-     * Αριθμός
-     */
   streetNumber?: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
   email?: string
-  /**
-     * Τ.Κ.
-     */
   zipcode?: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city?: string
   phone?: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   items?: Array<OrderItemCreateRequest>
 }
@@ -4296,38 +3490,26 @@ export type PatchedPayWayWriteRequest = {
       instructions?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost?: number
   freeThreshold?: number
-  /**
-     * Εικονίδιο
-     */
   icon?: Blob | File | null
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
   /**
-     * Διαμόρφωση Παρόχου
+     * Provider Configuration
      *
-     * Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+     * Provider-specific configuration (API keys, webhooks, etc.)
      */
   configuration?: unknown
 }
@@ -4347,13 +3529,7 @@ export type PatchedProductCategoryImageWriteRequest = {
      * Εικόνα
      */
   image?: Blob | File
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
   translations?: {
     el?: {
@@ -4390,22 +3566,10 @@ export type PatchedProductCategoryWriteRequest = {
     }
   }
   slug?: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -4422,9 +3586,6 @@ export type PatchedProductImageWriteRequest = {
      * Εικόνα
      */
   image?: Blob | File
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   translations?: {
     el?: {
@@ -4444,9 +3605,6 @@ export type PatchedProductImageWriteRequest = {
  */
 export type PatchedProductReviewWriteRequest = {
   product?: number
-  /**
-     * Συντ.
-     */
   rate?: RateEnum
   translations?: {
     el?: {
@@ -4484,33 +3642,15 @@ export type PatchedProductWriteRequest = {
   brand?: number | null
   price?: number
   vat?: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -4530,11 +3670,11 @@ export type PatchedRegionWriteRequest = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha?: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string
 }
@@ -4558,39 +3698,35 @@ export type PatchedSubscriptionTopicWriteRequest = {
     }
   }
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug?: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
 }
@@ -4610,9 +3746,6 @@ export type PatchedTagWriteRequest = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -4622,57 +3755,27 @@ export type PatchedTaggedItemWriteRequest = {
 }
 
 export type PatchedUserAddressWriteRequest = {
-  /**
-     * Τίτλος
-     */
   title?: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
-  /**
-     * Οδός
-     */
   street?: string
-  /**
-     * Αριθμός
-     */
   streetNumber?: string
-  /**
-     * Πόλη
-     */
   city?: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode?: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone?: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string
 }
@@ -4680,25 +3783,17 @@ export type PatchedUserAddressWriteRequest = {
 export type PatchedUserSubscriptionWriteRequest = {
   topic?: number
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
 }
 
 export type PatchedUserWriteRequest = {
   /**
-     * Διεύθυνση Email
+     * Διεύθυνση ηλεκτρονικού ταχυδρομείου
      */
   email?: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
   /**
      * Όνομα χρήστη
@@ -4711,70 +3806,52 @@ export type PatchedUserWriteRequest = {
      */
   image?: Blob | File | null
   phone?: string | null
-  /**
-     * Πόλη
-     */
   city?: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode?: string
-  /**
-     * Διεύθυνση
-     */
   address?: string
-  /**
-     * Τόπος
-     */
   place?: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Ημ/νία γέννησης
-     */
   birthDate?: string | null
   /**
-     * Προφίλ Twitter
+     * Twitter Profile
      */
   twitter?: string | string | null
   /**
-     * Προφίλ LinkedIn
+     * LinkedIn Profile
      */
   linkedin?: string | string | null
   /**
-     * Προφίλ Facebook
+     * Facebook Profile
      */
   facebook?: string | string | null
   /**
-     * Προφίλ Instagram
+     * Instagram Profile
      */
   instagram?: string | string | null
-  /**
-     * Ιστότοπος
-     */
   website?: string | string | null
   /**
-     * Προφίλ Youtube
+     * Youtube Profile
      */
   youtube?: string | string | null
   /**
-     * Προφίλ Github
+     * Github Profile
      */
   github?: string | string | null
-  /**
-     * Βιογραφικό
-     */
   bio?: string
   /**
-     * Γλώσσα
+     * Language
      *
-     * Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+     * Preferred language for emails and UI messages.
      */
   languageCode?: string
 }
@@ -4801,47 +3878,26 @@ export type PayWay = {
     }
   }
   readonly id: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost: number
   freeThreshold: number
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly iconFilename: string
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
 }
@@ -4868,47 +3924,26 @@ export type PayWayDetail = {
     }
   }
   readonly id: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost: number
   freeThreshold: number
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly iconFilename: string
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
   readonly configuration: unknown
@@ -4935,56 +3970,44 @@ export type PayWayWriteRequest = {
       instructions?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost: number
   freeThreshold?: number
-  /**
-     * Εικονίδιο
-     */
   icon?: Blob | File | null
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
   /**
-     * Διαμόρφωση Παρόχου
+     * Provider Configuration
      *
-     * Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)
+     * Provider-specific configuration (API keys, webhooks, etc.)
      */
   configuration?: unknown
 }
 
 /**
- * * `prepaid` - Προπληρωμένο
- * * `cod` - Αντικαταβολή
+ * * `prepaid` - Prepaid
+ * * `cod` - Cash on delivery
  */
 export type PaymentModeEnum = 'prepaid' | 'cod'
 
 /**
- * * `PENDING` - Εκκρεμεί
- * * `PROCESSING` - Σε επεξεργασία
- * * `COMPLETED` - Ολοκληρώθηκε
- * * `FAILED` - Απέτυχε
- * * `REFUNDED` - Επιστροφή Χρημάτων
- * * `PARTIALLY_REFUNDED` - Μερική επιστροφή
- * * `CANCELED` - Ακυρώθηκε
+ * * `PENDING` - Pending
+ * * `PROCESSING` - Processing
+ * * `COMPLETED` - Completed
+ * * `FAILED` - Failed
+ * * `REFUNDED` - Refunded
+ * * `PARTIALLY_REFUNDED` - Partially Refunded
+ * * `CANCELED` - Canceled
  */
 export type PaymentStatusEnum = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED' | 'REFUNDED' | 'PARTIALLY_REFUNDED' | 'CANCELED'
 
@@ -5020,32 +4043,21 @@ export type PerformanceMetrics = {
 export type PointsTransaction = {
   readonly id: number
   /**
-     * Πόντοι
-     *
-     * Θετικό για κέρδος/μπόνους, αρνητικό για εξαργύρωση/λήξη/προσαρμογή
+     * Positive for earn/bonus, negative for redeem/expire/adjust
      */
   readonly points: number
-  /**
-     * Τύπος συναλλαγής
-     */
   transactionType: TransactionTypeEnum
   readonly referenceOrder: number | null
-  /**
-     * Περιγραφή
-     */
   readonly description: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
 }
 
 /**
- * * `LOW` - Χαμηλή προτεραιότητα
- * * `NORMAL` - Κανονική προτεραιότητα
- * * `HIGH` - Υψηλή προτεραιότητα
- * * `URGENT` - Επείγουσα προτεραιότητα
- * * `CRITICAL` - Κρίσιμη προτεραιότητα
+ * * `LOW` - Low Priority
+ * * `NORMAL` - Normal Priority
+ * * `HIGH` - High Priority
+ * * `URGENT` - Urgent Priority
+ * * `CRITICAL` - Critical Priority
  */
 export type PriorityEnum = 'LOW' | 'NORMAL' | 'HIGH' | 'URGENT' | 'CRITICAL'
 
@@ -5071,50 +4083,27 @@ export type Product = {
   slug: string
   category: number
   /**
-     * Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+     * Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
      */
   readonly variantGroup: number | null
   readonly brand: number | null
   readonly brandName: string | null
   price: number
   vat: number
-  /**
-     * Προβολές
-     */
   readonly viewCount: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
   /**
-     * Όριο χαμηλού αποθέματος
-     *
-     * Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+     * Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
      */
   readonly lowStockThreshold: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
   readonly discountValue: number
   readonly priceSavePercent: number
@@ -5134,13 +4123,7 @@ export type Product = {
      * Return the number of likes/favourites for this product.
      */
   readonly likesCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly attributes: Array<ProductAttribute>
@@ -5149,42 +4132,24 @@ export type Product = {
 export type ProductAlert = {
   readonly id: number
   readonly uuid: string
-  /**
-     * Είδος
-     */
   kind: ProductAlertKindEnum
   product: number
   readonly user: number | null
   email?: string | null
   targetPrice?: number | null
-  /**
-     * Ενεργό
-     */
   readonly isActive: boolean
-  /**
-     * Ειδοποιήθηκε στις
-     */
   readonly notifiedAt: string | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
 /**
- * * `restock` - Αναπλήρωση
- * * `price_drop` - Πτώση τιμής
+ * * `restock` - Restock
+ * * `price_drop` - Price drop
  */
 export type ProductAlertKindEnum = 'restock' | 'price_drop'
 
 export type ProductAlertRequest = {
-  /**
-     * Είδος
-     */
   kind: ProductAlertKindEnum
   product: number
   email?: string | null
@@ -5206,9 +4171,6 @@ export type ProductAttribute = {
      * Return translated attribute value.
      */
   readonly value: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
 }
 
@@ -5242,20 +4204,11 @@ export type ProductCategory = {
     }
   }
   slug: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
   readonly level: number
   readonly treeId: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -5280,35 +4233,17 @@ export type ProductCategoryDetail = {
     }
   }
   slug: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
   readonly level: number
   readonly treeId: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly children: Array<ProductCategory>
   readonly recursiveProductCount: number
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -5323,17 +4258,8 @@ export type ProductCategoryImage = {
      * Εικόνα
      */
   image: string
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   translations: {
     el?: {
@@ -5351,13 +4277,7 @@ export type ProductCategoryImage = {
   }
   readonly imagePath: string
   readonly imageUrl: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -5379,17 +4299,8 @@ export type ProductCategoryImageDetail = {
      * Εικόνα
      */
   image: string
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   translations: {
     el?: {
@@ -5407,13 +4318,7 @@ export type ProductCategoryImageDetail = {
   }
   readonly imagePath: string
   readonly imageUrl: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -5427,13 +4332,7 @@ export type ProductCategoryImageWriteRequest = {
      * Εικόνα
      */
   image: Blob | File
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
   translations: {
     el?: {
@@ -5470,22 +4369,10 @@ export type ProductCategoryWriteRequest = {
     }
   }
   slug: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -5511,50 +4398,27 @@ export type ProductDetail = {
   slug: string
   category: number
   /**
-     * Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+     * Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
      */
   readonly variantGroup: number | null
   readonly brand: number | null
   readonly brandName: string | null
   price: number
   vat: number
-  /**
-     * Προβολές
-     */
   readonly viewCount: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
   /**
-     * Όριο χαμηλού αποθέματος
-     *
-     * Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+     * Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
      */
   readonly lowStockThreshold: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
   readonly discountValue: number
   readonly priceSavePercent: number
@@ -5574,20 +4438,12 @@ export type ProductDetail = {
      * Return the number of likes/favourites for this product.
      */
   readonly likesCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly attributes: Array<ProductAttribute>
   /**
-     * Ειδοποιήσεις πτώσης τιμής
-     *
-     * Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+     * When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
      */
   readonly priceDropAlertsEnabled: boolean
 }
@@ -5614,50 +4470,27 @@ export type ProductDetailResponse = {
   slug: string
   category: number
   /**
-     * Συνδέει αυτό το προϊόν με τις αδερφές παραλλαγές του (π.χ. το ίδιο είδος σε άλλα χρώματα). Τα μέλη μοιράζονται επιλογείς παραλλαγής στο κατάστημα.
+     * Links this product to its sibling variations (e.g. the same item in other colours). Members share variant selectors on the storefront.
      */
   readonly variantGroup: number | null
   readonly brand: number | null
   readonly brandName: string | null
   price: number
   vat: number
-  /**
-     * Προβολές
-     */
   readonly viewCount: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
   /**
-     * Όριο χαμηλού αποθέματος
-     *
-     * Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.
+     * Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.
      */
   readonly lowStockThreshold: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
   readonly discountValue: number
   readonly priceSavePercent: number
@@ -5677,20 +4510,12 @@ export type ProductDetailResponse = {
      * Return the number of likes/favourites for this product.
      */
   readonly likesCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly attributes: Array<ProductAttribute>
   /**
-     * Ειδοποιήσεις πτώσης τιμής
-     *
-     * Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.
+     * When enabled, customers can subscribe to a one-time email when this product's price drops below a target. Disabled by default — admins opt products in per SKU.
      */
   readonly priceDropAlertsEnabled: boolean
 }
@@ -5700,16 +4525,13 @@ export type ProductFavourite = {
   readonly userId: number
   readonly userUsername: string
   product: ProductDetail
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
   readonly uuid: string
 }
 
 export type ProductFavouriteByProductsRequestRequest = {
   /**
-     * Λίστα ID προϊόντων για έλεγχο αγαπημένων
+     * List of product IDs to check for favorites
      */
   productIds: Array<number>
 }
@@ -5726,15 +4548,9 @@ export type ProductFavouriteDetail = {
   readonly userId: number
   readonly userUsername: string
   product: ProductDetail
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
   readonly uuid: string
   readonly user: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -5761,13 +4577,7 @@ export type ProductImage = {
   readonly imageUrl: string
   readonly imageSizeKb: number
   readonly altText: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   translations: {
     el?: {
@@ -5781,9 +4591,6 @@ export type ProductImage = {
     }
   }
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
 }
 
@@ -5801,13 +4608,7 @@ export type ProductImageDetail = {
   readonly imageUrl: string
   readonly imageSizeKb: number
   readonly altText: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   translations: {
     el?: {
@@ -5821,9 +4622,6 @@ export type ProductImageDetail = {
     }
   }
   readonly mainImagePath: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
   readonly imageDimensions: {
     width?: number
@@ -5837,9 +4635,6 @@ export type ProductImageDetail = {
     totalProductImages?: number
     recommendedFor?: string
   }
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -5852,9 +4647,6 @@ export type ProductImageWriteRequest = {
      * Εικόνα
      */
   image: Blob | File
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   translations: {
     el?: {
@@ -5869,7 +4661,23 @@ export type ProductImageWriteRequest = {
   }
 }
 
+/**
+ * Common disclosure fields every search response carries.
+ *
+ * ``query_id`` attributes later clicks to this query (see the
+ * ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+ * query the zero-result fallback actually matched, so clients can
+ * disclose "showing results for …" instead of silently swapping.
+ */
 export type ProductMeiliSearchResponse = {
+  /**
+     * Identifier for this search, used to attribute clicks
+     */
+  queryId: string
+  /**
+     * The relaxed query used by the zero-result fallback, or null when results matched the original query
+     */
+  relaxedQuery: string | null
   limit: number
   offset: number
   estimatedTotalHits: number
@@ -5935,29 +4743,11 @@ export type ProductReview = {
   readonly id: number
   product: ProductBrief
   user: UserDetails
-  /**
-     * Συντ.
-     */
   rate: RateEnum
-  /**
-     * Κατάσταση
-     */
   status?: ReviewStatus
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Δημοσιεύθηκε στις
-     */
   readonly publishedAt: string | null
   readonly uuid: string
   translations: {
@@ -5980,29 +4770,11 @@ export type ProductReviewDetail = {
   readonly id: number
   product: Product
   user: UserDetails
-  /**
-     * Συντ.
-     */
   rate: RateEnum
-  /**
-     * Κατάσταση
-     */
   status?: ReviewStatus
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
-  /**
-     * Δημοσιεύθηκε στις
-     */
   readonly publishedAt: string | null
   readonly uuid: string
   translations: {
@@ -6023,9 +4795,6 @@ export type ProductReviewDetail = {
  */
 export type ProductReviewWriteRequest = {
   product: number
-  /**
-     * Συντ.
-     */
   rate: RateEnum
   translations: {
     el?: {
@@ -6062,19 +4831,10 @@ export type ProductVariant = {
     }
   }
   readonly slug: string
-  /**
-     * Ενεργή
-     */
   readonly active: boolean
-  /**
-     * Απόθεμα
-     */
   readonly stock: number
   readonly price: number
   readonly finalPrice: number
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   readonly discountPercent: number
   readonly mainImagePath: string
   readonly attributeValues: Array<ProductAttribute>
@@ -6112,47 +4872,29 @@ export type ProductWriteRequest = {
   brand?: number | null
   price: number
   vat: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
 /**
- * * `1` - Ένα
- * * `2` - Δύο
- * * `3` - Τρία
- * * `4` - Τέσσερα
- * * `5` - Πέντε
- * * `6` - Έξι
- * * `7` - Επτά
- * * `8` - Οκτώ
- * * `9` - Εννέα
- * * `10` - Δέκα
+ * * `1` - One
+ * * `2` - Two
+ * * `3` - Three
+ * * `4` - Four
+ * * `5` - Five
+ * * `6` - Six
+ * * `7` - Seven
+ * * `8` - Eight
+ * * `9` - Nine
+ * * `10` - Ten
  */
 export type RateEnum = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 
@@ -6215,24 +4957,15 @@ export type Region = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -6253,24 +4986,15 @@ export type RegionDetail = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -6291,11 +5015,11 @@ export type RegionWriteRequest = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
 }
@@ -6305,7 +5029,7 @@ export type RegionWriteRequest = {
  */
 export type ReleaseReservationsRequestRequest = {
   /**
-     * Λίστα ID δεσμεύσεων προς απελευθέρωση
+     * List of reservation IDs to release
      */
   reservationIds: Array<number>
 }
@@ -6315,15 +5039,15 @@ export type ReleaseReservationsRequestRequest = {
  */
 export type ReleaseReservationsResponse = {
   /**
-     * Μήνυμα επιτυχίας
+     * Success message
      */
   message: string
   /**
-     * Αριθμός αποδεσμευμένων κρατήσεων
+     * Number of reservations released
      */
   releasedCount: number
   /**
-     * Λίστα αποτυχημένων απελευθερώσεων με λεπτομέρειες σφάλματος
+     * List of failed releases with error details
      */
   failedReleases?: Array<{
     [key: string]: unknown
@@ -6348,19 +5072,25 @@ export type ReorderResponse = {
  */
 export type ReserveStockResponse = {
   /**
-     * Λίστα ID δημιουργημένων δεσμεύσεων αποθέματος
+     * List of created stock reservation IDs
      */
   reservationIds: Array<number>
   /**
-     * Μήνυμα επιτυχίας
+     * Success message
      */
   message: string
 }
 
 /**
- * * `NEW` - Νέο
- * * `TRUE` - Ναι
- * * `FALSE` - Όχι
+ * * `product` - product
+ * * `blog_post` - blog_post
+ */
+export type ResultTypeEnum = 'product' | 'blog_post'
+
+/**
+ * * `NEW` - New
+ * * `TRUE` - True
+ * * `FALSE` - False
  */
 export type ReviewStatus = 'NEW' | 'TRUE' | 'FALSE'
 
@@ -6392,6 +5122,35 @@ export type SearchAnalyticsResponse = {
      * Overall click-through rate (total clicks / total searches)
      */
   clickThroughRate: number
+}
+
+/**
+ * Payload for attributing a result click to a search query.
+ */
+export type SearchClickRequestRequest = {
+  /**
+     * The query_id returned by the search response
+     */
+  queryId: string
+  /**
+     * ID of the clicked result (Product or BlogPost ID)
+     */
+  resultId: string
+  /**
+     * Type of the clicked result
+     *
+     * * `product` - product
+     * * `blog_post` - blog_post
+     */
+  resultType: ResultTypeEnum
+  /**
+     * 0-indexed position of the result in the result list
+     */
+  position: number
+}
+
+export type SearchClickResponse = {
+  detail: string
 }
 
 /**
@@ -6428,22 +5187,22 @@ export type SettingDetail = {
 }
 
 /**
- * * `pending_creation` - Εκκρεμής δημιουργία
- * * `new` - Νέο
- * * `in_transit` - Σε μεταφορά
- * * `at_destination` - Στο κατάστημα παράδοσης
- * * `out_for_delivery` - Σε διανομή
- * * `delivered` - Παραδόθηκε
- * * `attempted` - Απόπειρα παράδοσης
- * * `returned` - Επιστράφηκε
- * * `canceled` - Ακυρώθηκε
- * * `lost` - Χάθηκε
+ * * `pending_creation` - Pending creation
+ * * `new` - New
+ * * `in_transit` - In transit
+ * * `at_destination` - At destination station
+ * * `out_for_delivery` - Out for delivery
+ * * `delivered` - Delivered
+ * * `attempted` - Delivery attempted
+ * * `returned` - Returned
+ * * `canceled` - Canceled
+ * * `lost` - Lost
  */
 export type ShipmentStateEnum = 'pending_creation' | 'new' | 'in_transit' | 'at_destination' | 'out_for_delivery' | 'delivered' | 'attempted' | 'returned' | 'canceled' | 'lost'
 
 /**
- * * `home_delivery` - Κατ' οίκον παράδοση
- * * `pickup_point` - Σημείο παραλαβής / locker
+ * * `home_delivery` - Home delivery
+ * * `pickup_point` - Pickup point / locker
  */
 export type ShippingKind = 'home_delivery' | 'pickup_point'
 
@@ -6460,14 +5219,14 @@ export type ShippingOption = {
   providerName: string
   kind: ShippingKind
   /**
-     * Null όταν ο πάροχος παραπέμπει στη γενική πάγια χρέωση.
+     * Null when the provider defers to the global flat rate.
      */
   price: number | null
   currency: string
   liveMode: boolean
   priority: number
   /**
-     * Απόλυτο URL για το λογότυπο μάρκας που ανέβασε ο χειριστής, υπολογισμένο ανά (πάροχο, τύπο) ώστε η γραμμή κατ' οίκον παράδοσης και η γραμμή σημείου παραλαβής του ίδιου μεταφορέα να μπορούν να εμφανίζουν διαφορετικές εικόνες. Null όταν δεν έχει μεταφορτωθεί λογότυπο — το κατάστημα τότε επιστρέφει στην ενσωματωμένη προεπιλογή του. Το ``settings.MEDIA_URL`` είναι απόλυτο σε κάθε περιβάλλον, οπότε αυτό είναι πάντα πλήρες URL όταν υπάρχει.
+     * Absolute URL for the operator-uploaded brand logo, resolved per (provider, kind) so the home-delivery row and the pickup-point row of the same carrier can show different images. Null when no logo is uploaded — the storefront then falls back to its bundled default. ``settings.MEDIA_URL`` is absolute in every environment so this is always a full URL when present.
      */
   logoUrl?: string | null
   metadata: {
@@ -6480,37 +5239,25 @@ export type ShippingProvider = {
   /**
      * Κωδικός
      *
-     * Σταθερό αναγνωριστικό που αντιστοιχεί στον καταχωρημένο προσαρμογέα μεταφορέα (π.χ. 'acs', 'boxnow').
+     * Stable identifier matching the registered carrier adapter (e.g. 'acs', 'boxnow').
      */
   readonly code: string
   /**
-     * Όνομα
-     *
-     * Όνομα εμφάνισης προς τους πελάτες (π.χ. 'ACS Courier').
+     * Display name shown to customers (e.g. 'ACS Courier').
      */
   readonly name: string
   /**
-     * Ενεργό
-     *
-     * Κύριος διακόπτης — όταν είναι False, ο πάροχος αποκρύπτεται από το checkout ανεξάρτητα από τις σημαίες δυνατοτήτων.
+     * Master switch — when False the provider is hidden from checkout regardless of capability flags.
      */
   readonly isActive: boolean
-  /**
-     * Υποστηρίζει Κατ' Οίκον Παράδοση
-     */
   readonly supportsHomeDelivery: boolean
-  /**
-     * Υποστηρίζει σημείο παραλαβής
-     */
   readonly supportsPickupPoint: boolean
   /**
-     * False = διαπιστευτήρια sandbox / δοκιμής. Χρησιμοποιείται από το UI διαχείρισης για να προειδοποιεί τους χειριστές ότι τα vouchers δεν θα αποσταλούν πραγματικά.
+     * False = sandbox / test credentials. Used by the admin UI to warn operators that vouchers won't actually ship.
      */
   readonly liveMode: boolean
   /**
-     * Προτεραιότητα
-     *
-     * Σειρά ταξινόμησης στο checkout — οι μικρότεροι αριθμοί εμφανίζονται πρώτοι.
+     * Sort order in checkout — lower numbers appear first.
      */
   readonly priority: number
   /**
@@ -6534,37 +5281,29 @@ export type ShippingProvider = {
      */
   readonly logoPickupPointFilename: string
   /**
-     * Μεταδεδομένα
-     *
-     * Διαμόρφωση ειδική για τον πάροχο (υποστηριζόμενες χώρες, σημαίες λειτουργιών, υποδείξεις branding).
+     * Provider-specific configuration (supported countries, feature flags, branding hints).
      */
   readonly metadata: unknown
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
 /**
- * * `1` - Κατάστημα
- * * `2` - Συνεργαζόμενο κατάστημα (2)
- * * `3` - Συνεργαζόμενο κατάστημα (3)
+ * * `1` - Shop
+ * * `2` - Partner shop (2)
+ * * `3` - Partner shop (3)
  * * `4` - Xpress Point
  * * `5` - Kiosk
- * * `7` - Smartpoint (χωρίς locker)
+ * * `7` - Smartpoint (no locker)
  * * `8` - Smartpoint locker
  */
 export type ShopKindEnum = 1 | 2 | 3 | 4 | 5 | 7 | 8
 
 /**
- * * `ACTIVE` - Ενεργή
- * * `PENDING` - Εκκρεμεί Επιβεβαίωση
- * * `UNSUBSCRIBED` - Διαγραφή
- * * `BOUNCED` - Επιστράφηκε
+ * * `ACTIVE` - Active
+ * * `PENDING` - Pending Confirmation
+ * * `UNSUBSCRIBED` - Unsubscribed
+ * * `BOUNCED` - Bounced
  */
 export type SubscriptionStatus = 'ACTIVE' | 'PENDING' | 'UNSUBSCRIBED' | 'BOUNCED'
 
@@ -6589,39 +5328,35 @@ export type SubscriptionTopic = {
   readonly id: number
   readonly uuid: string
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
   readonly subscriberCount: number
@@ -6648,49 +5383,39 @@ export type SubscriptionTopicDetail = {
   readonly id: number
   readonly uuid: string
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
   readonly subscriberCount: number
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -6713,39 +5438,35 @@ export type SubscriptionTopicWriteRequest = {
     }
   }
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
 }
@@ -6766,25 +5487,13 @@ export type Tag = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
-     * Πόσες φορές χρησιμοποιείται η ετικέτα
+     * Number of times this tag is used
      */
   readonly usageCount: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -6805,29 +5514,17 @@ export type TagDetail = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
-  /**
-     * Σειρά ταξινόμησης
-     */
   readonly sortOrder: number | null
   /**
-     * Πόσες φορές χρησιμοποιείται η ετικέτα
+     * Number of times this tag is used
      */
   readonly usageCount: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   /**
-     * Τύποι περιεχομένου με τους οποίους χρησιμοποιείται αυτή η ετικέτα
+     * Content types this tag is used with
      */
   readonly contentTypes: string
 }
@@ -6847,9 +5544,6 @@ export type TagWriteRequest = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -6858,12 +5552,12 @@ export type TaggedItem = {
   tag: Tag
   contentType: number
   /**
-     * Όνομα τύπου περιεχομένου
+     * Name of the content type
      */
   readonly contentTypeName: string
   objectId: number
   /**
-     * Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+     * Serialized representation of the related content object
      */
   readonly contentObject: {
     id?: number
@@ -6873,13 +5567,7 @@ export type TaggedItem = {
     active?: boolean
     [key: string]: unknown
   }
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -6889,12 +5577,12 @@ export type TaggedItemDetail = {
   tag: TagDetail
   contentType: number
   /**
-     * Όνομα τύπου περιεχομένου
+     * Name of the content type
      */
   readonly contentTypeName: string
   objectId: number
   /**
-     * Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου
+     * Serialized representation of the related content object
      */
   readonly contentObject: {
     id?: number
@@ -6904,13 +5592,7 @@ export type TaggedItemDetail = {
     active?: boolean
     [key: string]: unknown
   }
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
@@ -6991,21 +5673,21 @@ export type TopQuery = {
 }
 
 /**
- * * `MARKETING` - Καμπάνιες marketing
- * * `PRODUCT` - Ενημερώσεις προϊόντων
- * * `ACCOUNT` - Λογαριασμός Ανενεργός
- * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+ * * `MARKETING` - Marketing Campaigns
+ * * `PRODUCT` - Product Updates
+ * * `ACCOUNT` - Account Updates
+ * * `SYSTEM` - System Notifications
  * * `NEWSLETTER` - Newsletter
- * * `PROMOTIONAL` - Προωθητικό
- * * `OTHER` - Άλλο
+ * * `PROMOTIONAL` - Promotional
+ * * `OTHER` - Other
  */
 export type TopicCategory = 'MARKETING' | 'PRODUCT' | 'ACCOUNT' | 'SYSTEM' | 'NEWSLETTER' | 'PROMOTIONAL' | 'OTHER'
 
 /**
- * * `EARN` - Κερδίστε
- * * `REDEEM` - Εξαργύρωση
- * * `EXPIRE` - Λήξη
- * * `ADJUST` - Προσαρμογή
+ * * `EARN` - Earn
+ * * `REDEEM` - Redeem
+ * * `EXPIRE` - Expire
+ * * `ADJUST` - Adjust
  * * `BONUS` - Bonus
  */
 export type TransactionTypeEnum = 'EARN' | 'REDEEM' | 'EXPIRE' | 'ADJUST' | 'BONUS'
@@ -7049,9 +5731,9 @@ export type TrendingSearchResponse = {
 
 /**
  * * `apm` - APM
- * * `any_apm` - Οποιοδήποτε APM
- * * `warehouse` - Αποθήκη
- * * `depot` - Αποθήκη
+ * * `any_apm` - Any APM
+ * * `warehouse` - Warehouse
+ * * `depot` - Depot
  */
 export type TypeEnum = 'apm' | 'any_apm' | 'warehouse' | 'depot'
 
@@ -7070,190 +5752,88 @@ export type UpdateStatusRequest = {
 
 export type UserAddress = {
   readonly id: number
-  /**
-     * Τίτλος
-     */
   title: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Πόλη
-     */
   city: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   readonly user: number
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type UserAddressDetail = {
   readonly id: number
-  /**
-     * Τίτλος
-     */
   title: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Πόλη
-     */
   city: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   readonly user: number
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
 }
 
 export type UserAddressWriteRequest = {
-  /**
-     * Τίτλος
-     */
   title: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Πόλη
-     */
   city: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string
 }
@@ -7277,16 +5857,10 @@ export type UserDetails = {
      */
   readonly pk: number
   /**
-     * Διεύθυνση Email
+     * Διεύθυνση ηλεκτρονικού ταχυδρομείου
      */
   email: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
   readonly id: number
   /**
@@ -7296,78 +5870,63 @@ export type UserDetails = {
      */
   username?: string | string | null
   phone?: string | null
-  /**
-     * Πόλη
-     */
   city?: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode?: string
-  /**
-     * Διεύθυνση
-     */
   address?: string
-  /**
-     * Τόπος
-     */
   place?: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Ημ/νία γέννησης
-     */
   birthDate?: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly twitter: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly linkedin: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly facebook: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly instagram: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly website: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly youtube: string | null
   /**
-     * Σύνδεσμος URL ή κενή τιμή
+     * URL link or empty string
      */
   readonly github: string | null
-  /**
-     * Βιογραφικό
-     */
   bio?: string
   /**
-     * Γλώσσα
+     * Language
      *
-     * Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+     * Preferred language for emails and UI messages.
      */
   languageCode?: string
   /**
-     * Ενεργή
+     * Active
      */
   readonly isActive: boolean
   /**
-     * Προσωπικό
+     * Staff
      */
   readonly isStaff: boolean
   /**
@@ -7376,13 +5935,7 @@ export type UserDetails = {
      * Υποδηλώνει ότι ο συγκεκριμένος χρήστης έχει όλα τα δικαιώματα χωρίς να χρειάζεται να τα παραχωρήσετε ξεχωριστά.
      */
   readonly isSuperuser: boolean
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
   readonly uuid: string
   readonly mainImagePath: string
@@ -7396,31 +5949,14 @@ export type UserSubscription = {
   readonly user: number
   topic: number
   topicDetails: SubscriptionTopic
-  /**
-     * Κατάσταση
-     */
   status?: SubscriptionStatus
-  /**
-     * Εγγραφή στις
-     */
   readonly subscribedAt: string
-  /**
-     * Διαγραφή στις
-     */
   readonly unsubscribedAt: string | null
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
@@ -7432,56 +5968,31 @@ export type UserSubscriptionDetail = {
   readonly user: number
   topic: number
   topicDetails: SubscriptionTopic
-  /**
-     * Κατάσταση
-     */
   status?: SubscriptionStatus
-  /**
-     * Εγγραφή στις
-     */
   readonly subscribedAt: string
-  /**
-     * Διαγραφή στις
-     */
   readonly unsubscribedAt: string | null
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
-  /**
-     * Δημιουργήθηκε στις
-     */
   readonly createdAt: string
-  /**
-     * Ενημερώθηκε στις
-     */
   readonly updatedAt: string
 }
 
 export type UserSubscriptionWriteRequest = {
   topic: number
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
 }
 
 export type UserWriteRequest = {
   /**
-     * Διεύθυνση Email
+     * Διεύθυνση ηλεκτρονικού ταχυδρομείου
      */
   email: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
   /**
      * Όνομα χρήστη
@@ -7494,84 +6005,66 @@ export type UserWriteRequest = {
      */
   image?: Blob | File | null
   phone?: string | null
-  /**
-     * Πόλη
-     */
   city?: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode?: string
-  /**
-     * Διεύθυνση
-     */
   address?: string
-  /**
-     * Τόπος
-     */
   place?: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Ημ/νία γέννησης
-     */
   birthDate?: string | null
   /**
-     * Προφίλ Twitter
+     * Twitter Profile
      */
   twitter?: string | string | null
   /**
-     * Προφίλ LinkedIn
+     * LinkedIn Profile
      */
   linkedin?: string | string | null
   /**
-     * Προφίλ Facebook
+     * Facebook Profile
      */
   facebook?: string | string | null
   /**
-     * Προφίλ Instagram
+     * Instagram Profile
      */
   instagram?: string | string | null
-  /**
-     * Ιστότοπος
-     */
   website?: string | string | null
   /**
-     * Προφίλ Youtube
+     * Youtube Profile
      */
   youtube?: string | string | null
   /**
-     * Προφίλ Github
+     * Github Profile
      */
   github?: string | string | null
-  /**
-     * Βιογραφικό
-     */
   bio?: string
   /**
-     * Γλώσσα
+     * Language
      *
-     * Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+     * Preferred language for emails and UI messages.
      */
   languageCode?: string
 }
 
 export type UsernameUpdateRequest = {
   /**
-     * Νέο όνομα χρήστη
+     * New username
      */
   username: string
 }
 
 export type UsernameUpdateResponse = {
   /**
-     * Μήνυμα επιτυχίας για ενημέρωση ονόματος χρήστη
+     * Success message for username update
      */
   detail: string
 }
@@ -7642,9 +6135,6 @@ export type AttributeWritable = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -7664,9 +6154,6 @@ export type AttributeValueWritable = {
       value?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -7808,13 +6295,7 @@ export type BlogPostWritable = {
   author: number
   category: number
   tags: Array<number>
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
 }
 
@@ -7840,25 +6321,10 @@ export type BlogPostDetailWritable = {
       body?: string
     }
   }
-  /**
-     * Προβεβλημένο
-     */
   featured?: boolean
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -7877,9 +6343,6 @@ export type BlogTagWritable = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -7898,9 +6361,6 @@ export type BlogTagDetailWritable = {
       name?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -7913,28 +6373,16 @@ export type CartDetailWritable = {
 }
 
 export type CartItemWritable = {
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
 export type CartItemDetailWritable = {
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
 export type ContactWriteWritable = {
-  /**
-     * Όνομα
-     */
   name: string
   email: string
-  /**
-     * Μήνυμα
-     */
   message: string
 }
 
@@ -7954,20 +6402,17 @@ export type CountryWritable = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
 }
 
@@ -7987,20 +6432,17 @@ export type CountryDetailWritable = {
     }
   }
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   alpha2: string
   /**
-     * Κωδικός Χώρας (Alpha 3)
+     * Country Code Alpha 3
      */
   alpha3: string
   /**
-     * Κωδικός ISO χώρας
+     * ISO Country Code
      */
   isoCc?: number | null
-  /**
-     * Κωδικός κλήσης
-     */
   phoneCode?: number | null
 }
 
@@ -8031,9 +6473,6 @@ export type LoyaltyTierWritable = {
       description?: string
     }
   }
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
 }
 
@@ -8055,143 +6494,72 @@ export type NotificationWritable = {
       message?: string
     }
   }
-  /**
-     * Είδος
-     */
   kind?: NotificationKindEnum
-  /**
-     * Κατηγορία
-     */
   category?: NotificationCategory
-  /**
-     * Προτεραιότητα
-     */
   priority?: PriorityEnum
   /**
-     * Τύπος ειδοποίησης
+     * Fine-grained event identifier. See ``notification.enum.NotificationTypeEnum`` for the full catalogue. Left blank for ad-hoc admin broadcasts.
      *
-     * Λεπτομερές αναγνωριστικό συμβάντος. Δείτε ``notification.enum.NotificationTypeEnum`` για τον πλήρη κατάλογο. Αφήνεται κενό για περιστασιακές ανακοινώσεις διαχειριστή.
-     *
-     * * `order_created` - Η παραγγελία δημιουργήθηκε
-     * * `order_processing` - Επεξεργασία παραγγελίας
-     * * `order_shipped` - Η παραγγελία απεστάλη
-     * * `order_delivered` - Η παραγγελία παραδόθηκε
-     * * `order_completed` - Η παραγγελία ολοκληρώθηκε
-     * * `order_canceled` - Η παραγγελία ακυρώθηκε
-     * * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
-     * * `shipment_dispatched` - Αποστολή απεστάλη
-     * * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
-     * * `payment_failed` - Η πληρωμή απέτυχε
-     * * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
-     * * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
-     * * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
-     * * `comment_liked` - Επισήμανση σχολίου blog
-     * * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
-     * * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
-     * * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+     * * `order_created` - Order created
+     * * `order_processing` - Order processing
+     * * `order_shipped` - Order shipped
+     * * `order_delivered` - Order delivered
+     * * `order_completed` - Order completed
+     * * `order_canceled` - Order canceled
+     * * `order_refunded` - Order refunded
+     * * `shipment_dispatched` - Shipment dispatched
+     * * `payment_confirmed` - Payment confirmed
+     * * `payment_failed` - Payment failed
+     * * `price_drop_favourite` - Price drop (favourited product)
+     * * `restock_favourite` - Back in stock (favourited product)
+     * * `loyalty_tier_up` - Loyalty tier promotion
+     * * `comment_liked` - Blog comment liked
+     * * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+     * * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+     * * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
      */
   notificationType?: NotificationTypeEnum | BlankEnum
-  /**
-     * Ημερομηνία Λήξης
-     */
   expiryDate?: string | null
 }
 
 export type NotificationUserWritable = {
-  /**
-     * Ορατό
-     */
   seen?: boolean
-  /**
-     * Ορατό στις
-     */
   seenAt?: string | null
 }
 
 export type NotificationUserDetailWritable = {
-  /**
-     * Ορατό
-     */
   seen?: boolean
-  /**
-     * Ορατό στις
-     */
   seenAt?: string | null
 }
 
 export type OrderWritable = {
   user?: number | null
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
   payWay: number | null
-  /**
-     * Κατάσταση
-     */
   status?: OrderStatus
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
   email: string
-  /**
-     * Τ.Κ.
-     */
   zipcode: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city: string
   phone: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   items: Array<OrderItemDetailWritable>
-  /**
-     * Τύπος Εγγράφου
-     */
   documentType?: OrderDocumentType
-  /**
-     * ID πληρωμής
-     */
   paymentId?: string | null
-  /**
-     * Κατάσταση πληρωμής
-     */
   paymentStatus?: PaymentStatusEnum | BlankEnum
-  /**
-     * Μέθοδος πληρωμής
-     */
   paymentMethod?: string
 }
 
@@ -8207,124 +6575,124 @@ export type OrderWritable = {
  */
 export type OrderCreateFromCartRequestWritable = {
   /**
-     * ID μεθόδου πληρωμής
+     * Payment method ID
      */
   payWayId: number
   /**
-     * ID payment intent από τον πάροχο πληρωμών (υποχρεωτικό για online πληρωμές)
+     * Payment intent ID from payment provider (required for online payments)
      */
   paymentIntentId?: string | null
   /**
-     * Όνομα πελάτη
+     * Customer first name
      */
   firstName: string
   /**
-     * Επώνυμο πελάτη
+     * Customer last name
      */
   lastName: string
   /**
-     * Email πελάτη
+     * Customer email address
      */
   email: string
   /**
-     * Όνομα οδού
+     * Street name
      */
   street: string
   /**
-     * Αριθμός οδού
+     * Street number
      */
   streetNumber?: string
   /**
-     * Όνομα πόλης
+     * City name
      */
   city: string
   /**
-     * Ταχυδρομικός κώδικας
+     * Postal/ZIP code
      */
   zipcode: string
   /**
-     * Κωδικός χώρας alpha-2 (π.χ. 'GR', 'US')
+     * Country alpha-2 code (e.g., 'GR', 'US')
      */
   countryId: string
   /**
-     * Αλφαριθμητικός κωδικός περιφέρειας
+     * Region alpha code
      */
   regionId?: string | null
   /**
-     * Τηλέφωνο πελάτη
+     * Customer phone number
      */
   phone: string
   /**
-     * Σημειώσεις πελάτη ή ειδικές οδηγίες
+     * Customer notes or special instructions
      */
   customerNotes?: string
   /**
-     * Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)
+     * Floor number or label (e.g. FIRST_FLOOR)
      */
   floor?: string
   /**
-     * Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)
+     * Location type, e.g. HOME or OFFICE (optional)
      */
   locationType?: string
   /**
-     * ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.
+     * Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.
      */
   billingVatId?: string
   /**
-     * Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.
+     * ISO 3166-1 alpha-2 country code for the buyer's tax identity. Defaults to the order country when blank.
      */
   billingCountry?: string
   /**
-     * RECEIPT (Α.Λ.Π., Tier A — λιανική) ή INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Η επιλογή INVOICE απαιτεί έγκυρο ``billing_vat_id``.
+     * RECEIPT (Α.Λ.Π., Tier A — retail) or INVOICE (Τιμολόγιο Πώλησης, Tier B — B2B). Selecting INVOICE requires a valid ``billing_vat_id``.
      *
-     * * `RECEIPT` - Απόδειξη
-     * * `INVOICE` - Τιμολόγιο
+     * * `RECEIPT` - Receipt
+     * * `INVOICE` - Invoice
      */
   documentType?: OrderCreateDocumentType
   /**
-     * Αριθμός πόντων πιστότητας προς εξαργύρωση για έκπτωση σε αυτή την παραγγελία
+     * Number of loyalty points to redeem for discount on this order
      */
   loyaltyPointsToRedeem?: number | null
   /**
-     * ID locker APM BoxNow από το widget
+     * BoxNow APM locker ID from the widget
      */
   boxnowLockerId?: string
   /**
-     * Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο
+     * BoxNow compartment size: 1=Small, 2=Medium, 3=Large
      */
   boxnowCompartmentSize?: number
   /**
-     * Κωδικός μεταφορέα από /api/v1/shipping/options (π.χ. 'acs').
+     * Carrier code from /api/v1/shipping/options (e.g. 'acs').
      */
   shippingProviderCode?: string | string
   /**
-     * Γενικός τύπος εκπλήρωσης, ανεξάρτητος από τον πάροχο.
+     * Generic fulfilment kind, independent of provider.
      *
-     * * `home_delivery` - Κατ' οίκον παράδοση
-     * * `pickup_point` - Σημείο παραλαβής / locker
+     * * `home_delivery` - Home delivery
+     * * `pickup_point` - Pickup point / locker
      */
   shippingKind?: ShippingKind
   /**
-     * Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).
+     * ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).
      */
   acsStationExternalId?: string
   /**
-     * Τιμή ACS_Station_Branch_Destination.
+     * ACS_Station_Branch_Destination value.
      */
   acsStationBranch?: string
   /**
-     * Προαιρετική παράκαμψη του ACS Charge_Type ανά παραγγελία. Αφήστε το κενό για χρήση της προεπιλογής σε επίπεδο μεταφορέα (COD σε σύμβαση μόνο-COD). Ο ορισμός εδώ έχει νόημα μόνο αν η εμπορική σύμβαση με την ACS επιτρέπει την επιλεγμένη τιμή — μη έγκυροι συνδυασμοί απορρίπτονται από το ACS_Create_Voucher.
+     * Optional per-order ACS Charge_Type override. Leave unset to use the carrier-level default (COD on a COD-only contract). Setting this here only makes sense if the ACS commercial contract permits the chosen value — invalid combinations are rejected by ACS_Create_Voucher.
      *
-     * * `1` - Προπληρωμένο
-     * * `2` - Αντικαταβολή
+     * * `1` - Prepaid
+     * * `2` - Cash on delivery
      */
   acsChargeType?: AcsChargeType
   /**
-     * Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.
+     * Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.
      */
   acsItemQuantity?: number
   /**
-     * Πλαίσιο Meta Pixel: κλειδιά ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict με {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict με boolean ``ads``). Κενό dict / null όταν ο πελάτης αρνήθηκε τα cookies μάρκετινγκ· ο αποστολέας CAPI τότε παραλείπει την αποστολή.
+     * Meta Pixel context: keys ``fbp``, ``fbc``, ``client_user_agent``, ``client_ip_address``, ``event_ids`` (dict of {purchase, initiate_checkout, add_payment_info}), ``consent`` (dict with ``ads`` boolean). Empty dict / null when the customer declined marketing cookies; the CAPI dispatcher then skips the send.
      */
   meta?: {
     [key: string]: unknown
@@ -8334,104 +6702,44 @@ export type OrderCreateFromCartRequestWritable = {
 export type OrderDetailWritable = {
   user?: number | null
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string | null
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
   payWay: number | null
-  /**
-     * Κατάσταση
-     */
   status?: OrderStatus
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
   email: string
-  /**
-     * Τ.Κ.
-     */
   zipcode: string
-  /**
-     * Τόπος
-     */
   place?: string
-  /**
-     * Πόλη
-     */
   city: string
-  /**
-     * Σημειώσεις Πελάτη
-     */
   customerNotes?: string
   items: Array<OrderItemDetailWritable>
-  /**
-     * Τύπος Εγγράφου
-     */
   documentType?: OrderDocumentType
-  /**
-     * ID πληρωμής
-     */
   paymentId?: string | null
-  /**
-     * Κατάσταση πληρωμής
-     */
   paymentStatus?: PaymentStatusEnum | BlankEnum
-  /**
-     * Μέθοδος πληρωμής
-     */
   paymentMethod?: string
-  /**
-     * Αριθμός Παρακολούθησης
-     */
   trackingNumber?: string
-  /**
-     * Εταιρεία μεταφοράς
-     */
   shippingCarrier?: string
 }
 
 export type OrderItemWritable = {
   order: number
   product: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
 }
 
 export type OrderItemDetailWritable = {
   order: number
-  /**
-     * Ποσότητα
-     */
   quantity?: number
-  /**
-     * Σημειώσεις
-     */
   notes?: string
 }
 
@@ -8885,7 +7193,7 @@ export type PaginatedUserSubscriptionListWritable = {
 
 export type PatchedTaggedItemWriteRequestWritable = {
   /**
-     * ID ετικέτας προς ανάθεση
+     * ID of the tag to assign
      */
   tagId?: number
   contentType?: number
@@ -8913,32 +7221,20 @@ export type PayWayWritable = {
       instructions?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost: number
   freeThreshold: number
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
 }
@@ -8964,32 +7260,20 @@ export type PayWayDetailWritable = {
       instructions?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
   cost: number
   freeThreshold: number
-  /**
-     * Εικονίδιο
-     */
   icon?: string | null
   /**
-     * Κωδικός παρόχου
-     *
-     * Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. 'stripe', 'paypal')
+     * Code used to identify the payment provider in the system (e.g., 'stripe', 'paypal')
      */
   providerCode?: string
   /**
-     * Είναι online πληρωμή
-     *
-     * Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online
+     * Whether this payment method is processed online
      */
   isOnlinePayment?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)
+     * Whether this payment method requires manual confirmation (e.g., bank transfer)
      */
   requiresConfirmation?: boolean
 }
@@ -9016,40 +7300,19 @@ export type ProductWritable = {
   category: number
   price: number
   vat: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
 }
 
 export type ProductAlertWritable = {
-  /**
-     * Είδος
-     */
   kind: ProductAlertKindEnum
   product: number
   email?: string | null
@@ -9089,9 +7352,6 @@ export type ProductCategoryWritable = {
     }
   }
   slug: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
 }
@@ -9115,22 +7375,10 @@ export type ProductCategoryDetailWritable = {
     }
   }
   slug: string
-  /**
-     * Ενεργή
-     */
   active?: boolean
   parent?: number | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
 }
 
@@ -9143,13 +7391,7 @@ export type ProductCategoryImageWritable = {
      * Εικόνα
      */
   image: string
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
   translations: {
     el?: {
@@ -9176,13 +7418,7 @@ export type ProductCategoryImageDetailWritable = {
      * Εικόνα
      */
   image: string
-  /**
-     * Τύπος εικόνας
-     */
   imageType?: ImageTypeEnum
-  /**
-     * Ενεργή
-     */
   active?: boolean
   translations: {
     el?: {
@@ -9222,33 +7458,15 @@ export type ProductDetailWritable = {
   category: number
   price: number
   vat: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
 }
 
@@ -9274,33 +7492,15 @@ export type ProductDetailResponseWritable = {
   category: number
   price: number
   vat: number
-  /**
-     * Απόθεμα
-     */
   stock?: number
-  /**
-     * Ενεργή
-     */
   active?: boolean
   weight?: {
     unit?: string
     value?: number
   } | null
-  /**
-     * Τίτλος SEO
-     */
   seoTitle?: string
-  /**
-     * Περιγραφή SEO
-     */
   seoDescription?: string
-  /**
-     * Λέξεις-κλειδιά SEO
-     */
   seoKeywords?: string
-  /**
-     * Ποσοστό Έκπτωσης
-     */
   discountPercent?: number
 }
 
@@ -9324,9 +7524,6 @@ export type ProductImageWritable = {
      * Εικόνα
      */
   image: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   translations: {
     el?: {
@@ -9349,9 +7546,6 @@ export type ProductImageDetailWritable = {
      * Εικόνα
      */
   image: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   translations: {
     el?: {
@@ -9370,17 +7564,8 @@ export type ProductImageDetailWritable = {
  * Serializer that saves :class:`TranslatedFieldsField` automatically.
  */
 export type ProductReviewWritable = {
-  /**
-     * Συντ.
-     */
   rate: RateEnum
-  /**
-     * Κατάσταση
-     */
   status?: ReviewStatus
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
   translations: {
     el?: {
@@ -9399,17 +7584,8 @@ export type ProductReviewWritable = {
  * Serializer that saves :class:`TranslatedFieldsField` automatically.
  */
 export type ProductReviewDetailWritable = {
-  /**
-     * Συντ.
-     */
   rate: RateEnum
-  /**
-     * Κατάσταση
-     */
   status?: ReviewStatus
-  /**
-     * Δημοσιευμένο
-     */
   isPublished?: boolean
   translations: {
     el?: {
@@ -9471,11 +7647,11 @@ export type RegionWritable = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
 }
@@ -9496,11 +7672,11 @@ export type RegionDetailWritable = {
     }
   }
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   alpha: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
 }
@@ -9524,39 +7700,35 @@ export type SubscriptionTopicWritable = {
     }
   }
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
 }
@@ -9580,39 +7752,35 @@ export type SubscriptionTopicDetailWritable = {
     }
   }
   /**
-     * Μοναδικό αναγνωριστικό για το θέμα (π.χ. 'weekly-newsletter')
+     * Unique identifier for the topic (e.g., 'weekly-newsletter')
      */
   slug: string
   /**
-     * Κατηγορία
+     * Category of the subscription topic
      *
-     * Κατηγορία του θέματος εγγραφής
-     *
-     * * `MARKETING` - Καμπάνιες marketing
-     * * `PRODUCT` - Ενημερώσεις προϊόντων
-     * * `ACCOUNT` - Λογαριασμός Ανενεργός
-     * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+     * * `MARKETING` - Marketing Campaigns
+     * * `PRODUCT` - Product Updates
+     * * `ACCOUNT` - Account Updates
+     * * `SYSTEM` - System Notifications
      * * `NEWSLETTER` - Newsletter
-     * * `PROMOTIONAL` - Προωθητικό
-     * * `OTHER` - Άλλο
+     * * `PROMOTIONAL` - Promotional
+     * * `OTHER` - Other
      */
   category?: TopicCategory
   /**
-     * Ενεργή
+     * Active
      *
-     * Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή
+     * Whether this topic is currently available for subscription
      */
   isActive?: boolean
   /**
-     * Προεπιλεγμένη συνδρομή
+     * Default Subscription
      *
-     * Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα
+     * Whether new users are automatically subscribed to this topic
      */
   isDefault?: boolean
   /**
-     * Απαιτείται Επιβεβαίωση
-     *
-     * Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email
+     * Whether subscription to this topic requires email confirmation
      */
   requiresConfirmation?: boolean
 }
@@ -9632,9 +7800,6 @@ export type TagWritable = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -9653,9 +7818,6 @@ export type TagDetailWritable = {
       label?: string
     }
   }
-  /**
-     * Ενεργή
-     */
   active?: boolean
 }
 
@@ -9671,7 +7833,7 @@ export type TaggedItemDetailWritable = {
 
 export type TaggedItemWriteRequestWritable = {
   /**
-     * ID ετικέτας προς ανάθεση
+     * ID of the tag to assign
      */
   tagId: number
   contentType: number
@@ -9679,129 +7841,63 @@ export type TaggedItemWriteRequestWritable = {
 }
 
 export type UserAddressWritable = {
-  /**
-     * Τίτλος
-     */
   title: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Πόλη
-     */
   city: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string
 }
 
 export type UserAddressDetailWritable = {
-  /**
-     * Τίτλος
-     */
   title: string
-  /**
-     * Όνομα
-     */
   firstName: string
-  /**
-     * Επώνυμο
-     */
   lastName: string
-  /**
-     * Οδός
-     */
   street: string
-  /**
-     * Αριθμός
-     */
   streetNumber: string
-  /**
-     * Πόλη
-     */
   city: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode: string
-  /**
-     * Όροφος
-     */
   floor?: FloorEnum | BlankEnum
-  /**
-     * Τύπος τοποθεσίας
-     */
   locationType?: LocationTypeEnum | BlankEnum
   phone: string
-  /**
-     * Σημειώσεις
-     */
   notes?: string
-  /**
-     * Κύριο
-     */
   isMain?: boolean
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country: string
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region: string
 }
 
 export type UserDetailsWritable = {
   /**
-     * Διεύθυνση Email
+     * Διεύθυνση ηλεκτρονικού ταχυδρομείου
      */
   email: string
-  /**
-     * Όνομα
-     */
   firstName?: string
-  /**
-     * Επώνυμο
-     */
   lastName?: string
   /**
      * Όνομα χρήστη
@@ -9810,70 +7906,45 @@ export type UserDetailsWritable = {
      */
   username?: string | string | null
   phone?: string | null
-  /**
-     * Πόλη
-     */
   city?: string
   /**
-     * Ταχ. Κώδικας
+     * Zip Code
      */
   zipcode?: string
-  /**
-     * Διεύθυνση
-     */
   address?: string
-  /**
-     * Τόπος
-     */
   place?: string
   /**
-     * Κωδικός Χώρας (Alpha 2)
+     * Country Code Alpha 2
      */
   country?: string | null
   /**
-     * Κωδικός περιφέρειας
+     * Region Code
      */
   region?: string | null
-  /**
-     * Ημ/νία γέννησης
-     */
   birthDate?: string | null
-  /**
-     * Βιογραφικό
-     */
   bio?: string
   /**
-     * Γλώσσα
+     * Language
      *
-     * Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
+     * Preferred language for emails and UI messages.
      */
   languageCode?: string
 }
 
 export type UserSubscriptionWritable = {
   topic: number
-  /**
-     * Κατάσταση
-     */
   status?: SubscriptionStatus
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
 }
 
 export type UserSubscriptionDetailWritable = {
   topic: number
-  /**
-     * Κατάσταση
-     */
   status?: SubscriptionStatus
   /**
-     * Μεταδεδομένα
-     *
-     * Επιπλέον προτιμήσεις ή δεδομένα εγγραφής
+     * Additional subscription preferences or data
      */
   metadata?: unknown
 }
@@ -9935,11 +8006,11 @@ export type ListBlogAuthorData = {
   path?: never
   query?: {
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -9951,15 +8022,15 @@ export type ListBlogAuthorData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -9991,7 +8062,7 @@ export type CreateBlogAuthorData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10047,7 +8118,7 @@ export type RetrieveBlogAuthorData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10076,7 +8147,7 @@ export type PartialUpdateBlogAuthorData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10106,7 +8177,7 @@ export type UpdateBlogAuthorData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10176,7 +8247,7 @@ export type ListBlogCategoryData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -10188,15 +8259,15 @@ export type ListBlogCategoryData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -10228,7 +8299,7 @@ export type CreateBlogCategoryData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10284,7 +8355,7 @@ export type RetrieveBlogCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10313,7 +8384,7 @@ export type PartialUpdateBlogCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10343,7 +8414,7 @@ export type UpdateBlogCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10648,19 +8719,19 @@ export type ListBlogCommentData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+         * Filter comments that are ancestors of the given comment ID
          */
     ancestorOf?: string | number
     /**
-         * Φίλτρο ανά κατάσταση έγκρισης
+         * Filter by approval status
          */
     approved?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by comment content (case-insensitive)
          */
     content?: string
     /**
-         * Φίλτρο ανά ακριβές μήκος περιεχομένου
+         * Filter by exact content length
          */
     contentLength?: string | number
     /**
@@ -10675,23 +8746,23 @@ export type ListBlogCommentData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+         * Filter comments that are descendants of the given comment ID
          */
     descendantOf?: string | number
     /**
-         * Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+         * Filter comments that have content (true) or are empty (false)
          */
     hasContent?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+         * Filter comments that have likes (true) or no likes (false)
          */
     hasLikes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+         * Filter comments that have approved replies (true) or no replies (false)
          */
     hasReplies?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -10700,69 +8771,69 @@ export type ListBlogCommentData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+         * Filter anonymous comments (no user)
          */
     isAnonymous?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+         * Filter leaf comments (no approved replies)
          */
     isLeaf?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+         * Filter by comment nesting level (0 for top-level)
          */
     level?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+         * Filter comments at or below this nesting level
          */
     level_Gte?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+         * Filter comments at or above this nesting level
          */
     level_Lte?: string | number
     /**
-         * Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by left tree value (MPTT internal)
          */
     lft?: string | number
     lft_Gte?: string | number
     lft_Lte?: string | number
     /**
-         * Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+         * Filter comments liked by specific user ID
          */
     likedBy?: string | number
     /**
-         * Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+         * Filter comments with at most this content length
          */
     maxContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες επισημάνσεις
+         * Filter comments with at most this many likes
          */
     maxLikes?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at most this many approved replies
          */
     maxReplies?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+         * Filter comments with at least this content length
          */
     minContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+         * Filter comments with at least this many likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at least this many approved replies
          */
     minReplies?: string | number
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+         * Order comments by most likes first
          */
     mostLiked?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+         * Order comments by most approved replies first
          */
     mostReplied?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -10774,55 +8845,55 @@ export type ListBlogCommentData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά ID γονικού σχολίου
+         * Filter by parent comment ID
          */
     parent?: string | number
     /**
-         * Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+         * Filter top-level comments (true) or replies (false)
          */
     parent_Isnull?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID άρθρου
+         * Filter by blog post ID
          */
     post?: string | number
     /**
-         * Φίλτρο ανά ID συντάκτη άρθρου
+         * Filter by blog post author ID
          */
     post_Author?: string | number
     /**
-         * Φίλτρο ανά ID κατηγορίας άρθρου
+         * Filter by blog post category ID
          */
     post_Category?: string | number
     /**
-         * Φίλτρο ανά slug κατηγορίας άρθρου
+         * Filter by blog post category slug
          */
     post_Category_Slug?: string
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+         * Filter by blog post published status
          */
     post_IsPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά slug άρθρου
+         * Filter by blog post slug
          */
     post_Slug?: string
     /**
-         * Φίλτρο ανά τίτλο άρθρου
+         * Filter by blog post title
          */
     post_Title?: string
     /**
-         * Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by right tree value (MPTT internal)
          */
     rght?: string | number
     rght_Gte?: string | number
@@ -10832,7 +8903,7 @@ export type ListBlogCommentData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+         * Filter by tree ID (MPTT internal)
          */
     treeId?: string | number
     /**
@@ -10847,19 +8918,19 @@ export type ListBlogCommentData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη
+         * Filter by user email
          */
     user_Email?: string
     /**
-         * Φίλτρο σχολίων από ενεργούς χρήστες
+         * Filter comments by active users
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων από staff
+         * Filter comments by staff users
          */
     user_IsStaff?: 'true' | 'false' | '1' | '0' | boolean
     uuid?: string
@@ -10888,7 +8959,7 @@ export type CreateBlogCommentData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10944,7 +9015,7 @@ export type RetrieveBlogCommentData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -10973,7 +9044,7 @@ export type PartialUpdateBlogCommentData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -11003,7 +9074,7 @@ export type UpdateBlogCommentData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -11058,19 +9129,19 @@ export type ListBlogCommentRepliesData = {
   }
   query?: {
     /**
-         * Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+         * Filter comments that are ancestors of the given comment ID
          */
     ancestorOf?: string | number
     /**
-         * Φίλτρο ανά κατάσταση έγκρισης
+         * Filter by approval status
          */
     approved?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by comment content (case-insensitive)
          */
     content?: string
     /**
-         * Φίλτρο ανά ακριβές μήκος περιεχομένου
+         * Filter by exact content length
          */
     contentLength?: string | number
     /**
@@ -11085,19 +9156,19 @@ export type ListBlogCommentRepliesData = {
          */
     createdBefore?: string
     /**
-         * Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+         * Filter comments that are descendants of the given comment ID
          */
     descendantOf?: string | number
     /**
-         * Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+         * Filter comments that have content (true) or are empty (false)
          */
     hasContent?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+         * Filter comments that have likes (true) or no likes (false)
          */
     hasLikes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+         * Filter comments that have approved replies (true) or no replies (false)
          */
     hasReplies?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -11106,65 +9177,65 @@ export type ListBlogCommentRepliesData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+         * Filter anonymous comments (no user)
          */
     isAnonymous?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+         * Filter leaf comments (no approved replies)
          */
     isLeaf?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+         * Filter by comment nesting level (0 for top-level)
          */
     level?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+         * Filter comments at or below this nesting level
          */
     level_Gte?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+         * Filter comments at or above this nesting level
          */
     level_Lte?: string | number
     /**
-         * Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by left tree value (MPTT internal)
          */
     lft?: string | number
     lft_Gte?: string | number
     lft_Lte?: string | number
     /**
-         * Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+         * Filter comments liked by specific user ID
          */
     likedBy?: string | number
     /**
-         * Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+         * Filter comments with at most this content length
          */
     maxContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες επισημάνσεις
+         * Filter comments with at most this many likes
          */
     maxLikes?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at most this many approved replies
          */
     maxReplies?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+         * Filter comments with at least this content length
          */
     minContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+         * Filter comments with at least this many likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at least this many approved replies
          */
     minReplies?: string | number
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+         * Order comments by most likes first
          */
     mostLiked?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+         * Order comments by most approved replies first
          */
     mostReplied?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -11180,43 +9251,43 @@ export type ListBlogCommentRepliesData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο ανά ID γονικού σχολίου
+         * Filter by parent comment ID
          */
     parent?: string | number
     /**
-         * Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+         * Filter top-level comments (true) or replies (false)
          */
     parent_Isnull?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID άρθρου
+         * Filter by blog post ID
          */
     post?: string | number
     /**
-         * Φίλτρο ανά ID συντάκτη άρθρου
+         * Filter by blog post author ID
          */
     post_Author?: string | number
     /**
-         * Φίλτρο ανά ID κατηγορίας άρθρου
+         * Filter by blog post category ID
          */
     post_Category?: string | number
     /**
-         * Φίλτρο ανά slug κατηγορίας άρθρου
+         * Filter by blog post category slug
          */
     post_Category_Slug?: string
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+         * Filter by blog post published status
          */
     post_IsPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά slug άρθρου
+         * Filter by blog post slug
          */
     post_Slug?: string
     /**
-         * Φίλτρο ανά τίτλο άρθρου
+         * Filter by blog post title
          */
     post_Title?: string
     /**
-         * Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by right tree value (MPTT internal)
          */
     rght?: string | number
     rght_Gte?: string | number
@@ -11226,7 +9297,7 @@ export type ListBlogCommentRepliesData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+         * Filter by tree ID (MPTT internal)
          */
     treeId?: string | number
     /**
@@ -11241,19 +9312,19 @@ export type ListBlogCommentRepliesData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη
+         * Filter by user email
          */
     user_Email?: string
     /**
-         * Φίλτρο σχολίων από ενεργούς χρήστες
+         * Filter comments by active users
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων από staff
+         * Filter comments by staff users
          */
     user_IsStaff?: 'true' | 'false' | '1' | '0' | boolean
     uuid?: string
@@ -11284,19 +9355,19 @@ export type GetBlogCommentThreadData = {
   }
   query?: {
     /**
-         * Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+         * Filter comments that are ancestors of the given comment ID
          */
     ancestorOf?: string | number
     /**
-         * Φίλτρο ανά κατάσταση έγκρισης
+         * Filter by approval status
          */
     approved?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by comment content (case-insensitive)
          */
     content?: string
     /**
-         * Φίλτρο ανά ακριβές μήκος περιεχομένου
+         * Filter by exact content length
          */
     contentLength?: string | number
     /**
@@ -11311,19 +9382,19 @@ export type GetBlogCommentThreadData = {
          */
     createdBefore?: string
     /**
-         * Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+         * Filter comments that are descendants of the given comment ID
          */
     descendantOf?: string | number
     /**
-         * Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+         * Filter comments that have content (true) or are empty (false)
          */
     hasContent?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+         * Filter comments that have likes (true) or no likes (false)
          */
     hasLikes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+         * Filter comments that have approved replies (true) or no replies (false)
          */
     hasReplies?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -11332,65 +9403,65 @@ export type GetBlogCommentThreadData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+         * Filter anonymous comments (no user)
          */
     isAnonymous?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+         * Filter leaf comments (no approved replies)
          */
     isLeaf?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+         * Filter by comment nesting level (0 for top-level)
          */
     level?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+         * Filter comments at or below this nesting level
          */
     level_Gte?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+         * Filter comments at or above this nesting level
          */
     level_Lte?: string | number
     /**
-         * Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by left tree value (MPTT internal)
          */
     lft?: string | number
     lft_Gte?: string | number
     lft_Lte?: string | number
     /**
-         * Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+         * Filter comments liked by specific user ID
          */
     likedBy?: string | number
     /**
-         * Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+         * Filter comments with at most this content length
          */
     maxContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες επισημάνσεις
+         * Filter comments with at most this many likes
          */
     maxLikes?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at most this many approved replies
          */
     maxReplies?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+         * Filter comments with at least this content length
          */
     minContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+         * Filter comments with at least this many likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at least this many approved replies
          */
     minReplies?: string | number
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+         * Order comments by most likes first
          */
     mostLiked?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+         * Order comments by most approved replies first
          */
     mostReplied?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -11406,43 +9477,43 @@ export type GetBlogCommentThreadData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο ανά ID γονικού σχολίου
+         * Filter by parent comment ID
          */
     parent?: string | number
     /**
-         * Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+         * Filter top-level comments (true) or replies (false)
          */
     parent_Isnull?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID άρθρου
+         * Filter by blog post ID
          */
     post?: string | number
     /**
-         * Φίλτρο ανά ID συντάκτη άρθρου
+         * Filter by blog post author ID
          */
     post_Author?: string | number
     /**
-         * Φίλτρο ανά ID κατηγορίας άρθρου
+         * Filter by blog post category ID
          */
     post_Category?: string | number
     /**
-         * Φίλτρο ανά slug κατηγορίας άρθρου
+         * Filter by blog post category slug
          */
     post_Category_Slug?: string
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+         * Filter by blog post published status
          */
     post_IsPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά slug άρθρου
+         * Filter by blog post slug
          */
     post_Slug?: string
     /**
-         * Φίλτρο ανά τίτλο άρθρου
+         * Filter by blog post title
          */
     post_Title?: string
     /**
-         * Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by right tree value (MPTT internal)
          */
     rght?: string | number
     rght_Gte?: string | number
@@ -11452,7 +9523,7 @@ export type GetBlogCommentThreadData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+         * Filter by tree ID (MPTT internal)
          */
     treeId?: string | number
     /**
@@ -11467,19 +9538,19 @@ export type GetBlogCommentThreadData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη
+         * Filter by user email
          */
     user_Email?: string
     /**
-         * Φίλτρο σχολίων από ενεργούς χρήστες
+         * Filter comments by active users
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων από staff
+         * Filter comments by staff users
          */
     user_IsStaff?: 'true' | 'false' | '1' | '0' | boolean
     uuid?: string
@@ -11556,19 +9627,19 @@ export type ListMyBlogCommentsData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο σχολίων που είναι πρόγονοι του δεδομένου σχολίου
+         * Filter comments that are ancestors of the given comment ID
          */
     ancestorOf?: string | number
     /**
-         * Φίλτρο ανά κατάσταση έγκρισης
+         * Filter by approval status
          */
     approved?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by comment content (case-insensitive)
          */
     content?: string
     /**
-         * Φίλτρο ανά ακριβές μήκος περιεχομένου
+         * Filter by exact content length
          */
     contentLength?: string | number
     /**
@@ -11583,19 +9654,19 @@ export type ListMyBlogCommentsData = {
          */
     createdBefore?: string
     /**
-         * Φίλτρο σχολίων που είναι απόγονοι του δεδομένου σχολίου
+         * Filter comments that are descendants of the given comment ID
          */
     descendantOf?: string | number
     /**
-         * Φίλτρο σχολίων με περιεχόμενο (true) ή κενών (false)
+         * Filter comments that have content (true) or are empty (false)
          */
     hasContent?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με επισημάνσεις (true) ή χωρίς επισημάνσεις (false)
+         * Filter comments that have likes (true) or no likes (false)
          */
     hasLikes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων με εγκεκριμένες απαντήσεις (true) ή χωρίς απαντήσεις (false)
+         * Filter comments that have approved replies (true) or no replies (false)
          */
     hasReplies?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -11604,65 +9675,65 @@ export type ListMyBlogCommentsData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανώνυμων σχολίων (χωρίς χρήστη)
+         * Filter anonymous comments (no user)
          */
     isAnonymous?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο τελικών σχολίων (χωρίς εγκεκριμένες απαντήσεις)
+         * Filter leaf comments (no approved replies)
          */
     isLeaf?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επίπεδο ένθεσης σχολίου (0 για ανώτατο επίπεδο)
+         * Filter by comment nesting level (0 for top-level)
          */
     level?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή χαμηλότερα
+         * Filter comments at or below this nesting level
          */
     level_Gte?: string | number
     /**
-         * Φίλτρο σχολίων σε αυτό το επίπεδο ένθεσης ή υψηλότερα
+         * Filter comments at or above this nesting level
          */
     level_Lte?: string | number
     /**
-         * Φίλτρο ανά αριστερή τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by left tree value (MPTT internal)
          */
     lft?: string | number
     lft_Gte?: string | number
     lft_Lte?: string | number
     /**
-         * Φίλτρο σχολίων με επισήμανση από συγκεκριμένο χρήστη
+         * Filter comments liked by specific user ID
          */
     likedBy?: string | number
     /**
-         * Φίλτρο σχολίων με έως αυτό το μήκος περιεχομένου
+         * Filter comments with at most this content length
          */
     maxContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες επισημάνσεις
+         * Filter comments with at most this many likes
          */
     maxLikes?: string | number
     /**
-         * Φίλτρο σχολίων με έως τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at most this many approved replies
          */
     maxReplies?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον αυτό το μήκος περιεχομένου
+         * Filter comments with at least this content length
          */
     minContentLength?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες επισημάνσεις
+         * Filter comments with at least this many likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο σχολίων με τουλάχιστον τόσες εγκεκριμένες απαντήσεις
+         * Filter comments with at least this many approved replies
          */
     minReplies?: string | number
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες επισημάνσεις πρώτα
+         * Order comments by most likes first
          */
     mostLiked?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Ταξινόμηση σχολίων με τις περισσότερες εγκεκριμένες απαντήσεις πρώτα
+         * Order comments by most approved replies first
          */
     mostReplied?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -11678,43 +9749,43 @@ export type ListMyBlogCommentsData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο ανά ID γονικού σχολίου
+         * Filter by parent comment ID
          */
     parent?: string | number
     /**
-         * Φίλτρο σχολίων ανώτατου επιπέδου (true) ή απαντήσεων (false)
+         * Filter top-level comments (true) or replies (false)
          */
     parent_Isnull?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID άρθρου
+         * Filter by blog post ID
          */
     post?: string | number
     /**
-         * Φίλτρο ανά ID συντάκτη άρθρου
+         * Filter by blog post author ID
          */
     post_Author?: string | number
     /**
-         * Φίλτρο ανά ID κατηγορίας άρθρου
+         * Filter by blog post category ID
          */
     post_Category?: string | number
     /**
-         * Φίλτρο ανά slug κατηγορίας άρθρου
+         * Filter by blog post category slug
          */
     post_Category_Slug?: string
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης άρθρου
+         * Filter by blog post published status
          */
     post_IsPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά slug άρθρου
+         * Filter by blog post slug
          */
     post_Slug?: string
     /**
-         * Φίλτρο ανά τίτλο άρθρου
+         * Filter by blog post title
          */
     post_Title?: string
     /**
-         * Φίλτρο ανά δεξιά τιμή δέντρου (εσωτερικό MPTT)
+         * Filter by right tree value (MPTT internal)
          */
     rght?: string | number
     rght_Gte?: string | number
@@ -11724,7 +9795,7 @@ export type ListMyBlogCommentsData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά ID δέντρου (εσωτερικό MPTT)
+         * Filter by tree ID (MPTT internal)
          */
     treeId?: string | number
     /**
@@ -11739,19 +9810,19 @@ export type ListMyBlogCommentsData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη
+         * Filter by user email
          */
     user_Email?: string
     /**
-         * Φίλτρο σχολίων από ενεργούς χρήστες
+         * Filter comments by active users
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο σχολίων από staff
+         * Filter comments by staff users
          */
     user_IsStaff?: 'true' | 'false' | '1' | '0' | boolean
     uuid?: string
@@ -11780,46 +9851,46 @@ export type ListBlogPostData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ID συντάκτη
+         * Filter by author ID
          */
     author?: string | number
     /**
-         * Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author email (case-insensitive)
          */
     authorEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author full name (case-insensitive)
          */
     authorName?: string
     /**
-         * Φίλτρο ανά ID κατηγορίας
+         * Filter by category ID
          */
     category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by category name (case-insensitive)
          */
     categoryName?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ανά κατάσταση προτεινόμενου
+         * Filter by featured status
          */
     featured?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -11828,27 +9899,27 @@ export type ListBlogPostData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+         * Filter by minimum number of approved comments
          */
     minComments?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+         * Filter by minimum number of likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+         * Filter by minimum number of active tags
          */
     minTags?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό προβολών
+         * Filter by minimum number of views
          */
     minViewCount?: string | number
     /**
@@ -11860,26 +9931,26 @@ export type ListBlogPostData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
@@ -11889,26 +9960,26 @@ export type ListBlogPostData = {
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by tag label (case-insensitive)
          */
     tagName?: string
     /**
-         * Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+         * Filter by tag IDs (comma-separated)
          */
     tags?: string | Array<number>
     /**
-         * Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by title (case-insensitive)
          */
     title?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     uuid?: string
@@ -11940,7 +10011,7 @@ export type CreateBlogPostData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -11996,7 +10067,7 @@ export type RetrieveBlogPostData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -12025,7 +10096,7 @@ export type PartialUpdateBlogPostData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -12055,7 +10126,7 @@ export type UpdateBlogPostData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -12138,42 +10209,42 @@ export type ListBlogPostRelatedData = {
   }
   query?: {
     /**
-         * Φίλτρο ανά ID συντάκτη
+         * Filter by author ID
          */
     author?: string | number
     /**
-         * Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author email (case-insensitive)
          */
     authorEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author full name (case-insensitive)
          */
     authorName?: string
     /**
-         * Φίλτρο ανά ID κατηγορίας
+         * Filter by category ID
          */
     category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by category name (case-insensitive)
          */
     categoryName?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κατάσταση προτεινόμενου
+         * Filter by featured status
          */
     featured?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -12182,23 +10253,23 @@ export type ListBlogPostRelatedData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+         * Filter by minimum number of approved comments
          */
     minComments?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+         * Filter by minimum number of likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+         * Filter by minimum number of active tags
          */
     minTags?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό προβολών
+         * Filter by minimum number of views
          */
     minViewCount?: string | number
     /**
@@ -12206,14 +10277,14 @@ export type ListBlogPostRelatedData = {
          */
     ordering?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
@@ -12223,26 +10294,26 @@ export type ListBlogPostRelatedData = {
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by tag label (case-insensitive)
          */
     tagName?: string
     /**
-         * Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+         * Filter by tag IDs (comma-separated)
          */
     tags?: string | Array<number>
     /**
-         * Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by title (case-insensitive)
          */
     title?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     uuid?: string
@@ -12324,42 +10395,42 @@ export type ListFeaturedBlogPostsData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ID συντάκτη
+         * Filter by author ID
          */
     author?: string | number
     /**
-         * Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author email (case-insensitive)
          */
     authorEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author full name (case-insensitive)
          */
     authorName?: string
     /**
-         * Φίλτρο ανά ID κατηγορίας
+         * Filter by category ID
          */
     category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by category name (case-insensitive)
          */
     categoryName?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κατάσταση προτεινόμενου
+         * Filter by featured status
          */
     featured?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -12368,23 +10439,23 @@ export type ListFeaturedBlogPostsData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+         * Filter by minimum number of approved comments
          */
     minComments?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+         * Filter by minimum number of likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+         * Filter by minimum number of active tags
          */
     minTags?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό προβολών
+         * Filter by minimum number of views
          */
     minViewCount?: string | number
     /**
@@ -12400,14 +10471,14 @@ export type ListFeaturedBlogPostsData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
@@ -12417,26 +10488,26 @@ export type ListFeaturedBlogPostsData = {
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by tag label (case-insensitive)
          */
     tagName?: string
     /**
-         * Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+         * Filter by tag IDs (comma-separated)
          */
     tags?: string | Array<number>
     /**
-         * Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by title (case-insensitive)
          */
     title?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     uuid?: string
@@ -12491,42 +10562,42 @@ export type ListPopularBlogPostsData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ID συντάκτη
+         * Filter by author ID
          */
     author?: string | number
     /**
-         * Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author email (case-insensitive)
          */
     authorEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author full name (case-insensitive)
          */
     authorName?: string
     /**
-         * Φίλτρο ανά ID κατηγορίας
+         * Filter by category ID
          */
     category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by category name (case-insensitive)
          */
     categoryName?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κατάσταση προτεινόμενου
+         * Filter by featured status
          */
     featured?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -12535,23 +10606,23 @@ export type ListPopularBlogPostsData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+         * Filter by minimum number of approved comments
          */
     minComments?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+         * Filter by minimum number of likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+         * Filter by minimum number of active tags
          */
     minTags?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό προβολών
+         * Filter by minimum number of views
          */
     minViewCount?: string | number
     /**
@@ -12567,14 +10638,14 @@ export type ListPopularBlogPostsData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
@@ -12584,26 +10655,26 @@ export type ListPopularBlogPostsData = {
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by tag label (case-insensitive)
          */
     tagName?: string
     /**
-         * Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+         * Filter by tag IDs (comma-separated)
          */
     tags?: string | Array<number>
     /**
-         * Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by title (case-insensitive)
          */
     title?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     uuid?: string
@@ -12635,38 +10706,38 @@ export type ListTrendingBlogPostsData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ID συντάκτη
+         * Filter by author ID
          */
     author?: string | number
     /**
-         * Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author email (case-insensitive)
          */
     authorEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by author full name (case-insensitive)
          */
     authorName?: string
     /**
-         * Φίλτρο ανά ID κατηγορίας
+         * Filter by category ID
          */
     category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by category name (case-insensitive)
          */
     categoryName?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -12674,7 +10745,7 @@ export type ListTrendingBlogPostsData = {
          */
     days?: string | number
     /**
-         * Φίλτρο ανά κατάσταση προτεινόμενου
+         * Filter by featured status
          */
     featured?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -12683,23 +10754,23 @@ export type ListTrendingBlogPostsData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό εγκεκριμένων σχολίων
+         * Filter by minimum number of approved comments
          */
     minComments?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό επισημάνσεων
+         * Filter by minimum number of likes
          */
     minLikes?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό ενεργών ετικετών
+         * Filter by minimum number of active tags
          */
     minTags?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο αριθμό προβολών
+         * Filter by minimum number of views
          */
     minViewCount?: string | number
     /**
@@ -12715,14 +10786,14 @@ export type ListTrendingBlogPostsData = {
          */
     pageSize?: string | number
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
@@ -12732,26 +10803,26 @@ export type ListTrendingBlogPostsData = {
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by tag label (case-insensitive)
          */
     tagName?: string
     /**
-         * Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+         * Filter by tag IDs (comma-separated)
          */
     tags?: string | Array<number>
     /**
-         * Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by title (case-insensitive)
          */
     title?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     uuid?: string
@@ -12783,7 +10854,7 @@ export type ListBlogTagData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά κατάσταση ενεργοποίησης
+         * Filter by active status
          */
     active?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -12798,19 +10869,19 @@ export type ListBlogTagData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα με/χωρίς επισημάνσεις
+         * Filter tags used in posts that have/don't have likes
          */
     hasLikedPosts?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ετικετών με/χωρίς όνομα
+         * Filter tags that have/don't have a name
          */
     hasName?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ετικετών με/χωρίς άρθρα
+         * Filter tags that have/don't have posts
          */
     hasPosts?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -12819,39 +10890,39 @@ export type ListBlogTagData = {
          */
     id_In?: string | Array<number>
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ετικετών με έως X άρθρα
+         * Filter tags with at most X posts
          */
     maxPosts?: string | number
     /**
-         * Φίλτρο ετικετών με τουλάχιστον X άρθρα
+         * Filter tags with at least X posts
          */
     minPosts?: string | number
     /**
-         * Φίλτρο ετικετών με άρθρα που έχουν τουλάχιστον X συνολικές επισημάνσεις
+         * Filter tags with posts having at least X total likes
          */
     minTotalLikes?: string | number
     /**
-         * Ταξινόμηση ετικετών κατά συνολικές επισημάνσεις στα άρθρα που τις χρησιμοποιούν
+         * Order tags by total likes on posts using them
          */
     mostLiked?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+         * Order tags by usage count (most used first)
          */
     mostUsed?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά όνομα ετικέτας (μερική αντιστοίχιση)
+         * Filter by tag name (partial match)
          */
     name?: string
     /**
-         * Φίλτρο ανά ακριβές όνομα ετικέτας
+         * Filter by exact tag name
          */
     name_Exact?: string
     /**
-         * Φίλτρο ετικετών με όνομα που ξεκινά με
+         * Filter tags with names starting with
          */
     name_Startswith?: string
     /**
@@ -12863,31 +10934,31 @@ export type ListBlogTagData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται από συγκεκριμένο άρθρο
+         * Filter tags used by specific post ID
          */
     post?: string | number
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένου συντάκτη
+         * Filter tags used in posts by specific author
          */
     post_Author?: string | number
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται σε άρθρα συγκεκριμένης κατηγορίας
+         * Filter tags used in posts from specific category
          */
     post_Category?: string | number
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται σε δημοσιευμένα/μη δημοσιευμένα άρθρα
+         * Filter tags used in published/unpublished posts
          */
     post_IsPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -12901,7 +10972,7 @@ export type ListBlogTagData = {
     translations_Name_Icontains?: string
     translations_Name_Istartswith?: string
     /**
-         * Φίλτρο ετικετών που δεν χρησιμοποιούνται σε κανένα άρθρο
+         * Filter tags not used in any posts
          */
     unused?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -12941,7 +11012,7 @@ export type CreateBlogTagData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -12997,7 +11068,7 @@ export type RetrieveBlogTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -13026,7 +11097,7 @@ export type PartialUpdateBlogTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -13056,7 +11127,7 @@ export type UpdateBlogTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -13226,35 +11297,35 @@ export type ListCartItemData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ID καλαθιού
+         * Filter by cart ID
          */
     cart?: string | number
     /**
-         * Φίλτρο αντικειμένων σε καλάθια επισκεπτών
+         * Filter items in guest carts
          */
     cart_IsGuest?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID χρήστη καλαθιού
+         * Filter by cart user ID
          */
     cart_User?: string | number
     /**
-         * Φίλτρο ανά email χρήστη καλαθιού (μερική αντιστοίχιση)
+         * Filter by cart user email (partial match)
          */
     cart_User_Email?: string
     /**
-         * Φίλτρο ανά όνομα χρήστη καλαθιού (όνομα ή επώνυμο)
+         * Filter by cart user name (first or last)
          */
     cart_User_Name?: string
     /**
-         * Φίλτρο ανά UUID καλαθιού
+         * Filter by cart UUID
          */
     cart_Uuid?: string
     /**
-         * Φίλτρο ανά τελευταία δραστηριότητα καλαθιού μετά από ημερομηνία
+         * Filter by cart last activity after date
          */
     cartLastActivityAfter?: string
     /**
-         * Φίλτρο ανά τελευταία δραστηριότητα καλαθιού πριν από ημερομηνία
+         * Filter by cart last activity before date
          */
     cartLastActivityBefore?: string
     /**
@@ -13269,7 +11340,7 @@ export type ListCartItemData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
@@ -13278,47 +11349,47 @@ export type ListCartItemData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ειδών σε εγκαταλελειμμένα καλάθια (30+ ημέρες)
+         * Filter items in abandoned carts (30+ days)
          */
     inAbandonedCarts?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ειδών σε ενεργά καλάθια (24ωρο)
+         * Filter items in active carts (24hr)
          */
     inActiveCarts?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά μέγιστο ποσοστό έκπτωσης
+         * Filter by maximum discount percentage
          */
     maxDiscountPercent?: string | number
     /**
-         * Φίλτρο ανά μέγιστη τιμή προϊόντος
+         * Filter by maximum product price
          */
     maxPrice?: string | number
     /**
-         * Φίλτρο ανά μέγιστη ποσότητα
+         * Filter by maximum quantity
          */
     maxQuantity?: string | number
     /**
-         * Φίλτρο ανά μέγιστη συνολική τιμή (ποσότητα * τιμή)
+         * Filter by maximum total price (quantity * price)
          */
     maxTotalPrice?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο ποσοστό έκπτωσης
+         * Filter by minimum discount percentage
          */
     minDiscountPercent?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη τιμή προϊόντος
+         * Filter by minimum product price
          */
     minPrice?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη ποσότητα
+         * Filter by minimum quantity
          */
     minQuantity?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη συνολική τιμή (ποσότητα * τιμή)
+         * Filter by minimum total price (quantity * price)
          */
     minTotalPrice?: string | number
     /**
@@ -13330,47 +11401,47 @@ export type ListCartItemData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά ID προϊόντος
+         * Filter by product ID
          */
     product?: string | number
     /**
-         * Φίλτρο ανά ενεργή κατάσταση προϊόντος
+         * Filter by product active status
          */
     product_Active?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID κατηγορίας προϊόντος
+         * Filter by product category ID
          */
     product_Category?: string | number
     /**
-         * Φίλτρο ανά slug κατηγορίας προϊόντος
+         * Filter by product category slug
          */
     product_Category_Slug?: string
     /**
-         * Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+         * Filter by product name (partial match)
          */
     product_Name?: string
     /**
-         * Φίλτρο ανά sku προϊόντος (ακριβής αντιστοίχιση)
+         * Filter by product sku (exact match)
          */
     product_Sku?: string
     /**
-         * Φίλτρο ανά UUID προϊόντος
+         * Filter by product UUID
          */
     product_Uuid?: string
     /**
-         * Φίλτρο ανά ακριβή ποσότητα
+         * Filter by exact quantity
          */
     quantity?: string | number
     quantity_Gte?: string | number
@@ -13392,7 +11463,7 @@ export type ListCartItemData = {
     updatedBefore?: string
     uuid?: string
     /**
-         * Φίλτρο ειδών με εκπτώσεις προϊόντος
+         * Filter items with product discounts
          */
     withDiscounts?: 'true' | 'false' | '1' | '0' | boolean
   }
@@ -13480,7 +11551,7 @@ export type RetrieveCartItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -13515,7 +11586,7 @@ export type PartialUpdateCartItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -13580,7 +11651,7 @@ export type ListCartData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά τύπο καλαθιού
+         * Filter by cart type
          *
          * * `user` - User Cart
          * * `guest` - Guest Cart
@@ -13599,19 +11670,19 @@ export type ListCartData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο καλαθιών αδρανών για τουλάχιστον X ημέρες
+         * Filter carts inactive for at least X days
          */
     daysInactive?: string | number
     /**
-         * Φίλτρο καλαθιών με/χωρίς είδη σε έκπτωση
+         * Filter carts with/without discounted items
          */
     hasDiscounts?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο καλαθιών με/χωρίς είδη
+         * Filter carts that have/don't have items
          */
     hasItems?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -13620,58 +11691,58 @@ export type ListCartData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο εγκαταλελειμμένων καλαθιών (αδρανή για 30+ ημέρες)
+         * Filter abandoned carts (inactive for 30+ days)
          */
     isAbandoned?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ενεργών/εγκαταλελειμμένων καλαθιών (βάσει 30 ημερών αδράνειας)
+         * Filter active/abandoned carts (based on 30-day inactivity)
          */
     isActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο καλαθιών επισκεπτών (True) ή καλαθιών χρηστών (False)
+         * Filter guest carts (True) or user carts (False)
          */
     isGuest?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά ακριβή ημερομηνία τελευταίας δραστηριότητας
+         * Filter by exact last activity date
          */
     lastActivity?: string
     lastActivity_Date?: string
     lastActivity_Gte?: string
     lastActivity_Lte?: string
     /**
-         * Φίλτρο καλαθιών με τελευταία δραστηριότητα μετά από αυτή την ημερομηνία
+         * Filter carts with last activity after this date
          */
     lastActivityAfter?: string
     /**
-         * Φίλτρο καλαθιών με τελευταία δραστηριότητα πριν από αυτή την ημερομηνία
+         * Filter carts with last activity before this date
          */
     lastActivityBefore?: string
     /**
-         * Φίλτρο καλαθιών με έως X συνολικά είδη (ποσότητα)
+         * Filter carts with at most X total items (quantity)
          */
     maxItems?: string | number
     /**
-         * Φίλτρο καλαθιών με συνολική αξία έως X
+         * Filter carts with total value at most X
          */
     maxTotalValue?: string | number
     /**
-         * Φίλτρο καλαθιών με έως X μοναδικά είδη
+         * Filter carts with at most X unique items
          */
     maxUniqueItems?: string | number
     /**
-         * Φίλτρο καλαθιών με τουλάχιστον X συνολικά είδη (ποσότητα)
+         * Filter carts with at least X total items (quantity)
          */
     minItems?: string | number
     /**
-         * Φίλτρο καλαθιών με συνολική αξία τουλάχιστον X
+         * Filter carts with total value at least X
          */
     minTotalValue?: string | number
     /**
-         * Φίλτρο καλαθιών με τουλάχιστον X μοναδικά είδη
+         * Filter carts with at least X unique items
          */
     minUniqueItems?: string | number
     /**
@@ -13683,15 +11754,15 @@ export type ListCartData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -13710,23 +11781,23 @@ export type ListCartData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά ενεργούς χρήστες
+         * Filter by active users
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο καλαθιών με/χωρίς χρήστες
+         * Filter carts with/without users
          */
     user_Isnull?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+         * Filter by user email (partial match)
          */
     userEmail?: string
     /**
-         * Φίλτρο ανά πλήρες όνομα χρήστη (όνομα ή επώνυμο)
+         * Filter by user full name (first or last name)
          */
     userName?: string
     uuid?: string
@@ -13832,11 +11903,11 @@ export type ListCountryData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά ακριβή διψήφιο κωδικό χώρας
+         * Filter by exact 2-letter country code
          */
     alpha2?: string
     /**
-         * Φίλτρο ανά διψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+         * Filter by 2-letter country code (partial match)
          */
     alpha2_Icontains?: string
     alpha2_Iexact?: string
@@ -13845,11 +11916,11 @@ export type ListCountryData = {
          */
     alpha2_In?: string | Array<string>
     /**
-         * Φίλτρο ανά ακριβή τριψήφιο κωδικό χώρας
+         * Filter by exact 3-letter country code
          */
     alpha3?: string
     /**
-         * Φίλτρο ανά τριψήφιο κωδικό χώρας (μερική αντιστοίχιση)
+         * Filter by 3-letter country code (partial match)
          */
     alpha3_Icontains?: string
     alpha3_Iexact?: string
@@ -13858,7 +11929,7 @@ export type ListCountryData = {
          */
     alpha3_In?: string | Array<string>
     /**
-         * Φίλτρο ανά ήπειρο (βάσει κωδικών ISO)
+         * Filter by continent (based on ISO codes)
          *
          * * `AF` - Africa
          * * `AS` - Asia
@@ -13881,35 +11952,35 @@ export type ListCountryData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο χωρών με πλήρη δεδομένα (ISO, κλήση, σημαία, όνομα)
+         * Filter countries that have complete data (ISO, phone, flag, name)
          */
     hasAllData?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο χωρών με/χωρίς εικόνα σημαίας
+         * Filter countries that have/don't have flag image
          */
     hasFlagImage?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο χωρών με/χωρίς κωδικό ISO
+         * Filter countries that have/don't have ISO country code
          */
     hasIsoCc?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο χωρών με/χωρίς μετάφραση ονόματος
+         * Filter countries that have/don't have name translation
          */
     hasName?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο χωρών με/χωρίς κωδικό κλήσης
+         * Filter countries that have/don't have phone code
          */
     hasPhoneCode?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο χωρών μελών ΕΕ
+         * Filter EU member countries
          */
     isEu?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ακριβή ISO κωδικό χώρας
+         * Filter by exact ISO country code
          */
     isoCc?: string | number
     isoCc_Gte?: string | number
@@ -13919,31 +11990,31 @@ export type ListCountryData = {
     isoCc_In?: string | Array<number>
     isoCc_Lte?: string | number
     /**
-         * Φίλτρο χωρών με κωδικό ISO μικρότερο ή ίσο με
+         * Filter countries with ISO code less than or equal to
          */
     isoCcMax?: string | number
     /**
-         * Φίλτρο χωρών με κωδικό ISO μεγαλύτερο ή ίσο με
+         * Filter countries with ISO code greater than or equal to
          */
     isoCcMin?: string | number
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά πολλαπλούς κωδικούς χωρών (διαχωρισμένους με κόμμα, alpha-2 ή alpha-3)
+         * Filter by multiple country codes (comma-separated, alpha-2 or alpha-3)
          */
     multipleCodes?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+         * Filter by country name (partial match)
          */
     name?: string
     /**
-         * Φίλτρο ανά ακριβές όνομα χώρας
+         * Filter by exact country name
          */
     name_Exact?: string
     /**
-         * Φίλτρο χωρών με όνομα που ξεκινά με
+         * Filter countries with names starting with
          */
     name_Startswith?: string
     /**
@@ -13955,19 +12026,19 @@ export type ListCountryData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά ακριβή κωδικό κλήσης
+         * Filter by exact phone code
          */
     phoneCode?: string | number
     phoneCode_Gte?: string | number
@@ -13977,11 +12048,11 @@ export type ListCountryData = {
     phoneCode_In?: string | Array<number>
     phoneCode_Lte?: string | number
     /**
-         * Φίλτρο χωρών με κωδικό κλήσης μικρότερο ή ίσο με
+         * Filter countries with phone code less than or equal to
          */
     phoneCodeMax?: string | number
     /**
-         * Φίλτρο χωρών με κωδικό κλήσης μεγαλύτερο ή ίσο με
+         * Filter countries with phone code greater than or equal to
          */
     phoneCodeMin?: string | number
     /**
@@ -14028,7 +12099,7 @@ export type CreateCountryData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14055,9 +12126,9 @@ export type DestroyCountryData = {
   body?: never
   path: {
     /**
-         * Κωδικός Χώρας (Alpha 2)
+         * Country Code Alpha 2
          *
-         * A unique value identifying this Χώρα.
+         * A unique value identifying this Country.
          */
     alpha2: string
   }
@@ -14086,15 +12157,15 @@ export type RetrieveCountryData = {
   body?: never
   path: {
     /**
-         * Κωδικός Χώρας (Alpha 2)
+         * Country Code Alpha 2
          *
-         * A unique value identifying this Χώρα.
+         * A unique value identifying this Country.
          */
     alpha2: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14120,15 +12191,15 @@ export type PartialUpdateCountryData = {
   body?: PatchedCountryWriteRequest
   path: {
     /**
-         * Κωδικός Χώρας (Alpha 2)
+         * Country Code Alpha 2
          *
-         * A unique value identifying this Χώρα.
+         * A unique value identifying this Country.
          */
     alpha2: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14155,15 +12226,15 @@ export type UpdateCountryData = {
   body: CountryWriteRequest
   path: {
     /**
-         * Κωδικός Χώρας (Alpha 2)
+         * Country Code Alpha 2
          *
-         * A unique value identifying this Χώρα.
+         * A unique value identifying this Country.
          */
     alpha2: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14347,7 +12418,7 @@ export type GetNotificationsByIdsData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ειδοποιήσεων κατά κατάσταση προβολής. Αν είναι false, επιστρέφει μόνο τις μη ορατές ειδοποιήσεις.
+         * Filter notifications by seen status. If false, returns only unseen notifications.
          */
     seen?: 'true' | 'false' | '1' | '0' | boolean
   }
@@ -14376,15 +12447,15 @@ export type ListNotificationUserData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ειδοποιήσεων που έχουν προβληθεί (true) ή όχι (false)
+         * Filter notifications that have been seen (true) or not seen (false)
          */
     hasSeenAt?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ειδοποιήσεων υψηλής προτεραιότητας
+         * Filter high priority notifications
          */
     highPriority?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -14393,59 +12464,59 @@ export type ListNotificationUserData = {
          */
     id_In?: string | Array<number>
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά ID ειδοποίησης
+         * Filter by notification ID
          */
     notification?: string | number
     /**
-         * Φίλτρο ανά κατηγορία ειδοποίησης
+         * Filter by notification category
          */
     notification_Category?: string
     /**
-         * Φίλτρο ειδοποιήσεων που λήγουν μετά από αυτή την ημερομηνία
+         * Filter notifications expiring after this date
          */
     notification_ExpiresAfter?: string
     /**
-         * Φίλτρο ειδοποιήσεων που λήγουν πριν από αυτή την ημερομηνία
+         * Filter notifications expiring before this date
          */
     notification_ExpiresBefore?: string
     /**
-         * Φίλτρο ανά κατάσταση λήξης ειδοποίησης
+         * Filter by notification expiry status
          */
     notification_IsExpired?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά τύπο ειδοποίησης
+         * Filter by notification kind
          */
     notification_Kind?: string
     /**
-         * Φίλτρο ανά σύνδεσμο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by notification link (case-insensitive)
          */
     notification_Link?: string
     /**
-         * Φίλτρο ανά μήνυμα ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by notification message (case-insensitive)
          */
     notification_Message?: string
     /**
-         * Φίλτρο ανά προτεραιότητα ειδοποίησης
+         * Filter by notification priority
          */
     notification_Priority?: string
     /**
-         * Φίλτρο ανά τίτλο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by notification title (case-insensitive)
          */
     notification_Title?: string
     /**
-         * Φίλτρο ανά τύπο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by notification type (case-insensitive)
          */
     notification_Type?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID ειδοποιήσεων (διαχωρισμένα με κόμμα)
+         * Filter by multiple notification IDs (comma-separated)
          */
     notificationIds?: string
     /**
-         * Φίλτρο ανά τύπο ειδοποίησης
+         * Filter by notification kind
          */
     notificationKind?: string
     /**
@@ -14457,19 +12528,19 @@ export type ListNotificationUserData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ειδοποιήσεων των τελευταίων 7 ημερών
+         * Filter notifications from the last 7 days
          */
     recentNotifications?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -14477,26 +12548,26 @@ export type ListNotificationUserData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά κατάσταση προβολής
+         * Filter by seen status
          */
     seen?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ειδοποιήσεων που προβλήθηκαν μετά από αυτή την ημερομηνία
+         * Filter notifications seen after this date
          */
     seenAfter?: string
     seenAt_Date?: string
     seenAt_Gte?: string
     seenAt_Lte?: string
     /**
-         * Φίλτρο ειδοποιήσεων που προβλήθηκαν πριν από αυτή την ημερομηνία
+         * Filter notifications seen before this date
          */
     seenBefore?: string
     /**
-         * Φίλτρο μόνο ορατών ειδοποιήσεων
+         * Filter only seen notifications
          */
     seenOnly?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο μόνο μη ορατών ειδοποιήσεων
+         * Filter only unseen notifications
          */
     unseenOnly?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -14511,31 +12582,31 @@ export type ListNotificationUserData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user email (case-insensitive)
          */
     user_Email?: string
     /**
-         * Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user first name (case-insensitive)
          */
     user_FirstName?: string
     /**
-         * Φίλτρο ανά ενεργή κατάσταση χρήστη
+         * Filter by user active status
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά staff status χρήστη
+         * Filter by user staff status
          */
     user_IsStaff?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user last name (case-insensitive)
          */
     user_LastName?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+         * Filter by multiple user IDs (comma-separated)
          */
     userIds?: string
     uuid?: string
@@ -14592,7 +12663,7 @@ export type RetrieveNotificationUserData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14621,7 +12692,7 @@ export type PartialUpdateNotificationUserData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14651,7 +12722,7 @@ export type UpdateNotificationUserData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -14794,32 +12865,32 @@ export type ListOrderData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+         * Filter active orders (pending, processing, shipped, delivered)
          */
     activeOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+         * Filter orders that can be canceled
          */
     canBeCanceled?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+         * Filter by city (case-insensitive)
          */
     city?: string
     city_Icontains?: string
     /**
-         * Φίλτρο ανά κωδικό χώρας
+         * Filter by country code
          */
     country?: string
     /**
-         * Φίλτρο ανά alpha-2 κωδικό χώρας
+         * Filter by country alpha-2 code
          */
     country_Alpha2?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by country name (case-insensitive)
          */
     country_Name?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+         * Filter by multiple country IDs (comma-separated)
          */
     countryIds?: string
     /**
@@ -14834,51 +12905,51 @@ export type ListOrderData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     customerNotes?: string
     customerNotes_Icontains?: string
     /**
-         * Φίλτρο ανά τύπο εγγράφου
+         * Filter by document type
          */
     documentType?: string
     /**
-         * Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer email (case-insensitive)
          */
     email?: string
     email_Icontains?: string
     /**
-         * Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+         * Filter final orders (completed, canceled, refunded)
          */
     finalOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer first name (case-insensitive)
          */
     firstName?: string
     firstName_Icontains?: string
     /**
-         * Φίλτρο ανά όροφο
+         * Filter by floor
          */
     floor?: string
     /**
-         * Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+         * Filter orders that have/don't have customer notes
          */
     hasCustomerNotes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+         * Filter orders that have/don't have payment ID
          */
     hasPaymentId?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+         * Filter orders that have status update timestamp
          */
     hasStatusUpdatedAt?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+         * Filter orders that have/don't have tracking number
          */
     hasTracking?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς χρήστη
+         * Filter orders that have/don't have a user
          */
     hasUser?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -14887,32 +12958,32 @@ export type ListOrderData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ακυρωμένων παραγγελιών
+         * Filter canceled orders
          */
     isCanceled?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ολοκληρωμένων παραγγελιών
+         * Filter completed orders
          */
     isCompleted?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+         * Filter paid/unpaid orders
          */
     isPaid?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer last name (case-insensitive)
          */
     lastName?: string
     lastName_Icontains?: string
     /**
-         * Φίλτρο ανά τύπο τοποθεσίας
+         * Filter by location type
          */
     locationType?: string
     /**
-         * Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+         * Filter orders that need processing
          */
     needsProcessing?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -14924,61 +12995,59 @@ export type ListOrderData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     paidAmount_Gte?: string | number
     paidAmount_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστο πληρωμένο ποσό
+         * Filter by maximum paid amount
          */
     paidAmountMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+         * Filter by minimum paid amount
          */
     paidAmountMin?: string | number
     /**
-         * Φίλτρο ανά ID μεθόδου πληρωμής
+         * Filter by payment method ID
          */
     payWay?: string | number
     /**
-         * Φίλτρο ανά online μεθόδους πληρωμής
+         * Filter by online payment methods
          */
     payWay_IsOnlinePayment?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by payment method name (case-insensitive)
          */
     payWay_Name?: string
     /**
-         * Φίλτρο ανά ID πληρωμής
+         * Filter by payment ID
          */
     paymentId?: string
     paymentId_Icontains?: string
     /**
-         * Φίλτρο ανά μέθοδο πληρωμής
+         * Filter by payment method
          */
     paymentMethod?: string
     paymentMethod_Icontains?: string
     /**
-         * Κατάσταση πληρωμής
+         * Filter by payment status
          *
-         * Φίλτρο ανά κατάσταση πληρωμής
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `FAILED` - Απέτυχε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
-         * * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-         * * `CANCELED` - Ακυρώθηκε
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `COMPLETED` - Completed
+         * * `FAILED` - Failed
+         * * `REFUNDED` - Refunded
+         * * `PARTIALLY_REFUNDED` - Partially Refunded
+         * * `CANCELED` - Canceled
          */
     paymentStatus?: 'CANCELED' | 'COMPLETED' | 'FAILED' | 'PARTIALLY_REFUNDED' | 'PENDING' | 'PROCESSING' | 'REFUNDED'
     /**
@@ -14986,25 +13055,25 @@ export type ListOrderData = {
          */
     paymentStatus_In?: string | Array<string>
     /**
-         * Φίλτρο ανά αριθμό τηλεφώνου
+         * Filter by phone number
          */
     phone?: string
     phone_Icontains?: string
     /**
-         * Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by place (case-insensitive)
          */
     place?: string
     place_Icontains?: string
     /**
-         * Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+         * Filter orders from the last 30 days
          */
     recentOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κωδικό περιφέρειας
+         * Filter by region code
          */
     region?: string
     /**
-         * Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by region name (case-insensitive)
          */
     region_Name?: string
     /**
@@ -15012,33 +13081,31 @@ export type ListOrderData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά εταιρεία μεταφοράς
+         * Filter by shipping carrier
          */
     shippingCarrier?: string
     shippingCarrier_Icontains?: string
     shippingPrice_Gte?: string | number
     shippingPrice_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστα έξοδα αποστολής
+         * Filter by maximum shipping price
          */
     shippingPriceMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστα έξοδα αποστολής
+         * Filter by minimum shipping price
          */
     shippingPriceMin?: string | number
     /**
-         * Κατάσταση
+         * Filter by order status
          *
-         * Φίλτρο ανά κατάσταση παραγγελίας
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `SHIPPED` - Απεστάλη
-         * * `DELIVERED` - Παραδόθηκε
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `CANCELED` - Ακυρώθηκε
-         * * `RETURNED` - Επιστράφηκε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `SHIPPED` - Shipped
+         * * `DELIVERED` - Delivered
+         * * `COMPLETED` - Completed
+         * * `CANCELED` - Canceled
+         * * `RETURNED` - Returned
+         * * `REFUNDED` - Refunded
          */
     status?: 'CANCELED' | 'COMPLETED' | 'DELIVERED' | 'PENDING' | 'PROCESSING' | 'REFUNDED' | 'RETURNED' | 'SHIPPED'
     /**
@@ -15046,32 +13113,32 @@ export type ListOrderData = {
          */
     status_In?: string | Array<string>
     /**
-         * Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+         * Filter by multiple statuses (comma-separated)
          */
     statusList?: string
     /**
-         * Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+         * Filter orders with status updated after this date
          */
     statusUpdatedAfter?: string
     statusUpdatedAt_Date?: string
     statusUpdatedAt_Gte?: string
     statusUpdatedAt_Lte?: string
     /**
-         * Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+         * Filter orders with status updated before this date
          */
     statusUpdatedBefore?: string
     /**
-         * Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by street (case-insensitive)
          */
     street?: string
     street_Icontains?: string
     /**
-         * Φίλτρο ανά αριθμό
+         * Filter by street number
          */
     streetNumber?: string
     streetNumber_Icontains?: string
     /**
-         * Φίλτρο ανά αριθμό παρακολούθησης
+         * Filter by tracking number
          */
     trackingNumber?: string
     trackingNumber_Icontains?: string
@@ -15087,32 +13154,32 @@ export type ListOrderData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user email (case-insensitive)
          */
     user_Email?: string
     /**
-         * Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user first name (case-insensitive)
          */
     user_FirstName?: string
     /**
-         * Φίλτρο ανά ενεργή κατάσταση χρήστη
+         * Filter by user active status
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user last name (case-insensitive)
          */
     user_LastName?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+         * Filter by multiple user IDs (comma-separated)
          */
     userIds?: string
     uuid?: string
     /**
-         * Φίλτρο ανά Τ.Κ.
+         * Filter by zipcode
          */
     zipcode?: string
   }
@@ -15140,7 +13207,7 @@ export type CreateOrderData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15168,7 +13235,7 @@ export type ListOrderItemData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο χονδρικής (ποσότητα > 5)
+         * Filter bulk items (quantity > 5)
          */
     bulkItems?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -15183,19 +13250,19 @@ export type ListOrderItemData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ειδών με/χωρίς σημειώσεις
+         * Filter items that have/don't have notes
          */
     hasNotes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ειδών με/χωρίς ποσότητα επιστροφής
+         * Filter items that have/don't have refunded quantity
          */
     hasRefundedQuantity?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ειδών υψηλής αξίας (τιμή > 100)
+         * Filter high value items (price > 100)
          */
     highValueItems?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -15204,93 +13271,89 @@ export type ListOrderItemData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο πλήρως επιστραμμένων αντικειμένων
+         * Filter fully refunded items
          */
     isFullyRefunded?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο μερικώς επιστραμμένων αντικειμένων
+         * Filter partially refunded items
          */
     isPartiallyRefunded?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κατάσταση επιστροφής χρημάτων
+         * Filter by refund status
          */
     isRefunded?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά περιεχόμενο σημειώσεων (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by notes content (case-insensitive)
          */
     notes?: string
     notes_Icontains?: string
     /**
-         * Φίλτρο ανά ID παραγγελίας
+         * Filter by order ID
          */
     order?: string | number
     /**
-         * Φίλτρο ανά κωδικό χώρας παραγγελίας
+         * Filter by order country code
          */
     order_Country?: string
     /**
-         * Φίλτρο ανά email πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by order customer email (case-insensitive)
          */
     order_Email?: string
     /**
-         * Φίλτρο ανά όνομα πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by order customer first name (case-insensitive)
          */
     order_FirstName?: string
     /**
-         * Φίλτρο ανά επώνυμο πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by order customer last name (case-insensitive)
          */
     order_LastName?: string
     /**
-         * Κατάσταση πληρωμής
+         * Filter by order payment status
          *
-         * Φίλτρο ανά κατάσταση πληρωμής παραγγελίας
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `FAILED` - Απέτυχε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
-         * * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-         * * `CANCELED` - Ακυρώθηκε
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `COMPLETED` - Completed
+         * * `FAILED` - Failed
+         * * `REFUNDED` - Refunded
+         * * `PARTIALLY_REFUNDED` - Partially Refunded
+         * * `CANCELED` - Canceled
          */
     order_PaymentStatus?: 'CANCELED' | 'COMPLETED' | 'FAILED' | 'PARTIALLY_REFUNDED' | 'PENDING' | 'PROCESSING' | 'REFUNDED'
     /**
-         * Φίλτρο ανά κωδικό περιφέρειας παραγγελίας
+         * Filter by order region code
          */
     order_Region?: string
     /**
-         * Κατάσταση
+         * Filter by order status
          *
-         * Φίλτρο ανά κατάσταση παραγγελίας
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `SHIPPED` - Απεστάλη
-         * * `DELIVERED` - Παραδόθηκε
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `CANCELED` - Ακυρώθηκε
-         * * `RETURNED` - Επιστράφηκε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `SHIPPED` - Shipped
+         * * `DELIVERED` - Delivered
+         * * `COMPLETED` - Completed
+         * * `CANCELED` - Canceled
+         * * `RETURNED` - Returned
+         * * `REFUNDED` - Refunded
          */
     order_Status?: 'CANCELED' | 'COMPLETED' | 'DELIVERED' | 'PENDING' | 'PROCESSING' | 'REFUNDED' | 'RETURNED' | 'SHIPPED'
     /**
-         * Φίλτρο ανά ID χρήστη παραγγελίας
+         * Filter by order user ID
          */
     order_User?: string | number
     /**
-         * Φίλτρο ανά email χρήστη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by order user email (case-insensitive)
          */
     order_User_Email?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID παραγγελιών (διαχωρισμένα με κόμμα)
+         * Filter by multiple order IDs (comma-separated)
          */
     orderIds?: string
     /**
-         * Φίλτρο ανά πολλαπλές καταστάσεις παραγγελιών (διαχωρισμένες με κόμμα)
+         * Filter by multiple order statuses (comma-separated)
          */
     orderStatuses?: string
     /**
@@ -15301,11 +13364,11 @@ export type ListOrderItemData = {
     originalQuantity_Gte?: string | number
     originalQuantity_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστη αρχική ποσότητα
+         * Filter by maximum original quantity
          */
     originalQuantityMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη αρχική ποσότητα
+         * Filter by minimum original quantity
          */
     originalQuantityMin?: string | number
     /**
@@ -15313,88 +13376,88 @@ export type ListOrderItemData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     price?: string | number
     price_Gte?: string | number
     price_Lte?: string | number
     /**
-         * Φίλτρο ανά ακριβή τιμή
+         * Filter by exact price
          */
     priceExact?: string | number
     /**
-         * Φίλτρο ανά μέγιστη τιμή
+         * Filter by maximum price
          */
     priceMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη τιμή
+         * Filter by minimum price
          */
     priceMin?: string | number
     /**
-         * Φίλτρο ανά ID προϊόντος
+         * Filter by product ID
          */
     product?: string | number
     /**
-         * Φίλτρο ανά ενεργή κατάσταση προϊόντος
+         * Filter by product active status
          */
     product_Active?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID κατηγορίας προϊόντος
+         * Filter by product category ID
          */
     product_Category?: string | number
     /**
-         * Φίλτρο ανά όνομα κατηγορίας προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by product category name (case-insensitive)
          */
     product_Category_Name?: string
     /**
-         * Φίλτρο ανά όνομα προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by product name (case-insensitive)
          */
     product_Name?: string
     /**
-         * Φίλτρο ανά SKU προϊόντος
+         * Filter by product SKU
          */
     product_Sku?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID προϊόντων (διαχωρισμένα με κόμμα)
+         * Filter by multiple product IDs (comma-separated)
          */
     productIds?: string
     quantity?: string | number
     quantity_Gte?: string | number
     quantity_Lte?: string | number
     /**
-         * Φίλτρο ανά ακριβή ποσότητα
+         * Filter by exact quantity
          */
     quantityExact?: string | number
     /**
-         * Φίλτρο ανά μέγιστη ποσότητα
+         * Filter by maximum quantity
          */
     quantityMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη ποσότητα
+         * Filter by minimum quantity
          */
     quantityMin?: string | number
     /**
-         * Φίλτρο ειδών των τελευταίων 7 ημερών
+         * Filter items from the last 7 days
          */
     recentItems?: 'true' | 'false' | '1' | '0' | boolean
     refundedQuantity?: string | number
     refundedQuantity_Gte?: string | number
     refundedQuantity_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστη ποσότητα επιστροφής
+         * Filter by maximum refunded quantity
          */
     refundedQuantityMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη ποσότητα επιστροφής
+         * Filter by minimum refunded quantity
          */
     refundedQuantityMin?: string | number
     /**
@@ -15441,7 +13504,7 @@ export type CreateOrderItemData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15497,7 +13560,7 @@ export type RetrieveOrderItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15526,7 +13589,7 @@ export type PartialUpdateOrderItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15556,7 +13619,7 @@ export type UpdateOrderItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15637,7 +13700,7 @@ export type RetrieveOrderData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15666,7 +13729,7 @@ export type PartialUpdateOrderData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -15696,7 +13759,7 @@ export type UpdateOrderData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -16123,32 +14186,32 @@ export type ListMyOrdersData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ενεργών παραγγελιών (εκκρεμείς, σε επεξεργασία, απεσταλμένες, παραδομένες)
+         * Filter active orders (pending, processing, shipped, delivered)
          */
     activeOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών που μπορούν να ακυρωθούν
+         * Filter orders that can be canceled
          */
     canBeCanceled?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)
+         * Filter by city (case-insensitive)
          */
     city?: string
     city_Icontains?: string
     /**
-         * Φίλτρο ανά κωδικό χώρας
+         * Filter by country code
          */
     country?: string
     /**
-         * Φίλτρο ανά alpha-2 κωδικό χώρας
+         * Filter by country alpha-2 code
          */
     country_Alpha2?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by country name (case-insensitive)
          */
     country_Name?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)
+         * Filter by multiple country IDs (comma-separated)
          */
     countryIds?: string
     /**
@@ -16165,45 +14228,45 @@ export type ListMyOrdersData = {
     customerNotes?: string
     customerNotes_Icontains?: string
     /**
-         * Φίλτρο ανά τύπο εγγράφου
+         * Filter by document type
          */
     documentType?: string
     /**
-         * Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer email (case-insensitive)
          */
     email?: string
     email_Icontains?: string
     /**
-         * Φίλτρο οριστικών παραγγελιών (ολοκληρωμένες, ακυρωμένες, με επιστροφή χρημάτων)
+         * Filter final orders (completed, canceled, refunded)
          */
     finalOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer first name (case-insensitive)
          */
     firstName?: string
     firstName_Icontains?: string
     /**
-         * Φίλτρο ανά όροφο
+         * Filter by floor
          */
     floor?: string
     /**
-         * Φίλτρο παραγγελιών με/χωρίς σημειώσεις πελάτη
+         * Filter orders that have/don't have customer notes
          */
     hasCustomerNotes?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς ID πληρωμής
+         * Filter orders that have/don't have payment ID
          */
     hasPaymentId?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με χρονοσήμανση ενημέρωσης κατάστασης
+         * Filter orders that have status update timestamp
          */
     hasStatusUpdatedAt?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς αριθμό παρακολούθησης
+         * Filter orders that have/don't have tracking number
          */
     hasTracking?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο παραγγελιών με/χωρίς χρήστη
+         * Filter orders that have/don't have a user
          */
     hasUser?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -16212,28 +14275,28 @@ export type ListMyOrdersData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ακυρωμένων παραγγελιών
+         * Filter canceled orders
          */
     isCanceled?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ολοκληρωμένων παραγγελιών
+         * Filter completed orders
          */
     isCompleted?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο πληρωμένων/μη πληρωμένων παραγγελιών
+         * Filter paid/unpaid orders
          */
     isPaid?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by customer last name (case-insensitive)
          */
     lastName?: string
     lastName_Icontains?: string
     /**
-         * Φίλτρο ανά τύπο τοποθεσίας
+         * Filter by location type
          */
     locationType?: string
     /**
-         * Φίλτρο παραγγελιών που χρειάζονται επεξεργασία
+         * Filter orders that need processing
          */
     needsProcessing?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -16251,47 +14314,45 @@ export type ListMyOrdersData = {
     paidAmount_Gte?: string | number
     paidAmount_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστο πληρωμένο ποσό
+         * Filter by maximum paid amount
          */
     paidAmountMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο πληρωμένο ποσό
+         * Filter by minimum paid amount
          */
     paidAmountMin?: string | number
     /**
-         * Φίλτρο ανά ID μεθόδου πληρωμής
+         * Filter by payment method ID
          */
     payWay?: string | number
     /**
-         * Φίλτρο ανά online μεθόδους πληρωμής
+         * Filter by online payment methods
          */
     payWay_IsOnlinePayment?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by payment method name (case-insensitive)
          */
     payWay_Name?: string
     /**
-         * Φίλτρο ανά ID πληρωμής
+         * Filter by payment ID
          */
     paymentId?: string
     paymentId_Icontains?: string
     /**
-         * Φίλτρο ανά μέθοδο πληρωμής
+         * Filter by payment method
          */
     paymentMethod?: string
     paymentMethod_Icontains?: string
     /**
-         * Κατάσταση πληρωμής
+         * Filter by payment status
          *
-         * Φίλτρο ανά κατάσταση πληρωμής
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `FAILED` - Απέτυχε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
-         * * `PARTIALLY_REFUNDED` - Μερική επιστροφή
-         * * `CANCELED` - Ακυρώθηκε
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `COMPLETED` - Completed
+         * * `FAILED` - Failed
+         * * `REFUNDED` - Refunded
+         * * `PARTIALLY_REFUNDED` - Partially Refunded
+         * * `CANCELED` - Canceled
          */
     paymentStatus?: 'CANCELED' | 'COMPLETED' | 'FAILED' | 'PARTIALLY_REFUNDED' | 'PENDING' | 'PROCESSING' | 'REFUNDED'
     /**
@@ -16299,25 +14360,25 @@ export type ListMyOrdersData = {
          */
     paymentStatus_In?: string | Array<string>
     /**
-         * Φίλτρο ανά αριθμό τηλεφώνου
+         * Filter by phone number
          */
     phone?: string
     phone_Icontains?: string
     /**
-         * Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by place (case-insensitive)
          */
     place?: string
     place_Icontains?: string
     /**
-         * Φίλτρο παραγγελιών των τελευταίων 30 ημερών
+         * Filter orders from the last 30 days
          */
     recentOrders?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά κωδικό περιφέρειας
+         * Filter by region code
          */
     region?: string
     /**
-         * Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by region name (case-insensitive)
          */
     region_Name?: string
     /**
@@ -16325,33 +14386,31 @@ export type ListMyOrdersData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά εταιρεία μεταφοράς
+         * Filter by shipping carrier
          */
     shippingCarrier?: string
     shippingCarrier_Icontains?: string
     shippingPrice_Gte?: string | number
     shippingPrice_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστα έξοδα αποστολής
+         * Filter by maximum shipping price
          */
     shippingPriceMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστα έξοδα αποστολής
+         * Filter by minimum shipping price
          */
     shippingPriceMin?: string | number
     /**
-         * Κατάσταση
+         * Filter by order status
          *
-         * Φίλτρο ανά κατάσταση παραγγελίας
-         *
-         * * `PENDING` - Εκκρεμεί
-         * * `PROCESSING` - Σε επεξεργασία
-         * * `SHIPPED` - Απεστάλη
-         * * `DELIVERED` - Παραδόθηκε
-         * * `COMPLETED` - Ολοκληρώθηκε
-         * * `CANCELED` - Ακυρώθηκε
-         * * `RETURNED` - Επιστράφηκε
-         * * `REFUNDED` - Επιστροφή Χρημάτων
+         * * `PENDING` - Pending
+         * * `PROCESSING` - Processing
+         * * `SHIPPED` - Shipped
+         * * `DELIVERED` - Delivered
+         * * `COMPLETED` - Completed
+         * * `CANCELED` - Canceled
+         * * `RETURNED` - Returned
+         * * `REFUNDED` - Refunded
          */
     status?: 'CANCELED' | 'COMPLETED' | 'DELIVERED' | 'PENDING' | 'PROCESSING' | 'REFUNDED' | 'RETURNED' | 'SHIPPED'
     /**
@@ -16359,32 +14418,32 @@ export type ListMyOrdersData = {
          */
     status_In?: string | Array<string>
     /**
-         * Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)
+         * Filter by multiple statuses (comma-separated)
          */
     statusList?: string
     /**
-         * Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία
+         * Filter orders with status updated after this date
          */
     statusUpdatedAfter?: string
     statusUpdatedAt_Date?: string
     statusUpdatedAt_Gte?: string
     statusUpdatedAt_Lte?: string
     /**
-         * Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία
+         * Filter orders with status updated before this date
          */
     statusUpdatedBefore?: string
     /**
-         * Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by street (case-insensitive)
          */
     street?: string
     street_Icontains?: string
     /**
-         * Φίλτρο ανά αριθμό
+         * Filter by street number
          */
     streetNumber?: string
     streetNumber_Icontains?: string
     /**
-         * Φίλτρο ανά αριθμό παρακολούθησης
+         * Filter by tracking number
          */
     trackingNumber?: string
     trackingNumber_Icontains?: string
@@ -16400,32 +14459,32 @@ export type ListMyOrdersData = {
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user email (case-insensitive)
          */
     user_Email?: string
     /**
-         * Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user first name (case-insensitive)
          */
     user_FirstName?: string
     /**
-         * Φίλτρο ανά ενεργή κατάσταση χρήστη
+         * Filter by user active status
          */
     user_IsActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by user last name (case-insensitive)
          */
     user_LastName?: string
     /**
-         * Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)
+         * Filter by multiple user IDs (comma-separated)
          */
     userIds?: string
     uuid?: string
     /**
-         * Φίλτρο ανά Τ.Κ.
+         * Filter by zipcode
          */
     zipcode?: string
   }
@@ -16511,59 +14570,59 @@ export type ListPayWayData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά κατάσταση ενεργοποίησης
+         * Filter by active status
          */
     active?: 'true' | 'false' | '1' | '0' | boolean
     cost_Gte?: string | number
     cost_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστο κόστος
+         * Filter by maximum cost
          */
     costMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο κόστος
+         * Filter by minimum cost
          */
     costMin?: string | number
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+         * Filter by description (partial match)
          */
     description?: string
     freeThreshold_Gte?: string | number
     freeThreshold_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστο όριο δωρεάν
+         * Filter by maximum free threshold
          */
     freeThresholdMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστο όριο δωρεάν
+         * Filter by minimum free threshold
          */
     freeThresholdMin?: string | number
     /**
-         * Φίλτρο μεθόδων πληρωμής με/χωρίς διαμόρφωση
+         * Filter payment methods that have/don't have configuration
          */
     hasConfiguration?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο μεθόδων πληρωμής με/χωρίς εικονίδιο
+         * Filter payment methods that have/don't have an icon
          */
     hasIcon?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID μεθόδου πληρωμής
+         * Filter by payment method ID
          */
     id?: string | number
     /**
-         * Φίλτρο ανά κατάσταση online πληρωμής
+         * Filter by online payment status
          */
     isOnlinePayment?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+         * Filter by name (partial match)
          */
     name?: string
     /**
@@ -16575,24 +14634,24 @@ export type ListPayWayData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά κωδικό παρόχου (μερική αντιστοίχιση)
+         * Filter by provider code (partial match)
          */
     providerCode?: string
     providerCode_Icontains?: string
     /**
-         * Φίλτρο ανά απαίτηση επιβεβαίωσης
+         * Filter by confirmation requirement
          */
     requiresConfirmation?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -16600,11 +14659,11 @@ export type ListPayWayData = {
          */
     search?: string
     /**
-         * Συνδυάστε με το ``shippingProviderCode`` για να φιλτράρετε τις μεθόδους πληρωμής βάσει των κανόνων συμβατότητας του μεταφορέα για αυτόν τον τύπο.
+         * Pair with ``shippingProviderCode`` to filter pay ways by the carrier's compatibility rules for that kind.
          */
     shippingKind?: string
     /**
-         * Φίλτρο μεθόδων πληρωμής συμβατών με τον δεδομένο μεταφορέα αποστολής. Κάθε μεταφορέας διαθέτει τους δικούς του κανόνες συμβατότητας — το BoxNow (``boxnow``) υποστηρίζει αντικαταβολή σε lockers μέσω PAY ON THE GO και έτσι περνά κανονικά· η ACS περνά αμετάβλητη. Συνδυάστε με το ``shippingKind``.
+         * Filter pay ways compatible with the given shipping carrier. Each carrier owns its own compatibility rules — BoxNow (``boxnow``) supports COD on lockers via PAY ON THE GO and so passes through; ACS passes through unchanged. Pair with ``shippingKind``.
          */
     shippingProviderCode?: string
     sortOrder?: string | number
@@ -16636,7 +14695,7 @@ export type CreatePayWayData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -16692,7 +14751,7 @@ export type RetrievePayWayData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -16721,7 +14780,7 @@ export type PartialUpdatePayWayData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -16751,7 +14810,7 @@ export type UpdatePayWayData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -16815,7 +14874,7 @@ export type ListProductData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     deletedAt_Date?: string
@@ -16835,7 +14894,7 @@ export type ListProductData = {
     inStock?: 'true' | 'false' | '1' | '0' | boolean
     isDeleted?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -16919,15 +14978,15 @@ export type ListProductData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     price?: string | number
@@ -16985,7 +15044,7 @@ export type CreateProductData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17041,7 +15100,7 @@ export type RetrieveProductData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17070,7 +15129,7 @@ export type PartialUpdateProductData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17100,7 +15159,7 @@ export type UpdateProductData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17133,7 +15192,7 @@ export type ListProductImagesData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -17182,15 +15241,15 @@ export type ListProductReviewsData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -17289,7 +15348,7 @@ export type ListProductVariantsData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17317,19 +15376,17 @@ export type ListProductAlertData = {
   path?: never
   query?: {
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     isActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Είδος
-         *
-         * * `restock` - Αναπλήρωση
-         * * `price_drop` - Πτώση τιμής
+         * * `restock` - Restock
+         * * `price_drop` - Price drop
          */
     kind?: 'price_drop' | 'restock'
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -17341,15 +15398,15 @@ export type ListProductAlertData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     product?: string | number
@@ -17382,7 +15439,7 @@ export type CreateProductAlertData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17429,7 +15486,7 @@ export type RetrieveProductAlertData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17468,7 +15525,7 @@ export type ListAttributeData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     hasValues?: 'true' | 'false' | '1' | '0' | boolean
@@ -17478,7 +15535,7 @@ export type ListAttributeData = {
          */
     id_In?: string | Array<number>
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     name?: string
@@ -17491,15 +15548,15 @@ export type ListAttributeData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -17555,7 +15612,7 @@ export type CreateAttributeData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17611,7 +15668,7 @@ export type RetrieveAttributeData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17640,7 +15697,7 @@ export type PartialUpdateAttributeData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17670,7 +15727,7 @@ export type UpdateAttributeData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17715,7 +15772,7 @@ export type ListAttributeValueData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
@@ -17724,7 +15781,7 @@ export type ListAttributeValueData = {
          */
     id_In?: string | Array<number>
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -17736,15 +15793,15 @@ export type ListAttributeValueData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -17801,7 +15858,7 @@ export type CreateAttributeValueData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17857,7 +15914,7 @@ export type RetrieveAttributeValueData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17886,7 +15943,7 @@ export type PartialUpdateAttributeValueData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17916,7 +15973,7 @@ export type UpdateAttributeValueData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -17960,7 +16017,7 @@ export type ListProductCategoryData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
@@ -17989,7 +16046,7 @@ export type ListProductCategoryData = {
          */
     isRoot?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -18023,15 +16080,15 @@ export type ListProductCategoryData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -18101,7 +16158,7 @@ export type CreateProductCategoryData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18157,7 +16214,7 @@ export type RetrieveProductCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18186,7 +16243,7 @@ export type PartialUpdateProductCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18216,7 +16273,7 @@ export type UpdateProductCategoryData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18379,27 +16436,25 @@ export type ListProductCategoryImageData = {
     active?: 'true' | 'false' | '1' | '0' | boolean
     category?: string | number
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
     /**
-         * Τύπος εικόνας
-         *
-         * * `MAIN` - Κύρια εικόνα
-         * * `BANNER` - Banner
-         * * `ICON` - Εικονίδιο
-         * * `THUMBNAIL` - Μικρογραφία
-         * * `GALLERY` - Εικόνα συλλογής
-         * * `BACKGROUND` - Εικόνα φόντου
-         * * `HERO` - Κεντρική εικόνα
-         * * `FEATURE` - Κεντρική Εικόνα
-         * * `PROMOTIONAL` - Προωθητική εικόνα
-         * * `SEASONAL` - Εποχιακή εικόνα
+         * * `MAIN` - Main Image
+         * * `BANNER` - Banner Image
+         * * `ICON` - Icon Image
+         * * `THUMBNAIL` - Thumbnail Image
+         * * `GALLERY` - Gallery Image
+         * * `BACKGROUND` - Background Image
+         * * `HERO` - Hero Image
+         * * `FEATURE` - Feature Image
+         * * `PROMOTIONAL` - Promotional Image
+         * * `SEASONAL` - Seasonal Image
          */
     imageType?: 'BACKGROUND' | 'BANNER' | 'FEATURE' | 'GALLERY' | 'HERO' | 'ICON' | 'MAIN' | 'PROMOTIONAL' | 'SEASONAL' | 'THUMBNAIL'
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -18411,15 +16466,15 @@ export type ListProductCategoryImageData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -18451,7 +16506,7 @@ export type CreateProductCategoryImageData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18507,7 +16562,7 @@ export type RetrieveProductCategoryImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18536,7 +16591,7 @@ export type PartialUpdateProductCategoryImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18566,7 +16621,7 @@ export type UpdateProductCategoryImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18620,18 +16675,16 @@ export type GetProductCategoryImagesByCategoryData = {
     category?: string | number
     id?: string | number
     /**
-         * Τύπος εικόνας
-         *
-         * * `MAIN` - Κύρια εικόνα
-         * * `BANNER` - Banner
-         * * `ICON` - Εικονίδιο
-         * * `THUMBNAIL` - Μικρογραφία
-         * * `GALLERY` - Εικόνα συλλογής
-         * * `BACKGROUND` - Εικόνα φόντου
-         * * `HERO` - Κεντρική εικόνα
-         * * `FEATURE` - Κεντρική Εικόνα
-         * * `PROMOTIONAL` - Προωθητική εικόνα
-         * * `SEASONAL` - Εποχιακή εικόνα
+         * * `MAIN` - Main Image
+         * * `BANNER` - Banner Image
+         * * `ICON` - Icon Image
+         * * `THUMBNAIL` - Thumbnail Image
+         * * `GALLERY` - Gallery Image
+         * * `BACKGROUND` - Background Image
+         * * `HERO` - Hero Image
+         * * `FEATURE` - Feature Image
+         * * `PROMOTIONAL` - Promotional Image
+         * * `SEASONAL` - Seasonal Image
          */
     imageType?: 'BACKGROUND' | 'BANNER' | 'FEATURE' | 'GALLERY' | 'HERO' | 'ICON' | 'MAIN' | 'PROMOTIONAL' | 'SEASONAL' | 'THUMBNAIL'
     /**
@@ -18670,18 +16723,16 @@ export type GetProductCategoryImagesByTypeData = {
     category?: string | number
     id?: string | number
     /**
-         * Τύπος εικόνας
-         *
-         * * `MAIN` - Κύρια εικόνα
-         * * `BANNER` - Banner
-         * * `ICON` - Εικονίδιο
-         * * `THUMBNAIL` - Μικρογραφία
-         * * `GALLERY` - Εικόνα συλλογής
-         * * `BACKGROUND` - Εικόνα φόντου
-         * * `HERO` - Κεντρική εικόνα
-         * * `FEATURE` - Κεντρική Εικόνα
-         * * `PROMOTIONAL` - Προωθητική εικόνα
-         * * `SEASONAL` - Εποχιακή εικόνα
+         * * `MAIN` - Main Image
+         * * `BANNER` - Banner Image
+         * * `ICON` - Icon Image
+         * * `THUMBNAIL` - Thumbnail Image
+         * * `GALLERY` - Gallery Image
+         * * `BACKGROUND` - Background Image
+         * * `HERO` - Hero Image
+         * * `FEATURE` - Feature Image
+         * * `PROMOTIONAL` - Promotional Image
+         * * `SEASONAL` - Seasonal Image
          */
     imageType?: 'BACKGROUND' | 'BANNER' | 'FEATURE' | 'GALLERY' | 'HERO' | 'ICON' | 'MAIN' | 'PROMOTIONAL' | 'SEASONAL' | 'THUMBNAIL'
     /**
@@ -18725,12 +16776,12 @@ export type ListProductFavouriteData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -18742,15 +16793,15 @@ export type ListProductFavouriteData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     product?: string | number
@@ -18795,7 +16846,7 @@ export type CreateProductFavouriteData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18851,7 +16902,7 @@ export type RetrieveProductFavouriteData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18880,7 +16931,7 @@ export type PartialUpdateProductFavouriteData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -18910,7 +16961,7 @@ export type UpdateProductFavouriteData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19018,13 +17069,13 @@ export type ListProductImageData = {
   query?: {
     createdAt?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
     isMain?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -19036,15 +17087,15 @@ export type ListProductImageData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     product?: string | number
@@ -19079,7 +17130,7 @@ export type CreateProductImageData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19135,7 +17186,7 @@ export type RetrieveProductImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19164,7 +17215,7 @@ export type PartialUpdateProductImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19194,7 +17245,7 @@ export type UpdateProductImageData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19222,50 +17273,50 @@ export type ListProductReviewData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά περιεχόμενο σχολίου (μερική αντιστοίχιση)
+         * Filter by comment content (partial match)
          */
     comment?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter items created after this date
          */
     createdAfter?: string
     createdAt_Date?: string
     createdAt_Gte?: string
     createdAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter items created before this date
          */
     createdBefore?: string
     /**
-         * Φίλτρο αντικειμένων που είναι επί του παρόντος δημοσιευμένα (published_at <= now και is_published=True)
+         * Filter items that are currently published (published_at <= now and is_published=True)
          */
     currentlyPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο αξιολογήσεων με/χωρίς σχόλια
+         * Filter reviews that have/don't have comments
          */
     hasComment?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ID κριτικής
+         * Filter by review ID
          */
     id?: string | number
     /**
-         * Φίλτρο ανά κατάσταση δημοσίευσης
+         * Filter by published status
          */
     isPublished?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά μέγιστη βαθμολογία (alias)
+         * Filter by maximum rating (alias)
          */
     maxRate?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη βαθμολογία (alias)
+         * Filter by minimum rating (alias)
          */
     minRate?: string | number
     /**
@@ -19277,87 +17328,87 @@ export type ListProductReviewData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά ID προϊόντος
+         * Filter by product ID
          */
     product?: string | number
     /**
-         * Φίλτρο ανά ενεργή κατάσταση προϊόντος
+         * Filter by product active status
          */
     productActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο προϊόντων με μέγιστη μέση βαθμολογία
+         * Filter products with maximum average rating
          */
     productAvgRatingMax?: string | number
     /**
-         * Φίλτρο προϊόντων με ελάχιστη μέση βαθμολογία
+         * Filter products with minimum average rating
          */
     productAvgRatingMin?: string | number
     /**
-         * Φίλτρο ανά ID κατηγορίας προϊόντος
+         * Filter by product category ID
          */
     productCategory?: string | number
     /**
-         * Φίλτρο ανά ID προϊόντος
+         * Filter by product ID
          */
     productId?: string | number
     /**
-         * Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)
+         * Filter by product name (partial match)
          */
     productName?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία
+         * Filter items published after this date
          */
     publishedAfter?: string
     publishedAt_Date?: string
     publishedAt_Gte?: string
     publishedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία
+         * Filter items published before this date
          */
     publishedBefore?: string
     /**
-         * Φίλτρο αξιολογήσεων που δημοσιεύθηκαν τις τελευταίες N ημέρες
+         * Filter reviews published in the last N days
          */
     publishedRecentDays?: string | number
     /**
-         * Φίλτρο ανά ακριβή βαθμολογία
+         * Filter by exact rating
          *
-         * * `1` - Ένα
-         * * `2` - Δύο
-         * * `3` - Τρία
-         * * `4` - Τέσσερα
-         * * `5` - Πέντε
-         * * `6` - Έξι
-         * * `7` - Επτά
-         * * `8` - Οκτώ
-         * * `9` - Εννέα
-         * * `10` - Δέκα
+         * * `1` - One
+         * * `2` - Two
+         * * `3` - Three
+         * * `4` - Four
+         * * `5` - Five
+         * * `6` - Six
+         * * `7` - Seven
+         * * `8` - Eight
+         * * `9` - Nine
+         * * `10` - Ten
          */
     rate?: string | number
     rate_Gte?: string | number
     rate_Lte?: string | number
     /**
-         * Φίλτρο ανά μέγιστη βαθμολογία
+         * Filter by maximum rating
          */
     rateMax?: string | number
     /**
-         * Φίλτρο ανά ελάχιστη βαθμολογία
+         * Filter by minimum rating
          */
     rateMin?: string | number
     /**
-         * Φίλτρο αξιολογήσεων των τελευταίων N ημερών
+         * Filter reviews from the last N days
          */
     recentDays?: string | number
     /**
@@ -19365,53 +17416,51 @@ export type ListProductReviewData = {
          */
     search?: string
     /**
-         * Κατάσταση
+         * Filter by review status
          *
-         * Φίλτρο ανά κατάσταση αξιολόγησης
-         *
-         * * `NEW` - Νέο
-         * * `TRUE` - Ναι
-         * * `FALSE` - Όχι
+         * * `NEW` - New
+         * * `TRUE` - True
+         * * `FALSE` - False
          */
     status?: 'FALSE' | 'NEW' | 'TRUE'
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία
+         * Filter items updated after this date
          */
     updatedAfter?: string
     updatedAt_Date?: string
     updatedAt_Gte?: string
     updatedAt_Lte?: string
     /**
-         * Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία
+         * Filter items updated before this date
          */
     updatedBefore?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     user?: string | number
     /**
-         * Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)
+         * Filter by user email (partial match)
          */
     userEmail?: string
     /**
-         * Φίλτρο ανά όνομα χρήστη (μερική αντιστοίχιση)
+         * Filter by user first name (partial match)
          */
     userFirstName?: string
     /**
-         * Φίλτρο ανά ID χρήστη
+         * Filter by user ID
          */
     userId?: string | number
     /**
-         * Φίλτρο ανά επώνυμο χρήστη (μερική αντιστοίχιση)
+         * Filter by user last name (partial match)
          */
     userLastName?: string
     /**
-         * Φίλτρο χρηστών με ελάχιστο αριθμό αξιολογήσεων
+         * Filter users with minimum number of reviews
          */
     userReviewCountMin?: string | number
     uuid?: string
     /**
-         * Φίλτρο αξιολογήσεων από επαληθευμένες αγορές
+         * Filter reviews from verified purchases
          */
     verifiedPurchase?: 'true' | 'false' | '1' | '0' | boolean
   }
@@ -19439,7 +17488,7 @@ export type CreateProductReviewData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19495,7 +17544,7 @@ export type RetrieveProductReviewData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19524,7 +17573,7 @@ export type PartialUpdateProductReviewData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19554,7 +17603,7 @@ export type UpdateProductReviewData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19632,20 +17681,20 @@ export type ListRegionData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+         * Filter by region alpha code (partial match)
          */
     alpha?: string
     alpha_Icontains?: string
     /**
-         * Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+         * Filter by exact region alpha code
          */
     alphaExact?: string
     /**
-         * Φίλτρο ανά alpha-2 κωδικό χώρας
+         * Filter by country alpha-2 code
          */
     country?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+         * Filter by country name (partial match)
          */
     countryName?: string
     /**
@@ -19657,15 +17706,15 @@ export type ListRegionData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+         * Filter by region name (partial match)
          */
     name?: string
     /**
@@ -19677,15 +17726,15 @@ export type ListRegionData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -19729,7 +17778,7 @@ export type CreateRegionData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19756,9 +17805,9 @@ export type DestroyRegionData = {
   body?: never
   path: {
     /**
-         * Κωδικός περιφέρειας
+         * Region Code
          *
-         * A unique value identifying this Περιοχή.
+         * A unique value identifying this Region.
          */
     alpha: string
   }
@@ -19787,15 +17836,15 @@ export type RetrieveRegionData = {
   body?: never
   path: {
     /**
-         * Κωδικός περιφέρειας
+         * Region Code
          *
-         * A unique value identifying this Περιοχή.
+         * A unique value identifying this Region.
          */
     alpha: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19821,15 +17870,15 @@ export type PartialUpdateRegionData = {
   body?: PatchedRegionWriteRequest
   path: {
     /**
-         * Κωδικός περιφέρειας
+         * Region Code
          *
-         * A unique value identifying this Περιοχή.
+         * A unique value identifying this Region.
          */
     alpha: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19856,15 +17905,15 @@ export type UpdateRegionData = {
   body: RegionWriteRequest
   path: {
     /**
-         * Κωδικός περιφέρειας
+         * Region Code
          *
-         * A unique value identifying this Περιοχή.
+         * A unique value identifying this Region.
          */
     alpha: string
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -19891,28 +17940,28 @@ export type ListRegionsByCountryData = {
   body?: never
   path: {
     /**
-         * Κωδικός περιφέρειας
+         * Region Code
          *
-         * A unique value identifying this Περιοχή.
+         * A unique value identifying this Region.
          */
     alpha: string
   }
   query?: {
     /**
-         * Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)
+         * Filter by region alpha code (partial match)
          */
     alpha?: string
     alpha_Icontains?: string
     /**
-         * Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας
+         * Filter by exact region alpha code
          */
     alphaExact?: string
     /**
-         * Φίλτρο ανά alpha-2 κωδικό χώρας
+         * Filter by country alpha-2 code
          */
     country?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+         * Filter by country name (partial match)
          */
     countryName?: string
     /**
@@ -19924,7 +17973,7 @@ export type ListRegionsByCountryData = {
          */
     createdBefore?: string
     /**
-         * Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+         * Filter by region name (partial match)
          */
     name?: string
     /**
@@ -19980,15 +18029,15 @@ export type ApiV1SearchAnalyticsRetrieveData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά τύπο περιεχομένου: 'product', 'blog_post', ή 'federated'. Αν δεν δοθεί, συμπεριλαμβάνει όλους τους τύπους περιεχομένου.
+         * Filter by content type: 'product', 'blog_post', or 'federated'. If not provided, includes all content types.
          */
     contentType?: string
     /**
-         * Ημερομηνία λήξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει δεδομένα έως τη σημερινή ημερομηνία.
+         * End date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes data up to current date.
          */
     endDate?: string
     /**
-         * Ημερομηνία έναρξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει όλα τα ιστορικά δεδομένα.
+         * Start date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes all historical data.
          */
     startDate?: string
   }
@@ -20012,19 +18061,19 @@ export type ApiV1SearchBlogPostRetrieveData = {
   path?: never
   query: {
     /**
-         * Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+         * Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
          */
     languageCode?: string
     /**
-         * Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+         * Maximum number of results to return
          */
     limit?: string | number
     /**
-         * Αριθμός αποτελεσμάτων προς παράλειψη
+         * Number of results to skip
          */
     offset?: string | number
     /**
-         * String αναζήτησης
+         * Search query string
          */
     query: string
   }
@@ -20043,24 +18092,43 @@ export type ApiV1SearchBlogPostRetrieveResponses = {
 
 export type ApiV1SearchBlogPostRetrieveResponse = ApiV1SearchBlogPostRetrieveResponses[keyof ApiV1SearchBlogPostRetrieveResponses]
 
+export type ApiV1SearchClickCreateData = {
+  body: SearchClickRequestRequest
+  path?: never
+  query?: never
+  url: '/api/v1/search/click'
+}
+
+export type ApiV1SearchClickCreateErrors = {
+  400: ErrorResponse
+}
+
+export type ApiV1SearchClickCreateError = ApiV1SearchClickCreateErrors[keyof ApiV1SearchClickCreateErrors]
+
+export type ApiV1SearchClickCreateResponses = {
+  202: SearchClickResponse
+}
+
+export type ApiV1SearchClickCreateResponse = ApiV1SearchClickCreateResponses[keyof ApiV1SearchClickCreateResponses]
+
 export type ApiV1SearchFederatedRetrieveData = {
   body?: never
   path?: never
   query: {
     /**
-         * Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+         * Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
          */
     languageCode?: string
     /**
-         * Μέγιστος συνολικός αριθμός αποτελεσμάτων προς επιστροφή
+         * Maximum total number of results to return
          */
     limit?: string | number
     /**
-         * Αριθμός αποτελεσμάτων προς παράλειψη
+         * Number of results to skip
          */
     offset?: string | number
     /**
-         * String αναζήτησης
+         * Search query string
          */
     query: string
   }
@@ -20084,51 +18152,51 @@ export type ApiV1SearchProductRetrieveData = {
   path?: never
   query?: {
     /**
-         * ID τιμών χαρακτηριστικών διαχωρισμένα με κόμμα (attribute_values IN [ids])
+         * Comma-separated attribute value IDs (attribute_values IN [ids])
          */
     attributeValues?: string
     /**
-         * ID κατηγοριών διαχωρισμένα με κόμμα (category IN [ids])
+         * Comma-separated category IDs (category IN [ids])
          */
     categories?: string
     /**
-         * Πεδία facet διαχωρισμένα με κόμμα για πλήθη και στατιστικά
+         * Comma-separated facet fields for counts and stats
          */
     facets?: string
     /**
-         * Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. 'en', 'el', 'de'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.
+         * Language code to filter results (e.g., 'en', 'el', 'de'). If not provided, searches all languages.
          */
     languageCode?: string
     /**
-         * Φίλτρο ελάχιστων επισημάνσεων (likes_count >= value)
+         * Minimum likes filter (likes_count >= value)
          */
     likesMin?: string | number
     /**
-         * Μέγιστος αριθμός αποτελεσμάτων προς επιστροφή
+         * Maximum number of results to return
          */
     limit?: string | number
     /**
-         * Αριθμός αποτελεσμάτων προς παράλειψη
+         * Number of results to skip
          */
     offset?: string | number
     /**
-         * Φίλτρο μέγιστης τιμής (final_price <= value)
+         * Maximum price filter (final_price <= value)
          */
     priceMax?: string | number
     /**
-         * Φίλτρο ελάχιστης τιμής (final_price >= value)
+         * Minimum price filter (final_price >= value)
          */
     priceMin?: string | number
     /**
-         * Ερώτημα αναζήτησης πλήρους κειμένου (κενό για χωρίς φίλτρο αναζήτησης)
+         * Full-text search query (empty for no search filter)
          */
     query?: string
     /**
-         * Πεδίο ταξινόμησης (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
+         * Sort field (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)
          */
     sort?: string
     /**
-         * Φίλτρο ελάχιστων προβολών (view_count >= value)
+         * Minimum views filter (view_count >= value)
          */
     viewsMin?: string | number
   }
@@ -20152,15 +18220,15 @@ export type ListTrendingSearchesData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά τύπο περιεχομένου: product, blog_post, federated. Προεπιλογή product.
+         * Filter by content type: product, blog_post, federated. Defaults to product.
          */
     contentType?: string
     /**
-         * Φίλτρο ερωτημάτων ανά γλώσσα (π.χ. 'el').
+         * Filter queries by language (e.g. 'el').
          */
     languageCode?: string
     /**
-         * Μέγιστα αποτελέσματα. Προεπιλογή 8, ανώτατο 20.
+         * Max results. Default 8, cap 20.
          */
     limit?: string | number
   }
@@ -20197,7 +18265,7 @@ export type ApiV1SettingsGetRetrieveData = {
   path?: never
   query: {
     /**
-         * Όνομα κλειδιού ρύθμισης (π.χ. CHECKOUT_SHIPPING_PRICE)
+         * Setting key name (e.g., CHECKOUT_SHIPPING_PRICE)
          */
     key: string
   }
@@ -20442,11 +18510,11 @@ export type ListBoxNowLockerData = {
   path?: never
   query?: {
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -20458,15 +18526,15 @@ export type ListBoxNowLockerData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -20500,7 +18568,7 @@ export type RetrieveBoxNowLockerData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -20677,15 +18745,15 @@ export type ListTagData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά κατάσταση ενεργοποίησης
+         * Filter by active status
          */
     active?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο τύπο περιεχομένου
+         * Filter tags used for specific content type
          */
     contentType?: string
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται για περιεχόμενο από συγκεκριμένη εφαρμογή
+         * Filter tags used for content from specific app
          */
     contentType_AppLabel?: string
     /**
@@ -20700,15 +18768,15 @@ export type ListTagData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ετικετών με/χωρίς ετικέτα
+         * Filter tags that have/don't have a label
          */
     hasLabel?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ετικετών χρησιμοποιούμενων/μη
+         * Filter tags that are/aren't used
          */
     hasUsage?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -20717,35 +18785,35 @@ export type ListTagData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+         * Filter by tag label (partial match)
          */
     label?: string
     /**
-         * Φίλτρο ανά ακριβή ετικέτα
+         * Filter by exact tag label
          */
     label_Exact?: string
     /**
-         * Φίλτρο ετικετών με ετικέτα που ξεκινά με
+         * Filter tags with labels starting with
          */
     label_Startswith?: string
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται έως X φορές
+         * Filter tags used at most X times
          */
     maxUsageCount?: string | number
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται τουλάχιστον X φορές
+         * Filter tags used at least X times
          */
     minUsageCount?: string | number
     /**
-         * Ταξινόμηση ετικετών κατά πλήθος χρήσης (πιο δημοφιλείς πρώτα)
+         * Order tags by usage count (most used first)
          */
     mostUsed?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο ID αντικειμένου
+         * Filter tags used for specific object ID
          */
     objectId?: string | number
     /**
@@ -20757,15 +18825,15 @@ export type ListTagData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -20779,7 +18847,7 @@ export type ListTagData = {
     translations_Label_Icontains?: string
     translations_Label_Istartswith?: string
     /**
-         * Φίλτρο ετικετών που δεν χρησιμοποιούνται
+         * Filter tags not used anywhere
          */
     unused?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -20819,7 +18887,7 @@ export type CreateTagData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -20875,7 +18943,7 @@ export type RetrieveTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -20904,7 +18972,7 @@ export type PartialUpdateTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -20934,7 +19002,7 @@ export type UpdateTagData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -20962,11 +19030,11 @@ export type ListTaggedItemData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά όνομα model τύπου περιεχομένου
+         * Filter by content type model name
          */
     contentType?: string
     /**
-         * Φίλτρο ανά app label τύπου περιεχομένου
+         * Filter by content type app label
          */
     contentType_AppLabel?: string
     /**
@@ -20981,7 +19049,7 @@ export type ListTaggedItemData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     id?: string | number
@@ -20990,15 +19058,15 @@ export type ListTaggedItemData = {
          */
     id_In?: string | Array<number>
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά ID αντικειμένου
+         * Filter by object ID
          */
     objectId?: string | number
     /**
-         * Φίλτρο ανά πολλαπλά ID αντικειμένων (διαχωρισμένα με κόμμα)
+         * Filter by multiple object IDs (comma-separated)
          */
     objectId_In?: string | Array<number>
     /**
@@ -21010,15 +19078,15 @@ export type ListTaggedItemData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -21026,15 +19094,15 @@ export type ListTaggedItemData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά συγκεκριμένο ID ετικέτας
+         * Filter by specific tag ID
          */
     tag?: string | number
     /**
-         * Φίλτρο ανά ενεργή κατάσταση ετικέτας
+         * Filter by tag active status
          */
     tag_Active?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)
+         * Filter by tag label (partial match)
          */
     tag_Label?: string
     /**
@@ -21074,7 +19142,7 @@ export type CreateTaggedItemData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21130,7 +19198,7 @@ export type RetrieveTaggedItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21159,7 +19227,7 @@ export type PartialUpdateTaggedItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21189,7 +19257,7 @@ export type UpdateTaggedItemData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21232,11 +19300,11 @@ export type ListUserAccountData = {
   path?: never
   query?: {
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -21248,15 +19316,15 @@ export type ListUserAccountData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -21288,7 +19356,7 @@ export type CreateUserAccountData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21318,7 +19386,7 @@ export type RetrieveUserAccountData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21347,7 +19415,7 @@ export type PartialUpdateUserAccountData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21377,7 +19445,7 @@ export type UpdateUserAccountData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -21683,7 +19751,7 @@ export type GetUserAccountNotificationsData = {
          */
     search?: string
     /**
-         * Φίλτρο ειδοποιήσεων κατά κατάσταση ορατότητας.
+         * Filter notifications by seen/unseen state.
          */
     seen?: 'true' | 'false' | '1' | '0' | boolean
   }
@@ -21820,20 +19888,20 @@ export type ListUserAddressData = {
   path?: never
   query?: {
     /**
-         * Φίλτρο ανά όνομα πόλης (μερική αντιστοίχιση)
+         * Filter by city name (partial match)
          */
     city?: string
     city_Icontains?: string
     /**
-         * Φίλτρο ανά alpha_2 κωδικό χώρας
+         * Filter by country alpha_2 code
          */
     country?: string
     /**
-         * Φίλτρο ανά κωδικό χώρας (π.χ. 'US', 'CA')
+         * Filter by country code (e.g., 'US', 'CA')
          */
     countryCode?: string
     /**
-         * Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)
+         * Filter by country name (partial match)
          */
     countryName?: string
     /**
@@ -21848,26 +19916,24 @@ export type ListUserAddressData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+         * Filter by first name (partial match)
          */
     firstName?: string
     firstName_Icontains?: string
     /**
-         * Όροφος
-         *
-         * Φίλτρο ανά όροφο
+         * Filter by floor
          */
     floor?: '' | 'BASEMENT' | 'FIFTH_FLOOR' | 'FIRST_FLOOR' | 'FOURTH_FLOOR' | 'GROUND_FLOOR' | 'SECOND_FLOOR' | 'SIXTH_FLOOR_PLUS' | 'THIRD_FLOOR'
     /**
-         * Φίλτρο ανά πλήρες όνομα (όνομα + επώνυμο)
+         * Filter by full name (first + last name)
          */
     fullName?: string
     /**
-         * Φίλτρο διευθύνσεων με σημειώσεις
+         * Filter addresses that have notes
          */
     hasNotes?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -21876,20 +19942,20 @@ export type ListUserAddressData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κύρια διεύθυνση
+         * Filter by main address status
          */
     isMain?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά επώνυμο (μερική αντιστοίχιση)
+         * Filter by last name (partial match)
          */
     lastName?: string
     lastName_Icontains?: string
     /**
-         * Φίλτρο ανά τύπο τοποθεσίας (ακριβής αντιστοίχιση, χωρίς διάκριση πεζών/κεφαλαίων)
+         * Filter by location type (exact match, case insensitive)
          */
     locationType?: string
     locationType_Icontains?: string
@@ -21906,32 +19972,32 @@ export type ListUserAddressData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά αριθμό τηλεφώνου (μερική αντιστοίχιση)
+         * Filter by phone number (partial match)
          */
     phone?: string
     phone_Icontains?: string
     /**
-         * Φίλτρο ανά αλφαριθμητικό κωδικό περιφέρειας
+         * Filter by region alpha code
          */
     region?: string
     /**
-         * Φίλτρο ανά κωδικό περιφέρειας
+         * Filter by region code
          */
     regionCode?: string
     /**
-         * Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)
+         * Filter by region name (partial match)
          */
     regionName?: string
     /**
@@ -21939,12 +20005,12 @@ export type ListUserAddressData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά όνομα οδού (μερική αντιστοίχιση)
+         * Filter by street name (partial match)
          */
     street?: string
     street_Icontains?: string
     /**
-         * Φίλτρο ανά αριθμό
+         * Filter by street number
          */
     streetNumber?: string
     streetNumber_Icontains?: string
@@ -21963,12 +20029,12 @@ export type ListUserAddressData = {
     updatedBefore?: string
     uuid?: string
     /**
-         * Φίλτρο ανά ταχυδρομικό κώδικα (μερική αντιστοίχιση)
+         * Filter by zipcode (partial match)
          */
     zipcode?: string
     zipcode_Icontains?: string
     /**
-         * Φίλτρο ανά ακριβή ταχυδρομικό κώδικα
+         * Filter by exact zipcode
          */
     zipcodeExact?: string
   }
@@ -21996,7 +20062,7 @@ export type CreateUserAddressData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22052,7 +20118,7 @@ export type RetrieveUserAddressData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22081,7 +20147,7 @@ export type PartialUpdateUserAddressData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22111,7 +20177,7 @@ export type UpdateUserAddressData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22202,11 +20268,11 @@ export type ListUserSubscriptionData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο εγγραφών με metadata
+         * Filter subscriptions that have metadata
          */
     hasMetadata?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -22215,11 +20281,11 @@ export type ListUserSubscriptionData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση επιβεβαίωσης
+         * Filter by confirmation status
          */
     isConfirmed?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
@@ -22231,15 +20297,15 @@ export type ListUserSubscriptionData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
@@ -22247,70 +20313,66 @@ export type ListUserSubscriptionData = {
          */
     search?: string
     /**
-         * Κατάσταση
+         * Filter by subscription status
          *
-         * Φίλτρο ανά κατάσταση συνδρομής
-         *
-         * * `ACTIVE` - Ενεργή
-         * * `PENDING` - Εκκρεμεί Επιβεβαίωση
-         * * `UNSUBSCRIBED` - Διαγραφή
-         * * `BOUNCED` - Επιστράφηκε
+         * * `ACTIVE` - Active
+         * * `PENDING` - Pending Confirmation
+         * * `UNSUBSCRIBED` - Unsubscribed
+         * * `BOUNCED` - Bounced
          */
     status?: 'ACTIVE' | 'BOUNCED' | 'PENDING' | 'UNSUBSCRIBED'
     /**
-         * Φίλτρο εγγραφών που δημιουργήθηκαν μετά από αυτή την ημερομηνία
+         * Filter subscriptions created after this date
          */
     subscribedAfter?: string
     subscribedAt_Date?: string
     subscribedAt_Gte?: string
     subscribedAt_Lte?: string
     /**
-         * Φίλτρο εγγραφών που δημιουργήθηκαν πριν από αυτή την ημερομηνία
+         * Filter subscriptions created before this date
          */
     subscribedBefore?: string
     /**
-         * Φίλτρο ανά θέμα συνδρομής
+         * Filter by subscription topic
          */
     topic?: string | number
     /**
-         * Κατηγορία
+         * Filter by topic category
          *
-         * Φίλτρο ανά κατηγορία θέματος
-         *
-         * * `MARKETING` - Καμπάνιες marketing
-         * * `PRODUCT` - Ενημερώσεις προϊόντων
-         * * `ACCOUNT` - Λογαριασμός Ανενεργός
-         * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+         * * `MARKETING` - Marketing Campaigns
+         * * `PRODUCT` - Product Updates
+         * * `ACCOUNT` - Account Updates
+         * * `SYSTEM` - System Notifications
          * * `NEWSLETTER` - Newsletter
-         * * `PROMOTIONAL` - Προωθητικό
-         * * `OTHER` - Άλλο
+         * * `PROMOTIONAL` - Promotional
+         * * `OTHER` - Other
          */
     topicCategory?: 'ACCOUNT' | 'MARKETING' | 'NEWSLETTER' | 'OTHER' | 'PRODUCT' | 'PROMOTIONAL' | 'SYSTEM'
     /**
-         * Φίλτρο ανά περιγραφή θέματος (μερική αντιστοίχιση)
+         * Filter by topic description (partial match)
          */
     topicDescription?: string
     /**
-         * Φίλτρο ανά όνομα θέματος (μερική αντιστοίχιση)
+         * Filter by topic name (partial match)
          */
     topicName?: string
     /**
-         * Φίλτρο ανά slug θέματος (μερική αντιστοίχιση)
+         * Filter by topic slug (partial match)
          */
     topicSlug?: string
     /**
-         * Φίλτρο ανά ακριβές slug θέματος
+         * Filter by exact topic slug
          */
     topicSlugExact?: string
     /**
-         * Φίλτρο εγγραφών με διαγραφή μετά από αυτή την ημερομηνία
+         * Filter subscriptions unsubscribed after this date
          */
     unsubscribedAfter?: string
     unsubscribedAt_Date?: string
     unsubscribedAt_Gte?: string
     unsubscribedAt_Lte?: string
     /**
-         * Φίλτρο εγγραφών με διαγραφή πριν από αυτή την ημερομηνία
+         * Filter subscriptions unsubscribed before this date
          */
     unsubscribedBefore?: string
     /**
@@ -22350,7 +20412,7 @@ export type CreateUserSubscriptionData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22406,7 +20468,7 @@ export type RetrieveUserSubscriptionData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22435,7 +20497,7 @@ export type PartialUpdateUserSubscriptionData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22465,7 +20527,7 @@ export type UpdateUserSubscriptionData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22577,17 +20639,15 @@ export type ListSubscriptionTopicData = {
   path?: never
   query?: {
     /**
-         * Κατηγορία
+         * Filter by topic category
          *
-         * Φίλτρο ανά κατηγορία θέματος
-         *
-         * * `MARKETING` - Καμπάνιες marketing
-         * * `PRODUCT` - Ενημερώσεις προϊόντων
-         * * `ACCOUNT` - Λογαριασμός Ανενεργός
-         * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+         * * `MARKETING` - Marketing Campaigns
+         * * `PRODUCT` - Product Updates
+         * * `ACCOUNT` - Account Updates
+         * * `SYSTEM` - System Notifications
          * * `NEWSLETTER` - Newsletter
-         * * `PROMOTIONAL` - Προωθητικό
-         * * `OTHER` - Άλλο
+         * * `PROMOTIONAL` - Promotional
+         * * `OTHER` - Other
          */
     category?: 'ACCOUNT' | 'MARKETING' | 'NEWSLETTER' | 'OTHER' | 'PRODUCT' | 'PROMOTIONAL' | 'SYSTEM'
     /**
@@ -22602,15 +20662,15 @@ export type ListSubscriptionTopicData = {
          */
     createdBefore?: string
     /**
-         * Δείκτης (cursor) για σελιδοποίηση
+         * Cursor for pagination
          */
     cursor?: string
     /**
-         * Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)
+         * Filter by description (partial match)
          */
     description?: string
     /**
-         * Φίλτρο θεμάτων με εγγεγραμμένους
+         * Filter topics that have subscribers
          */
     hasSubscribers?: 'true' | 'false' | '1' | '0' | boolean
     id?: string | number
@@ -22619,19 +20679,19 @@ export type ListSubscriptionTopicData = {
          */
     id_In?: string | Array<number>
     /**
-         * Φίλτρο ανά κατάσταση ενεργοποίησης
+         * Filter by active status
          */
     isActive?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Φίλτρο ανά προεπιλεγμένη κατάσταση εγγραφής
+         * Filter by default subscription status
          */
     isDefault?: 'true' | 'false' | '1' | '0' | boolean
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
     /**
-         * Φίλτρο ανά όνομα (μερική αντιστοίχιση)
+         * Filter by name (partial match)
          */
     name?: string
     /**
@@ -22643,19 +20703,19 @@ export type ListSubscriptionTopicData = {
          */
     page?: string | number
     /**
-         * Αριθμός αποτελεσμάτων ανά σελίδα
+         * Number of results to return per page
          */
     pageSize?: string | number
     /**
-         * Ενεργοποίηση/απενεργοποίηση σελιδοποίησης
+         * Enable or disable pagination
          */
     pagination?: 'false' | 'true'
     /**
-         * Τύπος στρατηγικής σελιδοποίησης
+         * Pagination strategy type
          */
     paginationType?: 'cursor' | 'limitOffset' | 'pageNumber'
     /**
-         * Φίλτρο ανά απαίτηση επιβεβαίωσης
+         * Filter by confirmation requirement
          */
     requiresConfirmation?: 'true' | 'false' | '1' | '0' | boolean
     /**
@@ -22663,12 +20723,12 @@ export type ListSubscriptionTopicData = {
          */
     search?: string
     /**
-         * Φίλτρο ανά slug (μερική αντιστοίχιση)
+         * Filter by slug (partial match)
          */
     slug?: string
     slug_Icontains?: string
     /**
-         * Φίλτρο ανά ακριβές slug
+         * Filter by exact slug
          */
     slugExact?: string
     /**
@@ -22708,7 +20768,7 @@ export type CreateSubscriptionTopicData = {
   path?: never
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22764,7 +20824,7 @@ export type RetrieveSubscriptionTopicData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22793,7 +20853,7 @@ export type PartialUpdateSubscriptionTopicData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }
@@ -22823,7 +20883,7 @@ export type UpdateSubscriptionTopicData = {
   }
   query?: {
     /**
-         * Κωδικός γλώσσας για μεταφράσεις (el, en, de)
+         * Language code for translations (el, en, de)
          */
     languageCode?: 'de' | 'el' | 'en'
   }

--- a/shared/openapi/zod.gen.ts
+++ b/shared/openapi/zod.gen.ts
@@ -42,23 +42,23 @@ export const zAcsAddressValidationResponse = z.object({
 })
 
 /**
- * * `1` - Προπληρωμένο
- * * `2` - Αντικαταβολή
+ * * `1` - Prepaid
+ * * `2` - Cash on delivery
  */
 export const zAcsChargeType = z.union([z.literal(1), z.literal(2)]).register(z.globalRegistry, {
-  description: '* `1` - Προπληρωμένο\n* `2` - Αντικαταβολή',
+  description: '* `1` - Prepaid\n* `2` - Cash on delivery',
 })
 
 export const zAcsPickupList = z.object({
   id: z.int().readonly(),
   pickupListNo: z.string().register(z.globalRegistry, {
-    description: 'PickupList_No που επιστρέφεται από το ACS_Issue_Pickup_List.',
+    description: 'PickupList_No returned by ACS_Issue_Pickup_List.',
   }).readonly(),
   issuedAt: z.iso.datetime({ offset: true }).readonly(),
   issuedBy: z.int().readonly().nullable(),
   issuedByUsername: z.string().readonly().nullable(),
   billingCode: z.string().register(z.globalRegistry, {
-    description: 'Billing_Code που καταγράφεται τη στιγμή της έκδοσης, ώστε τα ιστορικά manifest να παραμένουν επανεκτυπώσιμα ακόμη κι αν αλλάξει η μεταβλητή περιβάλλοντος.',
+    description: 'Billing_Code captured at issuance time so historical manifests stay reprintable even if the env var changes.',
   }).readonly(),
   voucherCount: z.int().readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
@@ -68,19 +68,19 @@ export const zAcsPickupList = z.object({
 export const zAcsTrackingEvent = z.object({
   id: z.int().readonly(),
   eventTime: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Checkpoint_Date_Time από το ACS_TrackingDetails.',
+    description: 'Checkpoint_Date_Time from ACS_TrackingDetails.',
   }).readonly(),
   checkpointAction: z.string().register(z.globalRegistry, {
-    description: 'Checkpoint_Action_Description — κείμενο στα ελληνικά σε αναγνώσιμη μορφή που περιγράφει το συμβάν.',
+    description: 'Checkpoint_Action_Description — human-readable Greek text describing the event.',
   }).readonly(),
   checkpointLocation: z.string().register(z.globalRegistry, {
     description: 'Checkpoint_Location_Description.',
   }).readonly(),
   notes: z.string().register(z.globalRegistry, {
-    description: 'Πεδίο σχολίων ACS.',
+    description: 'ACS Comments field.',
   }).readonly(),
   receivedAt: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Πραγματικός χρόνος κατά τον οποίο η εργασία παρακολούθησης παρατήρησε αυτό το συμβάν.',
+    description: 'Wall-clock time when the polling task observed this event.',
   }).readonly(),
 })
 
@@ -335,25 +335,25 @@ export const zBlogCategoryDetail = z.object({
 
 export const zBlogCategoryReorderItemRequest = z.object({
   id: z.int().register(z.globalRegistry, {
-    description: 'ID κατηγορίας',
+    description: 'Category ID',
   }),
   sortOrder: z.int().register(z.globalRegistry, {
-    description: 'Νέα τιμή σειράς ταξινόμησης',
+    description: 'New sort order value',
   }),
 })
 
 export const zBlogCategoryReorderRequestRequest = z.object({
   categories: z.array(zBlogCategoryReorderItemRequest).register(z.globalRegistry, {
-    description: 'Λίστα κατηγοριών με νέες σειρές ταξινόμησης',
+    description: 'List of categories with new sort orders',
   }),
 })
 
 export const zBlogCategoryReorderResponse = z.object({
   updatedCount: z.int().register(z.globalRegistry, {
-    description: 'Αριθμός ενημερωμένων κατηγοριών',
+    description: 'Number of categories updated',
   }),
   message: z.string().register(z.globalRegistry, {
-    description: 'Μήνυμα επιτυχίας',
+    description: 'Success message',
   }),
 })
 
@@ -384,13 +384,13 @@ export const zBlogCategoryWriteRequest = z.object({
 
 export const zBlogCommentLikedCommentsRequestRequest = z.object({
   commentIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID σχολίων για έλεγχο κατάστασης επισήμανσης',
+    description: 'List of comment IDs to check like status for',
   }),
 })
 
 export const zBlogCommentLikedCommentsResponse = z.object({
   likedCommentIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID σχολίων που έχει επισημάνει ο τρέχων χρήστης',
+    description: 'List of comment IDs that are liked by the current user',
   }),
 })
 
@@ -467,13 +467,13 @@ export const zBlogPost = z.object({
 
 export const zBlogPostLikedPostsRequestRequest = z.object({
   postIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID άρθρων για έλεγχο επισημάνσεων',
+    description: 'List of post IDs to check for likes',
   }),
 })
 
 export const zBlogPostLikedPostsResponse = z.object({
   postIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID άρθρων με επισήμανση',
+    description: 'List of liked post IDs',
   }),
 })
 
@@ -492,11 +492,25 @@ export const zBlogPostMeiliSearchResult = z.object({
   contentType: z.string(),
 })
 
+/**
+ * Common disclosure fields every search response carries.
+ *
+ * ``query_id`` attributes later clicks to this query (see the
+ * ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+ * query the zero-result fallback actually matched, so clients can
+ * disclose "showing results for …" instead of silently swapping.
+ */
 export const zBlogPostMeiliSearchResponse = z.object({
+  queryId: z.uuid().register(z.globalRegistry, {
+    description: 'Identifier for this search, used to attribute clicks',
+  }),
+  relaxedQuery: z.string().nullable(),
   limit: z.int(),
   offset: z.int(),
   estimatedTotalHits: z.int(),
   results: z.array(zBlogPostMeiliSearchResult),
+}).register(z.globalRegistry, {
+  description: 'Common disclosure fields every search response carries.\n\n``query_id`` attributes later clicks to this query (see the\n``search/click`` endpoint); ``relaxed_query`` reports the trimmed\nquery the zero-result fallback actually matched, so clients can\ndisclose "showing results for …" instead of silently swapping.',
 })
 
 /**
@@ -552,7 +566,7 @@ export const zBlogTag = z.object({
   active: z.boolean().optional(),
   sortOrder: z.int().readonly().nullable(),
   postsCount: z.string().register(z.globalRegistry, {
-    description: 'Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα',
+    description: 'Number of blog posts using this tag',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -580,7 +594,7 @@ export const zBlogTagDetail = z.object({
   active: z.boolean().optional(),
   sortOrder: z.int().readonly().nullable(),
   postsCount: z.string().register(z.globalRegistry, {
-    description: 'Αριθμός άρθρων που χρησιμοποιούν αυτή την ετικέτα',
+    description: 'Number of blog posts using this tag',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -614,13 +628,13 @@ export const zBlogTagWriteRequest = z.object({
  */
 export const zBoxNowCustomerRequest = z.object({
   name: z.string().register(z.globalRegistry, {
-    description: 'Πλήρες όνομα πελάτη',
+    description: 'Customer full name',
   }).optional(),
   email: z.string().register(z.globalRegistry, {
-    description: 'Email πελάτη',
+    description: 'Customer email address',
   }).optional(),
   phoneNumber: z.string().register(z.globalRegistry, {
-    description: 'Τηλέφωνο πελάτη',
+    description: 'Customer phone number',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Nested ``customer`` object within a BoxNow webhook payload.',
@@ -631,10 +645,10 @@ export const zBoxNowCustomerRequest = z.object({
  */
 export const zBoxNowEventLocationRequest = z.object({
   displayName: z.string().register(z.globalRegistry, {
-    description: 'Όνομα locker ή hub σε αναγνώσιμη μορφή',
+    description: 'Human-readable locker or hub name',
   }).optional(),
   postalCode: z.string().register(z.globalRegistry, {
-    description: 'Ταχυδρομικός κώδικας της τοποθεσίας του συμβάντος',
+    description: 'Postal code of the event location',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Nested ``eventLocation`` object within a BoxNow webhook payload.',
@@ -648,19 +662,19 @@ export const zBoxNowEventLocationRequest = z.object({
  */
 export const zBoxNowNearestLockerRequestRequest = z.object({
   city: z.string().min(1).max(128).register(z.globalRegistry, {
-    description: 'Όνομα πόλης για αναζήτηση πλησιέστερου locker',
+    description: 'City name for nearest-locker lookup',
   }),
   street: z.string().min(1).max(255).register(z.globalRegistry, {
-    description: 'Οδός και αριθμός',
+    description: 'Street name and number',
   }),
   postalCode: z.string().min(1).max(16).register(z.globalRegistry, {
-    description: 'Ταχυδρομικός κώδικας',
+    description: 'Postal / ZIP code',
   }),
   region: z.string().min(1).max(8).register(z.globalRegistry, {
-    description: 'Ετικέτα γλώσσας IETF / κωδικός περιφέρειας (προεπιλογή: el-GR)',
+    description: 'IETF language tag / region code (default: el-GR)',
   }).optional().default('el-GR'),
   compartmentSize: z.int().gte(1).lte(3).register(z.globalRegistry, {
-    description: 'Απαιτούμενο μέγεθος θυρίδας: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο',
+    description: 'Required compartment size: 1=Small, 2=Medium, 3=Large',
   }).optional().default(1),
 }).register(z.globalRegistry, {
   description: 'Request body for ``POST /lockers/nearest``.\n\nMaps to the BoxNow ``/api/v2/delivery-requests:checkAddressDelivery``\nendpoint parameters.',
@@ -676,64 +690,64 @@ export const zBoxNowNearestLockerRequestRequest = z.object({
  */
 export const zBoxNowNearestLockerResponse = z.object({
   id: z.string().register(z.globalRegistry, {
-    description: 'Αναγνωριστικό APM BoxNow',
+    description: 'BoxNow APM identifier',
   }).readonly(),
   type: z.string().register(z.globalRegistry, {
-    description: 'Τύπος locker (π.χ. apm, warehouse)',
+    description: 'Locker type (e.g. apm, warehouse)',
   }).readonly(),
   image: z.string().register(z.globalRegistry, {
-    description: 'URL εικόνας locker',
+    description: 'URL of locker image',
   }).readonly(),
   lat: z.string().register(z.globalRegistry, {
-    description: 'Γεωγραφικό πλάτος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)',
+    description: 'Latitude (string as returned by BoxNow)',
   }).readonly(),
   lng: z.string().register(z.globalRegistry, {
-    description: 'Γεωγραφικό μήκος (συμβολοσειρά όπως επιστρέφεται από το BoxNow)',
+    description: 'Longitude (string as returned by BoxNow)',
   }).readonly(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Σύντομος τίτλος εμφάνισης',
+    description: 'Short display title',
   }).readonly(),
   name: z.string().register(z.globalRegistry, {
-    description: 'Πλήρες όνομα locker',
+    description: 'Full locker name',
   }).readonly(),
   postalCode: z.string().register(z.globalRegistry, {
-    description: 'Ταχ. κώδικας του locker',
+    description: 'Postal code of the locker',
   }).readonly(),
   country: z.string().register(z.globalRegistry, {
-    description: 'ISO 3166-1 alpha-2 κωδικός χώρας',
+    description: 'ISO 3166-1 alpha-2 country code',
   }).readonly(),
   note: z.string().register(z.globalRegistry, {
-    description: 'Λειτουργική σημείωση από BoxNow',
+    description: 'Operational note from BoxNow',
   }).readonly(),
   addressLine1: z.string().register(z.globalRegistry, {
-    description: 'Κύρια γραμμή διεύθυνσης',
+    description: 'Primary address line',
   }).readonly(),
   addressLine2: z.string().register(z.globalRegistry, {
-    description: 'Δευτερεύουσα γραμμή διεύθυνσης',
+    description: 'Secondary address line',
   }).readonly(),
   region: z.string().register(z.globalRegistry, {
-    description: 'Ετικέτα περιφέρειας IETF που επιστρέφεται από το BoxNow',
+    description: 'IETF region tag returned by BoxNow',
   }).readonly(),
   distance: z.number().register(z.globalRegistry, {
-    description: 'Απόσταση από τη δεδομένη διεύθυνση σε χιλιόμετρα',
+    description: 'Distance from the supplied address in kilometres',
   }).readonly(),
 }).register(z.globalRegistry, {
   description: 'Response shape returned by BoxNow\'s checkAddressDelivery call.\n\nMirrors ``/api/v2/delivery-requests:checkAddressDelivery`` response.\n``lat`` and ``lng`` are CharField because BoxNow returns them as\nstrings in this endpoint.  ``distance`` is the straight-line\ndistance in kilometres from the supplied address.',
 })
 
 /**
- * * `pending_creation` - Εκκρεμής δημιουργία
- * * `new` - Νέο
- * * `in_depot` - Σε αποθήκη
- * * `final_destination` - Στο locker
- * * `delivered` - Παραδόθηκε
- * * `returned` - Επιστράφηκε
- * * `expired` - Έληξε
- * * `canceled` - Ακυρώθηκε
- * * `accepted_for_return` - Αποδεκτό για επιστροφή
- * * `accepted_to_locker` - Αποδεκτό σε locker
- * * `missing` - Λείπει
- * * `lost` - Χάθηκε
+ * * `pending_creation` - Pending creation
+ * * `new` - New
+ * * `in_depot` - In depot
+ * * `final_destination` - At locker
+ * * `delivered` - Delivered
+ * * `returned` - Returned
+ * * `expired` - Expired
+ * * `canceled` - Canceled
+ * * `accepted_for_return` - Accepted for return
+ * * `accepted_to_locker` - Accepted to locker
+ * * `missing` - Missing
+ * * `lost` - Lost
  */
 export const zBoxNowParcelState = z.enum([
   'pending_creation',
@@ -749,7 +763,7 @@ export const zBoxNowParcelState = z.enum([
   'missing',
   'lost',
 ]).register(z.globalRegistry, {
-  description: '* `pending_creation` - Εκκρεμής δημιουργία\n* `new` - Νέο\n* `in_depot` - Σε αποθήκη\n* `final_destination` - Στο locker\n* `delivered` - Παραδόθηκε\n* `returned` - Επιστράφηκε\n* `expired` - Έληξε\n* `canceled` - Ακυρώθηκε\n* `accepted_for_return` - Αποδεκτό για επιστροφή\n* `accepted_to_locker` - Αποδεκτό σε locker\n* `missing` - Λείπει\n* `lost` - Χάθηκε',
+  description: '* `pending_creation` - Pending creation\n* `new` - New\n* `in_depot` - In depot\n* `final_destination` - At locker\n* `delivered` - Delivered\n* `returned` - Returned\n* `expired` - Expired\n* `canceled` - Canceled\n* `accepted_for_return` - Accepted for return\n* `accepted_to_locker` - Accepted to locker\n* `missing` - Missing\n* `lost` - Lost',
 })
 
 /**
@@ -761,17 +775,17 @@ export const zBoxNowParcelState = z.enum([
 export const zBoxNowParcelEvent = z.object({
   id: z.int().readonly(),
   webhookMessageId: z.string().register(z.globalRegistry, {
-    description: 'Πεδίο \'id\' του CloudEvents — κλειδί ιδεμποτεντίας',
+    description: 'CloudEvents \'id\' field — idempotency key',
   }).readonly(),
   eventType: zBoxNowParcelState,
   eventTypeDisplay: z.string().register(z.globalRegistry, {
-    description: 'Ετικέτα σε αναγνώσιμη μορφή για την τιμή event_type',
+    description: 'Human-readable label for the event_type choice',
   }).readonly(),
   parcelState: z.string().register(z.globalRegistry, {
-    description: 'Ακατέργαστη τιμή \'data.parcelState\' από το payload του webhook BoxNow',
+    description: 'Raw \'data.parcelState\' value from BoxNow webhook payload',
   }).readonly(),
   eventTime: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Χρονοσήμανση από το \'data.time\' στο payload του webhook',
+    description: 'Timestamp from \'data.time\' in the webhook payload',
   }).readonly(),
   displayName: z.string().register(z.globalRegistry, {
     description: 'data.eventLocation.displayName',
@@ -781,7 +795,7 @@ export const zBoxNowParcelEvent = z.object({
   }).readonly(),
   additionalInformation: z.string().readonly(),
   receivedAt: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Χρονοσήμανση λήψης του webhook από το GrooveShop (διαφορετική από το event_time)',
+    description: 'Timestamp when GrooveShop received the webhook (separate from event_time)',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
 }).register(z.globalRegistry, {
@@ -798,30 +812,30 @@ export const zBoxNowParcelEvent = z.object({
  */
 export const zBoxNowWebhookDataRequest = z.object({
   parcelId: z.string().min(1).register(z.globalRegistry, {
-    description: '10ψήφιος αριθμός voucher/δέματος BoxNow',
+    description: '10-digit BoxNow voucher/parcel number',
   }),
   parcelState: z.string().min(1).register(z.globalRegistry, {
-    description: 'Λεξιλόγιο κατάστασης δέματος BoxNow (data.parcelState)',
+    description: 'BoxNow parcel state vocabulary (data.parcelState)',
   }),
   parcelReferenceNumber: z.string().register(z.globalRegistry, {
-    description: 'Προαιρετικός αριθμός αναφοράς εμπόρου',
+    description: 'Optional merchant reference number',
   }).optional(),
   parcelName: z.string().register(z.globalRegistry, {
-    description: 'Προαιρετικό όνομα δέματος',
+    description: 'Optional descriptive parcel name',
   }).optional(),
   orderNumber: z.string().min(1).register(z.globalRegistry, {
-    description: 'Αριθμός παραγγελίας εμπόρου που αποστέλλεται κατά τη δημιουργία αιτήματος παράδοσης',
+    description: 'Merchant order number sent during delivery-request creation',
   }),
   event: z.string().min(1).register(z.globalRegistry, {
-    description: 'Συμβολοσειρά τύπου συμβάντος BoxNow (π.χ. \'in-depot\', \'final-destination\', \'delivered\')',
+    description: 'BoxNow event type string (e.g. \'in-depot\', \'final-destination\', \'delivered\')',
   }),
   eventLocation: zBoxNowEventLocationRequest.optional(),
   customer: zBoxNowCustomerRequest.optional(),
   additionalInformation: z.string().register(z.globalRegistry, {
-    description: 'Ελεύθερο κείμενο με επιπλέον πληροφορίες από το BoxNow',
+    description: 'Free-text additional information from BoxNow',
   }).optional(),
   time: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Χρονοσήμανση όταν συνέβη το συμβάν στο BoxNow',
+    description: 'Timestamp when the event occurred at BoxNow',
   }),
 }).register(z.globalRegistry, {
   description: '``data`` field of a BoxNow CloudEvent webhook envelope.\n\nReflects the payload shape described in the BoxNow webhook PDF.\n``camelCase`` field names are preserved because\n``djangorestframework-camel-case`` is already applied\nproject-wide at the middleware level; no manual aliasing needed.',
@@ -837,28 +851,28 @@ export const zBoxNowWebhookDataRequest = z.object({
  */
 export const zBoxNowWebhookEnvelopeRequest = z.object({
   specversion: z.string().min(1).register(z.globalRegistry, {
-    description: 'Έκδοση προδιαγραφής CloudEvents (αναμενόμενη: \'1.0\')',
+    description: 'CloudEvents specification version (expected: \'1.0\')',
   }),
   type: z.string().min(1).register(z.globalRegistry, {
-    description: 'Τύπος συμβάντος (αναμενόμενος: \'gr.boxnow.parcel_event_change\')',
+    description: 'Event type (expected: \'gr.boxnow.parcel_event_change\')',
   }),
   source: z.url().min(1).register(z.globalRegistry, {
-    description: 'URL προέλευσης πηγής συμβάντος',
+    description: 'Origin URL of the event source',
   }),
   subject: z.string().min(1).register(z.globalRegistry, {
-    description: 'Θέμα του συμβάντος (συνήθως το ID δέματος)',
+    description: 'Subject of the event (typically the parcel ID)',
   }),
   id: z.string().min(1).register(z.globalRegistry, {
-    description: 'Μοναδικό ID CloudEvents· χρησιμοποιείται ως κλειδί ιδεμποτεντίας (αποθηκεύεται ως webhook_message_id)',
+    description: 'Unique CloudEvents ID; used as idempotency key (stored as webhook_message_id)',
   }),
   time: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Χρονοσήμανση δημιουργίας του φακέλου',
+    description: 'Timestamp the envelope was generated',
   }),
   datacontenttype: z.string().min(1).register(z.globalRegistry, {
-    description: 'Τύπος MIME του πεδίου data (αναμενόμενος: \'application/json\')',
+    description: 'MIME type of the data field (expected: \'application/json\')',
   }),
   datasignature: z.string().min(1).register(z.globalRegistry, {
-    description: 'Δεκαεξαδικό digest HMAC-SHA256 του ακατέργαστου JSON αντικειμένου \'data\'· χρησιμοποιείται για επαλήθευση υπογραφής',
+    description: 'HMAC-SHA256 hex digest of the raw \'data\' JSON object; used for signature verification',
   }),
   data: zBoxNowWebhookDataRequest,
 }).register(z.globalRegistry, {
@@ -872,7 +886,7 @@ export const zBulkSubscriptionFailure = z.object({
 
 export const zBulkSubscriptionRequest = z.object({
   topicIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID θεμάτων για εγγραφή/διαγραφή',
+    description: 'List of topic IDs to subscribe/unsubscribe',
   }),
   action: zActionEnum,
 })
@@ -916,17 +930,17 @@ export const zCartCreatePaymentIntentRequestShippingKindEnum = z.enum(['home_del
  */
 export const zCartCreatePaymentIntentRequestRequest = z.object({
   payWayId: z.int().gte(1).register(z.globalRegistry, {
-    description: 'ID της επιλεγμένης μεθόδου πληρωμής (πρέπει να είναι online Stripe).',
+    description: 'ID of the selected PayWay (must be online Stripe).',
   }),
   shippingKind: zCartCreatePaymentIntentRequestShippingKindEnum,
   shippingProviderCode: z.string().max(32).register(z.globalRegistry, {
-    description: 'Κωδικός μεταφορέα που αντιστοιχεί σε καταχωρημένο προσαρμογέα αποστολής (π.χ. \'acs\', \'boxnow\'). Απαιτείται για ``pickup_point``· παραλείψτε/αφήστε κενό για ``home_delivery`` (το backend χρησιμοποιεί τη γενική πάγια χρέωση, αντίστοιχη με αυτή που θα υπολογίσει η επαλήθευση δημιουργίας παραγγελίας για το ίδιο αίτημα).',
+    description: 'Carrier code matching a registered shipping adapter (e.g. \'acs\', \'boxnow\'). Required for ``pickup_point``; omit/empty for ``home_delivery`` (the backend uses the generic flat rate, matching what the order-create verification will compute for the same body).',
   }).optional(),
   countryId: z.string().max(2).register(z.globalRegistry, {
-    description: 'Προαιρετικός κωδικός χώρας ISO 3166-1 alpha-2 — καθορίζει τον συντελεστή αποστολής σε επίπεδο χώρας. Πρέπει να ταιριάζει με αυτόν που θα φέρει το αίτημα δημιουργίας παραγγελίας.',
+    description: 'Optional ISO 3166-1 alpha-2 country code — drives the country-level shipping multiplier. Match what the order-create body will carry.',
   }).optional(),
   regionId: z.string().max(16).register(z.globalRegistry, {
-    description: 'Προαιρετικός κωδικός περιφέρειας — καθορίζει την προσαρμογή αποστολής σε επίπεδο περιφέρειας.',
+    description: 'Optional region code — drives the region-level shipping adjustment.',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Request body for ``POST /api/v1/cart/create-payment-intent``.\n\n``shipping_kind`` is required so the view\'s shipping calculation\nfollows the same code path the order-create verification runs.\n``shipping_provider_code`` is required for ``pickup_point`` (the\ncarrier identity drives the locker quote + per-carrier threshold)\nbut **omitted for ``home_delivery``** — home delivery is\nprovider-agnostic in checkout per the frontend\'s\n``shared/shipping/index.ts::carrierForMethod`` contract, and the\nbackend resolves the active home-delivery provider at order\ncreation. Sending whatever the frontend has guarantees both calc\npaths agree.',
@@ -946,16 +960,16 @@ export const zCartItemUpdateRequest = z.object({
  */
 export const zCartPaymentIntentResponse = z.object({
   clientSecret: z.string().register(z.globalRegistry, {
-    description: 'Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend',
+    description: 'Stripe PaymentIntent client secret for frontend confirmation',
   }),
   paymentIntentId: z.string().register(z.globalRegistry, {
-    description: 'ID του Stripe PaymentIntent προς αποθήκευση στην παραγγελία',
+    description: 'Stripe PaymentIntent ID to be stored on the order',
   }),
   amount: z.number().gt(-10000000000).lt(10000000000).register(z.globalRegistry, {
-    description: 'Συνολικό ποσό χρέωσης (καλάθι + αποστολή + έξοδα πληρωμής)',
+    description: 'Total charge amount (cart + shipping + payment fee)',
   }),
   currency: z.string().max(3).register(z.globalRegistry, {
-    description: 'Κωδικός νομίσματος ISO 4217 (π.χ. EUR)',
+    description: 'ISO 4217 currency code (e.g. EUR)',
   }),
 }).register(z.globalRegistry, {
   description: 'Response body returned by the create-payment-intent cart action.',
@@ -985,16 +999,16 @@ export const zConfirmAgentPaymentResponse = z.object({
     description: 'Stripe PaymentIntent ID that charged the token',
   }),
   status: z.string().register(z.globalRegistry, {
-    description: 'Κατάσταση πληρωμής',
+    description: 'Payment status',
   }),
   amount: z.string().register(z.globalRegistry, {
-    description: 'Ποσό πληρωμής',
+    description: 'Payment amount',
   }),
   currency: z.string().register(z.globalRegistry, {
-    description: 'Νόμισμα πληρωμής',
+    description: 'Payment currency',
   }),
   provider: z.string().register(z.globalRegistry, {
-    description: 'Όνομα παρόχου πληρωμών',
+    description: 'Payment provider name',
   }),
 })
 
@@ -1123,31 +1137,31 @@ export const zCreateCheckoutSessionResponse = z.object({
 
 export const zCreatePaymentIntentRequestRequest = z.object({
   paymentData: z.record(z.string(), z.string().min(1).max(500)).register(z.globalRegistry, {
-    description: 'Επιπλέον δεδομένα πληρωμής που απαιτούνται από τον πάροχο πληρωμών',
+    description: 'Additional payment data required by the payment provider',
   }).optional(),
 })
 
 export const zCreatePaymentIntentResponse = z.object({
   paymentId: z.string().register(z.globalRegistry, {
-    description: 'ID payment intent από τον πάροχο πληρωμών',
+    description: 'Payment intent ID from the payment provider',
   }),
   status: z.string().register(z.globalRegistry, {
-    description: 'Κατάσταση πληρωμής',
+    description: 'Payment status',
   }),
   amount: z.string().register(z.globalRegistry, {
-    description: 'Ποσό πληρωμής',
+    description: 'Payment amount',
   }),
   currency: z.string().register(z.globalRegistry, {
-    description: 'Νόμισμα πληρωμής',
+    description: 'Payment currency',
   }),
   provider: z.string().register(z.globalRegistry, {
-    description: 'Όνομα παρόχου πληρωμών',
+    description: 'Payment provider name',
   }),
   clientSecret: z.string().register(z.globalRegistry, {
-    description: 'Client secret του Stripe PaymentIntent για επιβεβαίωση στο frontend',
+    description: 'Stripe PaymentIntent client secret for frontend confirmation',
   }).optional(),
   requiresAction: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η πληρωμή απαιτεί επιπλέον ενέργεια (3D Secure κ.λπ.)',
+    description: 'Whether the payment requires additional action (3D Secure, etc.)',
   }).optional().default(false),
   nextAction: z.record(z.string(), z.unknown()).nullish(),
 })
@@ -1183,7 +1197,7 @@ export const zDateRange = z.object({
  */
 export const zDeleteAccountRequestRequest = z.object({
   confirmation: z.string().min(1).register(z.globalRegistry, {
-    description: 'Πρέπει να ισούται ακριβώς με τη συμβολοσειρά "DELETE".',
+    description: 'Must equal the literal string "DELETE".',
   }),
 }).register(z.globalRegistry, {
   description: 'Body for ``POST user/account/{id}/delete_account``.\n\nRequires the user to re-type ``DELETE`` as a guardrail. The allauth\nre-authentication happens outside this serializer via the session\nmiddleware\'s ``X-Session-Token`` header before the task is queued.',
@@ -1280,6 +1294,10 @@ export const zFederatedSearchResult = z.object({
  * Serializer for federated search response.
  */
 export const zFederatedSearchResponse = z.object({
+  queryId: z.uuid().register(z.globalRegistry, {
+    description: 'Identifier for this search, used to attribute clicks',
+  }),
+  relaxedQuery: z.string().nullable(),
   limit: z.int().register(z.globalRegistry, {
     description: 'Maximum number of results requested',
   }),
@@ -1297,14 +1315,14 @@ export const zFederatedSearchResponse = z.object({
 })
 
 /**
- * * `BASEMENT` - Υπόγειο
- * * `GROUND_FLOOR` - Ισόγειο
- * * `FIRST_FLOOR` - 1ος όροφος
- * * `SECOND_FLOOR` - 2ος όροφος
- * * `THIRD_FLOOR` - 3ος όροφος
- * * `FOURTH_FLOOR` - 4ος όροφος
- * * `FIFTH_FLOOR` - 5ος όροφος
- * * `SIXTH_FLOOR_PLUS` - 6ος όροφος +
+ * * `BASEMENT` - Basement
+ * * `GROUND_FLOOR` - Ground Floor
+ * * `FIRST_FLOOR` - First Floor
+ * * `SECOND_FLOOR` - Second Floor
+ * * `THIRD_FLOOR` - Third Floor
+ * * `FOURTH_FLOOR` - Fourth Floor
+ * * `FIFTH_FLOOR` - Fifth Floor
+ * * `SIXTH_FLOOR_PLUS` - Sixth Floor Plus
  */
 export const zFloorEnum = z.enum([
   'BASEMENT',
@@ -1316,7 +1334,7 @@ export const zFloorEnum = z.enum([
   'FIFTH_FLOOR',
   'SIXTH_FLOOR_PLUS',
 ]).register(z.globalRegistry, {
-  description: '* `BASEMENT` - Υπόγειο\n* `GROUND_FLOOR` - Ισόγειο\n* `FIRST_FLOOR` - 1ος όροφος\n* `SECOND_FLOOR` - 2ος όροφος\n* `THIRD_FLOOR` - 3ος όροφος\n* `FOURTH_FLOOR` - 4ος όροφος\n* `FIFTH_FLOOR` - 5ος όροφος\n* `SIXTH_FLOOR_PLUS` - 6ος όροφος +',
+  description: '* `BASEMENT` - Basement\n* `GROUND_FLOOR` - Ground Floor\n* `FIRST_FLOOR` - First Floor\n* `SECOND_FLOOR` - Second Floor\n* `THIRD_FLOOR` - Third Floor\n* `FOURTH_FLOOR` - Fourth Floor\n* `FIFTH_FLOOR` - Fifth Floor\n* `SIXTH_FLOOR_PLUS` - Sixth Floor Plus',
 })
 
 export const zHealthCheckResponse = z.object({
@@ -1326,16 +1344,16 @@ export const zHealthCheckResponse = z.object({
 })
 
 /**
- * * `MAIN` - Κύρια εικόνα
- * * `BANNER` - Banner
- * * `ICON` - Εικονίδιο
- * * `THUMBNAIL` - Μικρογραφία
- * * `GALLERY` - Εικόνα συλλογής
- * * `BACKGROUND` - Εικόνα φόντου
- * * `HERO` - Κεντρική εικόνα
- * * `FEATURE` - Κεντρική Εικόνα
- * * `PROMOTIONAL` - Προωθητική εικόνα
- * * `SEASONAL` - Εποχιακή εικόνα
+ * * `MAIN` - Main Image
+ * * `BANNER` - Banner Image
+ * * `ICON` - Icon Image
+ * * `THUMBNAIL` - Thumbnail Image
+ * * `GALLERY` - Gallery Image
+ * * `BACKGROUND` - Background Image
+ * * `HERO` - Hero Image
+ * * `FEATURE` - Feature Image
+ * * `PROMOTIONAL` - Promotional Image
+ * * `SEASONAL` - Seasonal Image
  */
 export const zImageTypeEnum = z.enum([
   'MAIN',
@@ -1349,7 +1367,7 @@ export const zImageTypeEnum = z.enum([
   'PROMOTIONAL',
   'SEASONAL',
 ]).register(z.globalRegistry, {
-  description: '* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα',
+  description: '* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image',
 })
 
 /**
@@ -1357,10 +1375,10 @@ export const zImageTypeEnum = z.enum([
  */
 export const zInvoiceDownloadResponse = z.object({
   invoiceNumber: z.string().register(z.globalRegistry, {
-    description: 'Διαδοχικό αναγνωριστικό στη μορφή ``INV-{YEAR}-{NNNNNN}``. Δεν επιτρέπονται κενά βάσει της ελληνικής φορολογικής νομοθεσίας.',
+    description: 'Sequential identifier in the form ``INV-{YEAR}-{NNNNNN}``. Gaps are not allowed by Greek tax law.',
   }).readonly(),
   issueDate: z.iso.date().register(z.globalRegistry, {
-    description: 'Φορολογική ημερομηνία έκδοσης. Αμετάβλητη μόλις εκδοθεί το τιμολόγιο — χρησιμοποιείται για διαδοχική αρίθμηση και αναφορές.',
+    description: 'Fiscal date of issue. Immutable once the invoice is rendered — used for sequential numbering and reporting.',
   }).readonly(),
   downloadUrl: z.string().readonly().nullable(),
   subtotal: z.string().readonly().nullable(),
@@ -1368,23 +1386,23 @@ export const zInvoiceDownloadResponse = z.object({
   total: z.string().readonly().nullable(),
   currency: z.string().readonly(),
   vatBreakdown: z.unknown().register(z.globalRegistry, {
-    description: 'Λίστα σε cache από γραμμές ``{rate, subtotal, vat, gross}`` — παγιωμένη τη στιγμή της έκδοσης, ώστε η εκ νέου απόδοση του τιμολογίου να δίνει πάντα τον ίδιο πίνακα ΦΠΑ ακόμη κι αν αλλάξουν οι συντελεστές των προϊόντων.',
+    description: 'Cached list of ``{rate, subtotal, vat, gross}`` rows — frozen at issue time so re-rendering the invoice always yields the same VAT table even if product rates change.',
   }),
 }).register(z.globalRegistry, {
   description: 'Invoice metadata plus an absolute URL to the streaming endpoint.',
 })
 
 /**
- * * `HOME` - Σπίτι
- * * `OFFICE` - Γραφείο
- * * `OTHER` - Άλλο
+ * * `HOME` - Αρχική
+ * * `OFFICE` - Office
+ * * `OTHER` - Other
  */
 export const zLocationTypeEnum = z.enum([
   'HOME',
   'OFFICE',
   'OTHER',
 ]).register(z.globalRegistry, {
-  description: '* `HOME` - Σπίτι\n* `OFFICE` - Γραφείο\n* `OTHER` - Άλλο',
+  description: '* `HOME` - Αρχική\n* `OFFICE` - Office\n* `OTHER` - Other',
 })
 
 /**
@@ -1407,10 +1425,10 @@ export const zLoyaltyTier = z.object({
     }).optional(),
   }),
   requiredLevel: z.int().register(z.globalRegistry, {
-    description: 'Ελάχιστο επίπεδο για την επίτευξη αυτού του tier',
+    description: 'Minimum level to achieve this tier',
   }).readonly(),
   pointsMultiplier: z.number().gt(-1000).lt(1000).register(z.globalRegistry, {
-    description: 'Πολλαπλασιαστής που εφαρμόζεται στους πόντους που κερδίζουν οι χρήστες σε αυτό το tier',
+    description: 'Multiplier applied to earned points for users in this tier',
   }).readonly(),
   icon: z.url().nullish(),
   mainImagePath: z.string().readonly(),
@@ -1441,20 +1459,20 @@ export const zLoyaltySummary = z.object({
 })
 
 /**
- * * `ORDER` - Παραγγελία
- * * `PAYMENT` - Πληρωμή
- * * `SHIPPING` - Μεταφορικά
- * * `CART` - Καλάθι
- * * `PRODUCT` - Προϊόν
- * * `ACCOUNT` - Λογαριασμός Ανενεργός
- * * `SECURITY` - Ασφάλεια
- * * `PROMOTION` - Προσφορά
- * * `SYSTEM` - Σύστημα
- * * `REVIEW` - Εξέταση
- * * `WISHLIST` - Λίστα επιθυμιών
- * * `SUPPORT` - Υποστήριξη
+ * * `ORDER` - Ταξινόμηση
+ * * `PAYMENT` - Payment
+ * * `SHIPPING` - Shipping
+ * * `CART` - Cart
+ * * `PRODUCT` - Product
+ * * `ACCOUNT` - Account
+ * * `SECURITY` - Security
+ * * `PROMOTION` - Promotion
+ * * `SYSTEM` - System
+ * * `REVIEW` - Review
+ * * `WISHLIST` - Wishlist
+ * * `SUPPORT` - Support
  * * `NEWSLETTER` - Newsletter
- * * `RECOMMENDATION` - Σύσταση
+ * * `RECOMMENDATION` - Recommendation
  */
 export const zNotificationCategory = z.enum([
   'ORDER',
@@ -1472,12 +1490,12 @@ export const zNotificationCategory = z.enum([
   'NEWSLETTER',
   'RECOMMENDATION',
 ]).register(z.globalRegistry, {
-  description: '* `ORDER` - Παραγγελία\n* `PAYMENT` - Πληρωμή\n* `SHIPPING` - Μεταφορικά\n* `CART` - Καλάθι\n* `PRODUCT` - Προϊόν\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SECURITY` - Ασφάλεια\n* `PROMOTION` - Προσφορά\n* `SYSTEM` - Σύστημα\n* `REVIEW` - Εξέταση\n* `WISHLIST` - Λίστα επιθυμιών\n* `SUPPORT` - Υποστήριξη\n* `NEWSLETTER` - Newsletter\n* `RECOMMENDATION` - Σύσταση',
+  description: '* `ORDER` - Ταξινόμηση\n* `PAYMENT` - Payment\n* `SHIPPING` - Shipping\n* `CART` - Cart\n* `PRODUCT` - Product\n* `ACCOUNT` - Account\n* `SECURITY` - Security\n* `PROMOTION` - Promotion\n* `SYSTEM` - System\n* `REVIEW` - Review\n* `WISHLIST` - Wishlist\n* `SUPPORT` - Support\n* `NEWSLETTER` - Newsletter\n* `RECOMMENDATION` - Recommendation',
 })
 
 export const zNotificationCountResponse = z.object({
   count: z.int().register(z.globalRegistry, {
-    description: 'Αριθμός μη ορατών ειδοποιήσεων',
+    description: 'Number of unseen notifications',
   }),
 })
 
@@ -1487,10 +1505,10 @@ export const zNotificationIdsRequest = z.object({
 
 /**
  * * `ERROR` - Σφάλμα
- * * `SUCCESS` - Επιτυχία
- * * `INFO` - Πληροφορία
- * * `WARNING` - Προειδοποίηση
- * * `DANGER` - Κίνδυνος
+ * * `SUCCESS` - Success
+ * * `INFO` - Info
+ * * `WARNING` - Warning
+ * * `DANGER` - Danger
  */
 export const zNotificationKindEnum = z.enum([
   'ERROR',
@@ -1499,33 +1517,33 @@ export const zNotificationKindEnum = z.enum([
   'WARNING',
   'DANGER',
 ]).register(z.globalRegistry, {
-  description: '* `ERROR` - Σφάλμα\n* `SUCCESS` - Επιτυχία\n* `INFO` - Πληροφορία\n* `WARNING` - Προειδοποίηση\n* `DANGER` - Κίνδυνος',
+  description: '* `ERROR` - Σφάλμα\n* `SUCCESS` - Success\n* `INFO` - Info\n* `WARNING` - Warning\n* `DANGER` - Danger',
 })
 
 export const zNotificationSuccessResponse = z.object({
   success: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η λειτουργία ήταν επιτυχής',
+    description: 'Whether the operation was successful',
   }).optional(),
 })
 
 /**
- * * `order_created` - Η παραγγελία δημιουργήθηκε
- * * `order_processing` - Επεξεργασία παραγγελίας
- * * `order_shipped` - Η παραγγελία απεστάλη
- * * `order_delivered` - Η παραγγελία παραδόθηκε
- * * `order_completed` - Η παραγγελία ολοκληρώθηκε
- * * `order_canceled` - Η παραγγελία ακυρώθηκε
- * * `order_refunded` - Επιστροφή χρημάτων παραγγελίας
- * * `shipment_dispatched` - Αποστολή απεστάλη
- * * `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε
- * * `payment_failed` - Η πληρωμή απέτυχε
- * * `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)
- * * `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)
- * * `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης
- * * `comment_liked` - Επισήμανση σχολίου blog
- * * `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker
- * * `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε
- * * `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση
+ * * `order_created` - Order created
+ * * `order_processing` - Order processing
+ * * `order_shipped` - Order shipped
+ * * `order_delivered` - Order delivered
+ * * `order_completed` - Order completed
+ * * `order_canceled` - Order canceled
+ * * `order_refunded` - Order refunded
+ * * `shipment_dispatched` - Shipment dispatched
+ * * `payment_confirmed` - Payment confirmed
+ * * `payment_failed` - Payment failed
+ * * `price_drop_favourite` - Price drop (favourited product)
+ * * `restock_favourite` - Back in stock (favourited product)
+ * * `loyalty_tier_up` - Loyalty tier promotion
+ * * `comment_liked` - Blog comment liked
+ * * `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker
+ * * `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered
+ * * `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery
  */
 export const zNotificationTypeEnum = z.enum([
   'order_created',
@@ -1546,7 +1564,7 @@ export const zNotificationTypeEnum = z.enum([
   'BOXNOW_PARCEL_DELIVERED',
   'ACS_OUT_FOR_DELIVERY',
 ]).register(z.globalRegistry, {
-  description: '* `order_created` - Η παραγγελία δημιουργήθηκε\n* `order_processing` - Επεξεργασία παραγγελίας\n* `order_shipped` - Η παραγγελία απεστάλη\n* `order_delivered` - Η παραγγελία παραδόθηκε\n* `order_completed` - Η παραγγελία ολοκληρώθηκε\n* `order_canceled` - Η παραγγελία ακυρώθηκε\n* `order_refunded` - Επιστροφή χρημάτων παραγγελίας\n* `shipment_dispatched` - Αποστολή απεστάλη\n* `payment_confirmed` - Η πληρωμή επιβεβαιώθηκε\n* `payment_failed` - Η πληρωμή απέτυχε\n* `price_drop_favourite` - Πτώση τιμής (αγαπημένο προϊόν)\n* `restock_favourite` - Διαθέσιμο ξανά (αγαπημένο προϊόν)\n* `loyalty_tier_up` - Αναβάθμιση επιπέδου επιβράβευσης\n* `comment_liked` - Επισήμανση σχολίου blog\n* `BOXNOW_PARCEL_AT_LOCKER` - Το δέμα BoxNow έφτασε στο locker\n* `BOXNOW_PARCEL_DELIVERED` - Το δέμα BoxNow παραδόθηκε\n* `ACS_OUT_FOR_DELIVERY` - Δέμα ACS προς παράδοση',
+  description: '* `order_created` - Order created\n* `order_processing` - Order processing\n* `order_shipped` - Order shipped\n* `order_delivered` - Order delivered\n* `order_completed` - Order completed\n* `order_canceled` - Order canceled\n* `order_refunded` - Order refunded\n* `shipment_dispatched` - Shipment dispatched\n* `payment_confirmed` - Payment confirmed\n* `payment_failed` - Payment failed\n* `price_drop_favourite` - Price drop (favourited product)\n* `restock_favourite` - Back in stock (favourited product)\n* `loyalty_tier_up` - Loyalty tier promotion\n* `comment_liked` - Blog comment liked\n* `BOXNOW_PARCEL_AT_LOCKER` - BoxNow parcel arrived at locker\n* `BOXNOW_PARCEL_DELIVERED` - BoxNow parcel delivered\n* `ACS_OUT_FOR_DELIVERY` - ACS parcel out for delivery',
 })
 
 export const zNotificationUser = z.object({
@@ -1562,7 +1580,7 @@ export const zNotificationUser = z.object({
 
 export const zNotificationUserActionRequest = z.object({
   notificationUserIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID χρηστών ειδοποίησης προς σήμανση ως ορατά/μη ορατά',
+    description: 'List of notification user IDs to mark as seen/unseen',
   }),
 })
 
@@ -1571,20 +1589,20 @@ export const zNotificationUserWriteRequest = z.object({
 })
 
 /**
- * * `RECEIPT` - Απόδειξη
- * * `INVOICE` - Τιμολόγιο
+ * * `RECEIPT` - Receipt
+ * * `INVOICE` - Invoice
  */
 export const zOrderCreateDocumentType = z.enum(['RECEIPT', 'INVOICE']).register(z.globalRegistry, {
-  description: '* `RECEIPT` - Απόδειξη\n* `INVOICE` - Τιμολόγιο',
+  description: '* `RECEIPT` - Receipt\n* `INVOICE` - Invoice',
 })
 
 /**
- * * `RECEIPT` - Απόδειξη
- * * `INVOICE` - Τιμολόγιο
- * * `PROFORMA` - Προτιμολόγιο
- * * `SHIPPING_LABEL` - Ετικέτα αποστολής
- * * `RETURN_LABEL` - Ετικέτα επιστροφής
- * * `CREDIT_NOTE` - Πιστωτικό
+ * * `RECEIPT` - Receipt
+ * * `INVOICE` - Invoice
+ * * `PROFORMA` - Proforma Invoice
+ * * `SHIPPING_LABEL` - Shipping Label
+ * * `RETURN_LABEL` - Return Label
+ * * `CREDIT_NOTE` - Credit Note
  */
 export const zOrderDocumentType = z.enum([
   'RECEIPT',
@@ -1594,7 +1612,7 @@ export const zOrderDocumentType = z.enum([
   'RETURN_LABEL',
   'CREDIT_NOTE',
 ]).register(z.globalRegistry, {
-  description: '* `RECEIPT` - Απόδειξη\n* `INVOICE` - Τιμολόγιο\n* `PROFORMA` - Προτιμολόγιο\n* `SHIPPING_LABEL` - Ετικέτα αποστολής\n* `RETURN_LABEL` - Ετικέτα επιστροφής\n* `CREDIT_NOTE` - Πιστωτικό',
+  description: '* `RECEIPT` - Receipt\n* `INVOICE` - Invoice\n* `PROFORMA` - Proforma Invoice\n* `SHIPPING_LABEL` - Shipping Label\n* `RETURN_LABEL` - Return Label\n* `CREDIT_NOTE` - Credit Note',
 })
 
 export const zOrderItem = z.object({
@@ -1620,10 +1638,10 @@ export const zOrderItemCreateRequest = z.object({
 
 export const zOrderItemRefundRequest = z.object({
   quantity: z.int().gte(1).register(z.globalRegistry, {
-    description: 'Ποσότητα προς επιστροφή. Αν δεν δοθεί, επιστρέφονται όλα.',
+    description: 'Quantity to refund. If not provided, refunds all.',
   }).optional(),
   reason: z.string().max(255).register(z.globalRegistry, {
-    description: 'Προαιρετική αιτία επιστροφής',
+    description: 'Optional reason for the refund',
   }).optional(),
 })
 
@@ -1641,14 +1659,14 @@ export const zOrderItemWriteRequest = z.object({
 })
 
 /**
- * * `PENDING` - Εκκρεμεί
- * * `PROCESSING` - Σε επεξεργασία
- * * `SHIPPED` - Απεστάλη
- * * `DELIVERED` - Παραδόθηκε
- * * `COMPLETED` - Ολοκληρώθηκε
- * * `CANCELED` - Ακυρώθηκε
- * * `RETURNED` - Επιστράφηκε
- * * `REFUNDED` - Επιστροφή Χρημάτων
+ * * `PENDING` - Pending
+ * * `PROCESSING` - Processing
+ * * `SHIPPED` - Shipped
+ * * `DELIVERED` - Delivered
+ * * `COMPLETED` - Completed
+ * * `CANCELED` - Canceled
+ * * `RETURNED` - Returned
+ * * `REFUNDED` - Refunded
  */
 export const zOrderStatus = z.enum([
   'PENDING',
@@ -1660,7 +1678,7 @@ export const zOrderStatus = z.enum([
   'RETURNED',
   'REFUNDED',
 ]).register(z.globalRegistry, {
-  description: '* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων',
+  description: '* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded',
 })
 
 export const zOrderWriteRequest = z.object({
@@ -2029,16 +2047,16 @@ export const zPatchedPayWayWriteRequest = z.object({
   freeThreshold: z.number().gt(-1000000000).lt(1000000000).optional(),
   icon: z.string().nullish(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
   configuration: z.unknown().register(z.globalRegistry, {
-    description: 'Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)',
+    description: 'Provider-specific configuration (API keys, webhooks, etc.)',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -2239,7 +2257,7 @@ export const zPatchedUserAddressWriteRequest = z.object({
 export const zPatchedUserSubscriptionWriteRequest = z.object({
   topic: z.int().optional(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
 })
 
@@ -2290,7 +2308,7 @@ export const zPatchedUserWriteRequest = z.object({
   ]).nullish(),
   bio: z.string().optional(),
   languageCode: z.string().min(1).max(10).register(z.globalRegistry, {
-    description: 'Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.',
+    description: 'Preferred language for emails and UI messages.',
   }).optional(),
 })
 
@@ -2327,13 +2345,13 @@ export const zPayWay = z.object({
   uuid: z.uuid().readonly(),
   iconFilename: z.string().readonly(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -2385,13 +2403,13 @@ export const zPayWayDetail = z.object({
   uuid: z.uuid().readonly(),
   iconFilename: z.string().readonly(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
   configuration: z.unknown(),
 }).register(z.globalRegistry, {
@@ -2424,37 +2442,37 @@ export const zPayWayWriteRequest = z.object({
   freeThreshold: z.number().gt(-1000000000).lt(1000000000).optional(),
   icon: z.string().nullish(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
   configuration: z.unknown().register(z.globalRegistry, {
-    description: 'Διαμόρφωση ειδική για τον πάροχο (κλειδιά API, webhooks κ.λπ.)',
+    description: 'Provider-specific configuration (API keys, webhooks, etc.)',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
 })
 
 /**
- * * `prepaid` - Προπληρωμένο
- * * `cod` - Αντικαταβολή
+ * * `prepaid` - Prepaid
+ * * `cod` - Cash on delivery
  */
 export const zPaymentModeEnum = z.enum(['prepaid', 'cod']).register(z.globalRegistry, {
-  description: '* `prepaid` - Προπληρωμένο\n* `cod` - Αντικαταβολή',
+  description: '* `prepaid` - Prepaid\n* `cod` - Cash on delivery',
 })
 
 /**
- * * `PENDING` - Εκκρεμεί
- * * `PROCESSING` - Σε επεξεργασία
- * * `COMPLETED` - Ολοκληρώθηκε
- * * `FAILED` - Απέτυχε
- * * `REFUNDED` - Επιστροφή Χρημάτων
- * * `PARTIALLY_REFUNDED` - Μερική επιστροφή
- * * `CANCELED` - Ακυρώθηκε
+ * * `PENDING` - Pending
+ * * `PROCESSING` - Processing
+ * * `COMPLETED` - Completed
+ * * `FAILED` - Failed
+ * * `REFUNDED` - Refunded
+ * * `PARTIALLY_REFUNDED` - Partially Refunded
+ * * `CANCELED` - Canceled
  */
 export const zPaymentStatusEnum = z.enum([
   'PENDING',
@@ -2465,7 +2483,7 @@ export const zPaymentStatusEnum = z.enum([
   'PARTIALLY_REFUNDED',
   'CANCELED',
 ]).register(z.globalRegistry, {
-  description: '* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε',
+  description: '* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled',
 })
 
 export const zPaymentStatusResponse = z.object({
@@ -2495,11 +2513,11 @@ export const zPerformanceMetrics = z.object({
 })
 
 /**
- * * `LOW` - Χαμηλή προτεραιότητα
- * * `NORMAL` - Κανονική προτεραιότητα
- * * `HIGH` - Υψηλή προτεραιότητα
- * * `URGENT` - Επείγουσα προτεραιότητα
- * * `CRITICAL` - Κρίσιμη προτεραιότητα
+ * * `LOW` - Low Priority
+ * * `NORMAL` - Normal Priority
+ * * `HIGH` - High Priority
+ * * `URGENT` - Urgent Priority
+ * * `CRITICAL` - Critical Priority
  */
 export const zPriorityEnum = z.enum([
   'LOW',
@@ -2508,7 +2526,7 @@ export const zPriorityEnum = z.enum([
   'URGENT',
   'CRITICAL',
 ]).register(z.globalRegistry, {
-  description: '* `LOW` - Χαμηλή προτεραιότητα\n* `NORMAL` - Κανονική προτεραιότητα\n* `HIGH` - Υψηλή προτεραιότητα\n* `URGENT` - Επείγουσα προτεραιότητα\n* `CRITICAL` - Κρίσιμη προτεραιότητα',
+  description: '* `LOW` - Low Priority\n* `NORMAL` - Normal Priority\n* `HIGH` - High Priority\n* `URGENT` - Urgent Priority\n* `CRITICAL` - Critical Priority',
 })
 
 /**
@@ -2547,11 +2565,11 @@ export const zNotification = z.object({
 })
 
 /**
- * * `restock` - Αναπλήρωση
- * * `price_drop` - Πτώση τιμής
+ * * `restock` - Restock
+ * * `price_drop` - Price drop
  */
 export const zProductAlertKindEnum = z.enum(['restock', 'price_drop']).register(z.globalRegistry, {
-  description: '* `restock` - Αναπλήρωση\n* `price_drop` - Πτώση τιμής',
+  description: '* `restock` - Restock\n* `price_drop` - Price drop',
 })
 
 export const zProductAlert = z.object({
@@ -2635,7 +2653,7 @@ export const zProduct = z.object({
   viewCount: z.int().readonly(),
   stock: z.int().gte(0).lte(2147483647).optional(),
   lowStockThreshold: z.int().register(z.globalRegistry, {
-    description: 'Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.',
+    description: 'Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.',
   }).readonly(),
   active: z.boolean().optional(),
   weight: z.object({
@@ -2679,7 +2697,7 @@ export const zCartItem = z.object({
     totalWeight: z.number(),
     weightUnit: z.string(),
   }).register(z.globalRegistry, {
-    description: 'Πληροφορίες βάρους για υπολογισμούς αποστολής',
+    description: 'Weight information for shipping calculations',
   }).readonly(),
   price: z.number().gt(-1000000000).lt(1000000000).readonly(),
   finalPrice: z.number().gt(-1000000000).lt(1000000000).readonly(),
@@ -2711,10 +2729,10 @@ export const zCart = z.object({
     description: 'Return the number of unique items in the cart.\n\nUses annotated value if available (from optimized queryset),\notherwise queries the database.',
   }).readonly(),
   totalWeightGrams: z.int().register(z.globalRegistry, {
-    description: 'Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.',
+    description: 'Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.',
   }).readonly(),
   currency: z.string().register(z.globalRegistry, {
-    description: 'Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού',
+    description: 'ISO 4217 currency code for all monetary values in this cart',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -2737,16 +2755,16 @@ export const zCartDetail = z.object({
     description: 'Return the number of unique items in the cart.\n\nUses annotated value if available (from optimized queryset),\notherwise queries the database.',
   }).readonly(),
   totalWeightGrams: z.int().register(z.globalRegistry, {
-    description: 'Συνολικό βάρος καλαθιού σε γραμμάρια. Προωθείται στο /api/v1/shipping/options κατά το checkout ώστε η ζωντανή τιμολόγηση ACS να υπολογίζει βάσει του πραγματικού εύρους βάρους που θα χρεώσει η έκδοση voucher.',
+    description: 'Total cart weight in grams. Forwarded to /api/v1/shipping/options at checkout so ACS live pricing quotes against the actual weight bracket the voucher mint will charge.',
   }).readonly(),
   currency: z.string().register(z.globalRegistry, {
-    description: 'Κωδικός νομίσματος ISO 4217 για όλες τις χρηματικές τιμές αυτού του καλαθιού',
+    description: 'ISO 4217 currency code for all monetary values in this cart',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
   lastActivity: z.iso.datetime({ offset: true }).readonly(),
   recommendations: z.array(zProduct).register(z.globalRegistry, {
-    description: 'Προτάσεις προϊόντων βάσει περιεχομένου καλαθιού',
+    description: 'Product recommendations based on cart contents',
   }).readonly(),
 })
 
@@ -2760,7 +2778,7 @@ export const zCartItemDetail = z.object({
     totalWeight: z.number(),
     weightUnit: z.string(),
   }).register(z.globalRegistry, {
-    description: 'Πληροφορίες βάρους για υπολογισμούς αποστολής',
+    description: 'Weight information for shipping calculations',
   }).readonly(),
   price: z.number().gt(-1000000000).lt(1000000000).readonly(),
   finalPrice: z.number().gt(-1000000000).lt(1000000000).readonly(),
@@ -2775,7 +2793,7 @@ export const zCartItemDetail = z.object({
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
   uuid: z.uuid().readonly(),
   recommendations: z.array(zProduct).register(z.globalRegistry, {
-    description: 'Σχετικά προϊόντα που ίσως ενδιαφέρουν τον πελάτη',
+    description: 'Related products that might interest the customer',
   }).readonly(),
 })
 
@@ -3167,7 +3185,7 @@ export const zProductDetail = z.object({
   viewCount: z.int().readonly(),
   stock: z.int().gte(0).lte(2147483647).optional(),
   lowStockThreshold: z.int().register(z.globalRegistry, {
-    description: 'Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.',
+    description: 'Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.',
   }).readonly(),
   active: z.boolean().optional(),
   weight: z.object({
@@ -3198,7 +3216,7 @@ export const zProductDetail = z.object({
   uuid: z.uuid().readonly(),
   attributes: z.array(zProductAttribute).readonly(),
   priceDropAlertsEnabled: z.boolean().register(z.globalRegistry, {
-    description: 'Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.',
+    description: 'When enabled, customers can subscribe to a one-time email when this product\'s price drops below a target. Disabled by default — admins opt products in per SKU.',
   }).readonly(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -3233,7 +3251,7 @@ export const zProductDetailResponse = z.object({
   viewCount: z.int().readonly(),
   stock: z.int().gte(0).lte(2147483647).optional(),
   lowStockThreshold: z.int().register(z.globalRegistry, {
-    description: 'Επίπεδο αποθέματος στο ή κάτω από το οποίο οι διαχειριστές λαμβάνουν ειδοποίηση χαμηλού αποθέματος. Ορίστε 0 για απενεργοποίηση των ειδοποιήσεων για αυτό το προϊόν.',
+    description: 'Stock level at or below which admins get a low-stock alert. Set to 0 to disable alerts for this product.',
   }).readonly(),
   active: z.boolean().optional(),
   weight: z.object({
@@ -3264,7 +3282,7 @@ export const zProductDetailResponse = z.object({
   uuid: z.uuid().readonly(),
   attributes: z.array(zProductAttribute).readonly(),
   priceDropAlertsEnabled: z.boolean().register(z.globalRegistry, {
-    description: 'Όταν είναι ενεργοποιημένο, οι πελάτες μπορούν να εγγραφούν για ένα εφάπαξ email όταν η τιμή αυτού του προϊόντος πέσει κάτω από έναν στόχο. Απενεργοποιημένο από προεπιλογή — οι διαχειριστές το ενεργοποιούν ανά SKU.',
+    description: 'When enabled, customers can subscribe to a one-time email when this product\'s price drops below a target. Disabled by default — admins opt products in per SKU.',
   }).readonly(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -3294,7 +3312,7 @@ export const zPaginatedProductFavouriteList = z.object({
 
 export const zProductFavouriteByProductsRequestRequest = z.object({
   productIds: z.array(z.int()).max(100).register(z.globalRegistry, {
-    description: 'Λίστα ID προϊόντων για έλεγχο αγαπημένων',
+    description: 'List of product IDs to check for favorites',
   }),
 })
 
@@ -3455,7 +3473,19 @@ export const zProductMeiliSearchResult = z.object({
   vatPercent: z.number().nullable(),
 })
 
+/**
+ * Common disclosure fields every search response carries.
+ *
+ * ``query_id`` attributes later clicks to this query (see the
+ * ``search/click`` endpoint); ``relaxed_query`` reports the trimmed
+ * query the zero-result fallback actually matched, so clients can
+ * disclose "showing results for …" instead of silently swapping.
+ */
 export const zProductMeiliSearchResponse = z.object({
+  queryId: z.uuid().register(z.globalRegistry, {
+    description: 'Identifier for this search, used to attribute clicks',
+  }),
+  relaxedQuery: z.string().nullable(),
   limit: z.int(),
   offset: z.int(),
   estimatedTotalHits: z.int(),
@@ -3464,6 +3494,8 @@ export const zProductMeiliSearchResponse = z.object({
     description: 'Facet distribution with counts per category/value',
   }).optional(),
   facetStats: zFacetStats.optional(),
+}).register(z.globalRegistry, {
+  description: 'Common disclosure fields every search response carries.\n\n``query_id`` attributes later clicks to this query (see the\n``search/click`` endpoint); ``relaxed_query`` reports the trimmed\nquery the zero-result fallback actually matched, so clients can\ndisclose "showing results for …" instead of silently swapping.',
 })
 
 /**
@@ -3554,16 +3586,16 @@ export const zProductWriteRequest = z.object({
 })
 
 /**
- * * `1` - Ένα
- * * `2` - Δύο
- * * `3` - Τρία
- * * `4` - Τέσσερα
- * * `5` - Πέντε
- * * `6` - Έξι
- * * `7` - Επτά
- * * `8` - Οκτώ
- * * `9` - Εννέα
- * * `10` - Δέκα
+ * * `1` - One
+ * * `2` - Two
+ * * `3` - Three
+ * * `4` - Four
+ * * `5` - Five
+ * * `6` - Six
+ * * `7` - Seven
+ * * `8` - Eight
+ * * `9` - Nine
+ * * `10` - Ten
  */
 export const zRateEnum = z.union([
   z.literal(1),
@@ -3577,7 +3609,7 @@ export const zRateEnum = z.union([
   z.literal(9),
   z.literal(10),
 ]).register(z.globalRegistry, {
-  description: '* `1` - Ένα\n* `2` - Δύο\n* `3` - Τρία\n* `4` - Τέσσερα\n* `5` - Πέντε\n* `6` - Έξι\n* `7` - Επτά\n* `8` - Οκτώ\n* `9` - Εννέα\n* `10` - Δέκα',
+  description: '* `1` - One\n* `2` - Two\n* `3` - Three\n* `4` - Four\n* `5` - Five\n* `6` - Six\n* `7` - Seven\n* `8` - Eight\n* `9` - Nine\n* `10` - Ten',
 })
 
 /**
@@ -3746,7 +3778,7 @@ export const zRegionWriteRequest = z.object({
  */
 export const zReleaseReservationsRequestRequest = z.object({
   reservationIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID δεσμεύσεων προς απελευθέρωση',
+    description: 'List of reservation IDs to release',
   }),
 }).register(z.globalRegistry, {
   description: 'Serializer for releasing stock reservations.',
@@ -3757,13 +3789,13 @@ export const zReleaseReservationsRequestRequest = z.object({
  */
 export const zReleaseReservationsResponse = z.object({
   message: z.string().register(z.globalRegistry, {
-    description: 'Μήνυμα επιτυχίας',
+    description: 'Success message',
   }),
   releasedCount: z.int().register(z.globalRegistry, {
-    description: 'Αριθμός αποδεσμευμένων κρατήσεων',
+    description: 'Number of reservations released',
   }),
   failedReleases: z.array(z.record(z.string(), z.unknown())).register(z.globalRegistry, {
-    description: 'Λίστα αποτυχημένων απελευθερώσεων με λεπτομέρειες σφάλματος',
+    description: 'List of failed releases with error details',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer for release reservations response.',
@@ -3787,26 +3819,56 @@ export const zReorderResponse = z.object({
  */
 export const zReserveStockResponse = z.object({
   reservationIds: z.array(z.int()).register(z.globalRegistry, {
-    description: 'Λίστα ID δημιουργημένων δεσμεύσεων αποθέματος',
+    description: 'List of created stock reservation IDs',
   }),
   message: z.string().register(z.globalRegistry, {
-    description: 'Μήνυμα επιτυχίας',
+    description: 'Success message',
   }),
 }).register(z.globalRegistry, {
   description: 'Serializer for reserve stock response.',
 })
 
 /**
- * * `NEW` - Νέο
- * * `TRUE` - Ναι
- * * `FALSE` - Όχι
+ * * `product` - product
+ * * `blog_post` - blog_post
+ */
+export const zResultTypeEnum = z.enum(['product', 'blog_post']).register(z.globalRegistry, {
+  description: '* `product` - product\n* `blog_post` - blog_post',
+})
+
+/**
+ * * `NEW` - New
+ * * `TRUE` - True
+ * * `FALSE` - False
  */
 export const zReviewStatus = z.enum([
   'NEW',
   'TRUE',
   'FALSE',
 ]).register(z.globalRegistry, {
-  description: '* `NEW` - Νέο\n* `TRUE` - Ναι\n* `FALSE` - Όχι',
+  description: '* `NEW` - New\n* `TRUE` - True\n* `FALSE` - False',
+})
+
+/**
+ * Payload for attributing a result click to a search query.
+ */
+export const zSearchClickRequestRequest = z.object({
+  queryId: z.uuid().register(z.globalRegistry, {
+    description: 'The query_id returned by the search response',
+  }),
+  resultId: z.string().min(1).max(100).register(z.globalRegistry, {
+    description: 'ID of the clicked result (Product or BlogPost ID)',
+  }),
+  resultType: zResultTypeEnum,
+  position: z.int().gte(0).register(z.globalRegistry, {
+    description: '0-indexed position of the result in the result list',
+  }),
+}).register(z.globalRegistry, {
+  description: 'Payload for attributing a result click to a search query.',
+})
+
+export const zSearchClickResponse = z.object({
+  detail: z.string(),
 })
 
 /**
@@ -3838,16 +3900,16 @@ export const zSettingDetail = z.object({
 })
 
 /**
- * * `pending_creation` - Εκκρεμής δημιουργία
- * * `new` - Νέο
- * * `in_transit` - Σε μεταφορά
- * * `at_destination` - Στο κατάστημα παράδοσης
- * * `out_for_delivery` - Σε διανομή
- * * `delivered` - Παραδόθηκε
- * * `attempted` - Απόπειρα παράδοσης
- * * `returned` - Επιστράφηκε
- * * `canceled` - Ακυρώθηκε
- * * `lost` - Χάθηκε
+ * * `pending_creation` - Pending creation
+ * * `new` - New
+ * * `in_transit` - In transit
+ * * `at_destination` - At destination station
+ * * `out_for_delivery` - Out for delivery
+ * * `delivered` - Delivered
+ * * `attempted` - Delivery attempted
+ * * `returned` - Returned
+ * * `canceled` - Canceled
+ * * `lost` - Lost
  */
 export const zShipmentStateEnum = z.enum([
   'pending_creation',
@@ -3861,15 +3923,15 @@ export const zShipmentStateEnum = z.enum([
   'canceled',
   'lost',
 ]).register(z.globalRegistry, {
-  description: '* `pending_creation` - Εκκρεμής δημιουργία\n* `new` - Νέο\n* `in_transit` - Σε μεταφορά\n* `at_destination` - Στο κατάστημα παράδοσης\n* `out_for_delivery` - Σε διανομή\n* `delivered` - Παραδόθηκε\n* `attempted` - Απόπειρα παράδοσης\n* `returned` - Επιστράφηκε\n* `canceled` - Ακυρώθηκε\n* `lost` - Χάθηκε',
+  description: '* `pending_creation` - Pending creation\n* `new` - New\n* `in_transit` - In transit\n* `at_destination` - At destination station\n* `out_for_delivery` - Out for delivery\n* `delivered` - Delivered\n* `attempted` - Delivery attempted\n* `returned` - Returned\n* `canceled` - Canceled\n* `lost` - Lost',
 })
 
 /**
- * * `home_delivery` - Κατ' οίκον παράδοση
- * * `pickup_point` - Σημείο παραλαβής / locker
+ * * `home_delivery` - Home delivery
+ * * `pickup_point` - Pickup point / locker
  */
 export const zShippingKind = z.enum(['home_delivery', 'pickup_point']).register(z.globalRegistry, {
-  description: '* `home_delivery` - Κατ\' οίκον παράδοση\n* `pickup_point` - Σημείο παραλαβής / locker',
+  description: '* `home_delivery` - Home delivery\n* `pickup_point` - Pickup point / locker',
 })
 
 /**
@@ -3880,7 +3942,7 @@ export const zFreeShippingProviderEntry = z.object({
   providerName: z.string(),
   kind: zShippingKind,
   threshold: z.number().gt(-1000000000).lt(1000000000).register(z.globalRegistry, {
-    description: 'Υποσύνολο καλαθιού στο νόμισμα της απόκρισης πάνω από το οποίο αυτός ο συνδυασμός (πάροχος, τύπος) αποστέλλει δωρεάν.',
+    description: 'Cart subtotal in the response\'s currency above which this (provider, kind) ships free.',
   }),
   priority: z.int(),
 }).register(z.globalRegistry, {
@@ -3911,59 +3973,59 @@ export const zFreeShippingInfo = z.object({
  */
 export const zOrderCreateFromCartRequest = z.object({
   payWayId: z.int().register(z.globalRegistry, {
-    description: 'ID μεθόδου πληρωμής',
+    description: 'Payment method ID',
   }),
   paymentIntentId: z.string().nullish(),
   firstName: z.string().min(1).max(150).register(z.globalRegistry, {
-    description: 'Όνομα πελάτη',
+    description: 'Customer first name',
   }),
   lastName: z.string().min(1).max(150).register(z.globalRegistry, {
-    description: 'Επώνυμο πελάτη',
+    description: 'Customer last name',
   }),
   email: z.email().min(1).register(z.globalRegistry, {
-    description: 'Email πελάτη',
+    description: 'Customer email address',
   }),
   street: z.string().min(1).max(255).register(z.globalRegistry, {
-    description: 'Όνομα οδού',
+    description: 'Street name',
   }),
   streetNumber: z.string().max(50).register(z.globalRegistry, {
-    description: 'Αριθμός οδού',
+    description: 'Street number',
   }).optional(),
   city: z.string().min(1).max(100).register(z.globalRegistry, {
-    description: 'Όνομα πόλης',
+    description: 'City name',
   }),
   zipcode: z.string().min(1).max(20).register(z.globalRegistry, {
-    description: 'Ταχυδρομικός κώδικας',
+    description: 'Postal/ZIP code',
   }),
   countryId: z.string().min(1).register(z.globalRegistry, {
-    description: 'Κωδικός χώρας alpha-2 (π.χ. \'GR\', \'US\')',
+    description: 'Country alpha-2 code (e.g., \'GR\', \'US\')',
   }),
   regionId: z.string().nullish(),
   phone: z.string().min(1).register(z.globalRegistry, {
-    description: 'Τηλέφωνο πελάτη',
+    description: 'Customer phone number',
   }),
   customerNotes: z.string().max(500).register(z.globalRegistry, {
-    description: 'Σημειώσεις πελάτη ή ειδικές οδηγίες',
+    description: 'Customer notes or special instructions',
   }).optional(),
   floor: z.string().max(50).register(z.globalRegistry, {
-    description: 'Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)',
+    description: 'Floor number or label (e.g. FIRST_FLOOR)',
   }).optional(),
   locationType: z.string().max(100).register(z.globalRegistry, {
-    description: 'Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)',
+    description: 'Location type, e.g. HOME or OFFICE (optional)',
   }).optional(),
   billingVatId: z.string().max(12).register(z.globalRegistry, {
-    description: 'ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.',
+    description: 'Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.',
   }).optional(),
   billingCountry: z.string().max(2).register(z.globalRegistry, {
-    description: 'Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.',
+    description: 'ISO 3166-1 alpha-2 country code for the buyer\'s tax identity. Defaults to the order country when blank.',
   }).optional(),
   documentType: zOrderCreateDocumentType.optional(),
   loyaltyPointsToRedeem: z.int().gte(0).nullish(),
   boxnowLockerId: z.string().max(64).register(z.globalRegistry, {
-    description: 'ID locker APM BoxNow από το widget',
+    description: 'BoxNow APM locker ID from the widget',
   }).optional(),
   boxnowCompartmentSize: z.int().gte(1).lte(3).register(z.globalRegistry, {
-    description: 'Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο',
+    description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large',
   }).optional().default(1),
   shippingProviderCode: z.union([
     z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/),
@@ -3971,14 +4033,14 @@ export const zOrderCreateFromCartRequest = z.object({
   ]).optional(),
   shippingKind: zShippingKind.optional(),
   acsStationExternalId: z.string().max(32).register(z.globalRegistry, {
-    description: 'Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).',
+    description: 'ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).',
   }).optional(),
   acsStationBranch: z.string().max(32).register(z.globalRegistry, {
-    description: 'Τιμή ACS_Station_Branch_Destination.',
+    description: 'ACS_Station_Branch_Destination value.',
   }).optional(),
   acsChargeType: zAcsChargeType.optional(),
   acsItemQuantity: z.int().gte(1).lte(20).register(z.globalRegistry, {
-    description: 'Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.',
+    description: 'Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer for creating orders from cart (dual-flow payment architecture).\n\nThis serializer supports two payment flows:\n1. Online payments (is_online_payment=True): Requires payment_intent_id\n2. Offline payments (is_online_payment=False): No payment_intent_id required\n\nThe order is created from an existing cart identified via X-Cart-Id header.\nCart is NOT sent in request body - it\'s retrieved from the header using CartService.',
@@ -4009,21 +4071,21 @@ export const zShippingOption = z.object({
 export const zShippingProvider = z.object({
   id: z.int().readonly(),
   code: z.string().regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Σταθερό αναγνωριστικό που αντιστοιχεί στον καταχωρημένο προσαρμογέα μεταφορέα (π.χ. \'acs\', \'boxnow\').',
+    description: 'Stable identifier matching the registered carrier adapter (e.g. \'acs\', \'boxnow\').',
   }).readonly(),
   name: z.string().register(z.globalRegistry, {
-    description: 'Όνομα εμφάνισης προς τους πελάτες (π.χ. \'ACS Courier\').',
+    description: 'Display name shown to customers (e.g. \'ACS Courier\').',
   }).readonly(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Κύριος διακόπτης — όταν είναι False, ο πάροχος αποκρύπτεται από το checkout ανεξάρτητα από τις σημαίες δυνατοτήτων.',
+    description: 'Master switch — when False the provider is hidden from checkout regardless of capability flags.',
   }).readonly(),
   supportsHomeDelivery: z.boolean().readonly(),
   supportsPickupPoint: z.boolean().readonly(),
   liveMode: z.boolean().register(z.globalRegistry, {
-    description: 'False = διαπιστευτήρια sandbox / δοκιμής. Χρησιμοποιείται από το UI διαχείρισης για να προειδοποιεί τους χειριστές ότι τα vouchers δεν θα αποσταλούν πραγματικά.',
+    description: 'False = sandbox / test credentials. Used by the admin UI to warn operators that vouchers won\'t actually ship.',
   }).readonly(),
   priority: z.int().register(z.globalRegistry, {
-    description: 'Σειρά ταξινόμησης στο checkout — οι μικρότεροι αριθμοί εμφανίζονται πρώτοι.',
+    description: 'Sort order in checkout — lower numbers appear first.',
   }).readonly(),
   logo: z.url().readonly().nullable(),
   logoPickupPoint: z.url().readonly().nullable(),
@@ -4037,19 +4099,19 @@ export const zShippingProvider = z.object({
     description: 'Filename of the pickup-point logo (or empty).',
   }).readonly(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Διαμόρφωση ειδική για τον πάροχο (υποστηριζόμενες χώρες, σημαίες λειτουργιών, υποδείξεις branding).',
+    description: 'Provider-specific configuration (supported countries, feature flags, branding hints).',
   }),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
 })
 
 /**
- * * `1` - Κατάστημα
- * * `2` - Συνεργαζόμενο κατάστημα (2)
- * * `3` - Συνεργαζόμενο κατάστημα (3)
+ * * `1` - Shop
+ * * `2` - Partner shop (2)
+ * * `3` - Partner shop (3)
  * * `4` - Xpress Point
  * * `5` - Kiosk
- * * `7` - Smartpoint (χωρίς locker)
+ * * `7` - Smartpoint (no locker)
  * * `8` - Smartpoint locker
  */
 export const zShopKindEnum = z.union([
@@ -4061,7 +4123,7 @@ export const zShopKindEnum = z.union([
   z.literal(7),
   z.literal(8),
 ]).register(z.globalRegistry, {
-  description: '* `1` - Κατάστημα\n* `2` - Συνεργαζόμενο κατάστημα (2)\n* `3` - Συνεργαζόμενο κατάστημα (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (χωρίς locker)\n* `8` - Smartpoint locker',
+  description: '* `1` - Shop\n* `2` - Partner shop (2)\n* `3` - Partner shop (3)\n* `4` - Xpress Point\n* `5` - Kiosk\n* `7` - Smartpoint (no locker)\n* `8` - Smartpoint locker',
 })
 
 /**
@@ -4074,10 +4136,10 @@ export const zAcsStation = z.object({
   id: z.int().readonly(),
   uuid: z.uuid().readonly(),
   externalId: z.string().register(z.globalRegistry, {
-    description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το \'ATH\')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.',
+    description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under \'ATH\'); the (external_id, branch_code) pair is the locker\'s identity.',
   }).readonly(),
   branchCode: z.string().register(z.globalRegistry, {
-    description: 'ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.',
+    description: 'ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.',
   }).readonly().default(''),
   shopKind: zShopKindEnum,
   name: z.string().readonly(),
@@ -4085,7 +4147,7 @@ export const zAcsStation = z.object({
   city: z.string().readonly(),
   postalCode: z.string().readonly(),
   countryCode: z.string().register(z.globalRegistry, {
-    description: 'ISO 3166-1 alpha-2 κωδικός χώρας.',
+    description: 'ISO 3166-1 alpha-2 country code.',
   }).readonly(),
   lat: z.string().readonly().nullable(),
   lng: z.string().readonly().nullable(),
@@ -4108,16 +4170,16 @@ export const zAcsShipmentDetail = z.object({
   voucherNo: z.string().readonly().nullable(),
   shipmentState: zShipmentStateEnum,
   shipmentStateDisplay: z.string().register(z.globalRegistry, {
-    description: 'Ετικέτα σε αναγνώσιμη μορφή για την τιμή shipment_state',
+    description: 'Human-readable label for the shipment_state choice',
   }).readonly(),
   deliveryKind: zShippingKind,
   weightGrams: z.int().register(z.globalRegistry, {
-    description: 'Εσωτερικά γραμμάρια· μετατρέπονται σε κιλά (>= 0,5) κατά την κλήση API σύμφωνα με τις απαιτήσεις βάρους της ACS.',
+    description: 'Internal grams; converted to kilograms (>= 0.5) at API call time per ACS Weight requirements.',
   }).readonly(),
   itemQuantity: z.int().readonly(),
   chargeType: zAcsChargeType,
   deliveryProducts: z.string().register(z.globalRegistry, {
-    description: 'Κωδικοί Acs_Delivery_Products διαχωρισμένοι με κόμμα (COD, REC, SAT, RDO …).',
+    description: 'Comma-separated Acs_Delivery_Products codes (COD, REC, SAT, RDO …).',
   }).readonly(),
   lastEventAt: z.iso.datetime({ offset: true }).readonly().nullable(),
   lastPolledAt: z.iso.datetime({ offset: true }).readonly().nullable(),
@@ -4125,14 +4187,14 @@ export const zAcsShipmentDetail = z.object({
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
   stationDestinationExternalId: z.string().register(z.globalRegistry, {
-    description: 'Μη κανονικοποιημένο ACS_SHOP_STATION_ID — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή AcsStation.',
+    description: 'Denormalised ACS_SHOP_STATION_ID — preserved even if the AcsStation row is deleted.',
   }).readonly(),
   stationBranchDestination: z.string().register(z.globalRegistry, {
-    description: 'Τιμή Acs_Station_Branch_Destination.',
+    description: 'Acs_Station_Branch_Destination value.',
   }).readonly(),
   station: zAcsStation.nullable(),
   events: z.array(zAcsTrackingEvent).register(z.globalRegistry, {
-    description: 'Τελευταία 50 συμβάντα παρακολούθησης ταξινομημένα κατά event_time φθίνουσα.',
+    description: 'Last 50 tracking events ordered by event_time desc.',
   }).readonly(),
   labelUrl: z.string().readonly().nullable(),
   cancelRequestedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
@@ -4150,10 +4212,10 @@ export const zAcsStationDetail = z.object({
   id: z.int().readonly(),
   uuid: z.uuid().readonly(),
   externalId: z.string().register(z.globalRegistry, {
-    description: 'ACS_SHOP_STATION_ID_EN — ο κωδικός σταθμού ΠΕΡΙΟΧΗΣ, χρησιμοποιείται ως Acs_Station_Destination. ΔΕΝ είναι μοναδικός από μόνος του: κάθε locker Smartpoint μιας περιοχής τον μοιράζεται (π.χ. 50 lockers κάτω από το \'ATH\')· το ζεύγος (external_id, branch_code) είναι η ταυτότητα του locker.',
+    description: 'ACS_SHOP_STATION_ID_EN — the AREA station code, used as Acs_Station_Destination. NOT unique on its own: every Smartpoint locker in an area shares it (e.g. 50 lockers under \'ATH\'); the (external_id, branch_code) pair is the locker\'s identity.',
   }).readonly(),
   branchCode: z.string().register(z.globalRegistry, {
-    description: 'ACS_SHOP_BRANCH_ID — συνδυάζεται με το external_id κατά τη δημιουργία vouchers (Acs_Station_Branch_Destination). Διακρίνει τα επιμέρους lockers μιας περιοχής σταθμού.',
+    description: 'ACS_SHOP_BRANCH_ID — paired with external_id when creating vouchers (Acs_Station_Branch_Destination). Distinguishes individual lockers within a station area.',
   }).readonly().default(''),
   shopKind: zShopKindEnum,
   name: z.string().readonly(),
@@ -4161,7 +4223,7 @@ export const zAcsStationDetail = z.object({
   city: z.string().readonly(),
   postalCode: z.string().readonly(),
   countryCode: z.string().register(z.globalRegistry, {
-    description: 'ISO 3166-1 alpha-2 κωδικός χώρας.',
+    description: 'ISO 3166-1 alpha-2 country code.',
   }).readonly(),
   lat: z.string().readonly().nullable(),
   lng: z.string().readonly().nullable(),
@@ -4192,10 +4254,10 @@ export const zPaginatedAcsStationList = z.object({
 })
 
 /**
- * * `ACTIVE` - Ενεργή
- * * `PENDING` - Εκκρεμεί Επιβεβαίωση
- * * `UNSUBSCRIBED` - Διαγραφή
- * * `BOUNCED` - Επιστράφηκε
+ * * `ACTIVE` - Active
+ * * `PENDING` - Pending Confirmation
+ * * `UNSUBSCRIBED` - Unsubscribed
+ * * `BOUNCED` - Bounced
  */
 export const zSubscriptionStatus = z.enum([
   'ACTIVE',
@@ -4203,7 +4265,7 @@ export const zSubscriptionStatus = z.enum([
   'UNSUBSCRIBED',
   'BOUNCED',
 ]).register(z.globalRegistry, {
-  description: '* `ACTIVE` - Ενεργή\n* `PENDING` - Εκκρεμεί Επιβεβαίωση\n* `UNSUBSCRIBED` - Διαγραφή\n* `BOUNCED` - Επιστράφηκε',
+  description: '* `ACTIVE` - Active\n* `PENDING` - Pending Confirmation\n* `UNSUBSCRIBED` - Unsubscribed\n* `BOUNCED` - Bounced',
 })
 
 /**
@@ -4225,7 +4287,7 @@ export const zTag = z.object({
   active: z.boolean().optional(),
   sortOrder: z.int().readonly().nullable(),
   usageCount: z.string().register(z.globalRegistry, {
-    description: 'Πόσες φορές χρησιμοποιείται η ετικέτα',
+    description: 'Number of times this tag is used',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -4266,13 +4328,13 @@ export const zTagDetail = z.object({
   active: z.boolean().optional(),
   sortOrder: z.int().readonly().nullable(),
   usageCount: z.string().register(z.globalRegistry, {
-    description: 'Πόσες φορές χρησιμοποιείται η ετικέτα',
+    description: 'Number of times this tag is used',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
   uuid: z.uuid().readonly(),
   contentTypes: z.string().register(z.globalRegistry, {
-    description: 'Τύποι περιεχομένου με τους οποίους χρησιμοποιείται αυτή η ετικέτα',
+    description: 'Content types this tag is used with',
   }).readonly(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -4303,7 +4365,7 @@ export const zTaggedItem = z.object({
   tag: zTag,
   contentType: z.int(),
   contentTypeName: z.string().register(z.globalRegistry, {
-    description: 'Όνομα τύπου περιεχομένου',
+    description: 'Name of the content type',
   }).readonly(),
   objectId: z.int().gte(0).lte(2147483647),
   contentObject: z.object({
@@ -4313,7 +4375,7 @@ export const zTaggedItem = z.object({
     price: z.string().optional(),
     active: z.boolean().optional(),
   }).register(z.globalRegistry, {
-    description: 'Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου',
+    description: 'Serialized representation of the related content object',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -4338,7 +4400,7 @@ export const zTaggedItemDetail = z.object({
   tag: zTagDetail,
   contentType: z.int(),
   contentTypeName: z.string().register(z.globalRegistry, {
-    description: 'Όνομα τύπου περιεχομένου',
+    description: 'Name of the content type',
   }).readonly(),
   objectId: z.int().gte(0).lte(2147483647),
   contentObject: z.object({
@@ -4348,7 +4410,7 @@ export const zTaggedItemDetail = z.object({
     price: z.string().optional(),
     active: z.boolean().optional(),
   }).register(z.globalRegistry, {
-    description: 'Σειριοποιημένη αναπαράσταση του σχετικού αντικειμένου περιεχομένου',
+    description: 'Serialized representation of the related content object',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -4431,13 +4493,13 @@ export const zTopQuery = z.object({
 })
 
 /**
- * * `MARKETING` - Καμπάνιες marketing
- * * `PRODUCT` - Ενημερώσεις προϊόντων
- * * `ACCOUNT` - Λογαριασμός Ανενεργός
- * * `SYSTEM` - Ειδοποιήσεις Συστήματος
+ * * `MARKETING` - Marketing Campaigns
+ * * `PRODUCT` - Product Updates
+ * * `ACCOUNT` - Account Updates
+ * * `SYSTEM` - System Notifications
  * * `NEWSLETTER` - Newsletter
- * * `PROMOTIONAL` - Προωθητικό
- * * `OTHER` - Άλλο
+ * * `PROMOTIONAL` - Promotional
+ * * `OTHER` - Other
  */
 export const zTopicCategory = z.enum([
   'MARKETING',
@@ -4448,7 +4510,7 @@ export const zTopicCategory = z.enum([
   'PROMOTIONAL',
   'OTHER',
 ]).register(z.globalRegistry, {
-  description: '* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο',
+  description: '* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other',
 })
 
 /**
@@ -4470,17 +4532,17 @@ export const zPatchedSubscriptionTopicWriteRequest = z.object({
     }).optional(),
   }).optional(),
   slug: z.string().min(1).max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }).optional(),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -4507,17 +4569,17 @@ export const zSubscriptionTopic = z.object({
   id: z.int().readonly(),
   uuid: z.uuid().readonly(),
   slug: z.string().max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
   subscriberCount: z.int().readonly(),
 }).register(z.globalRegistry, {
@@ -4558,17 +4620,17 @@ export const zSubscriptionTopicDetail = z.object({
   id: z.int().readonly(),
   uuid: z.uuid().readonly(),
   slug: z.string().max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
   subscriberCount: z.int().readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
@@ -4596,27 +4658,27 @@ export const zSubscriptionTopicWriteRequest = z.object({
     }).optional(),
   }),
   slug: z.string().min(1).max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
 })
 
 /**
- * * `EARN` - Κερδίστε
- * * `REDEEM` - Εξαργύρωση
- * * `EXPIRE` - Λήξη
- * * `ADJUST` - Προσαρμογή
+ * * `EARN` - Earn
+ * * `REDEEM` - Redeem
+ * * `EXPIRE` - Expire
+ * * `ADJUST` - Adjust
  * * `BONUS` - Bonus
  */
 export const zTransactionTypeEnum = z.enum([
@@ -4626,7 +4688,7 @@ export const zTransactionTypeEnum = z.enum([
   'ADJUST',
   'BONUS',
 ]).register(z.globalRegistry, {
-  description: '* `EARN` - Κερδίστε\n* `REDEEM` - Εξαργύρωση\n* `EXPIRE` - Λήξη\n* `ADJUST` - Προσαρμογή\n* `BONUS` - Bonus',
+  description: '* `EARN` - Earn\n* `REDEEM` - Redeem\n* `EXPIRE` - Expire\n* `ADJUST` - Adjust\n* `BONUS` - Bonus',
 })
 
 /**
@@ -4635,7 +4697,7 @@ export const zTransactionTypeEnum = z.enum([
 export const zPointsTransaction = z.object({
   id: z.int().readonly(),
   points: z.int().register(z.globalRegistry, {
-    description: 'Θετικό για κέρδος/μπόνους, αρνητικό για εξαργύρωση/λήξη/προσαρμογή',
+    description: 'Positive for earn/bonus, negative for redeem/expire/adjust',
   }).readonly(),
   transactionType: zTransactionTypeEnum,
   referenceOrder: z.int().readonly().nullable(),
@@ -4694,9 +4756,9 @@ export const zTrendingSearchResponse = z.object({
 
 /**
  * * `apm` - APM
- * * `any_apm` - Οποιοδήποτε APM
- * * `warehouse` - Αποθήκη
- * * `depot` - Αποθήκη
+ * * `any_apm` - Any APM
+ * * `warehouse` - Warehouse
+ * * `depot` - Depot
  */
 export const zTypeEnum = z.enum([
   'apm',
@@ -4704,7 +4766,7 @@ export const zTypeEnum = z.enum([
   'warehouse',
   'depot',
 ]).register(z.globalRegistry, {
-  description: '* `apm` - APM\n* `any_apm` - Οποιοδήποτε APM\n* `warehouse` - Αποθήκη\n* `depot` - Αποθήκη',
+  description: '* `apm` - APM\n* `any_apm` - Any APM\n* `warehouse` - Warehouse\n* `depot` - Depot',
 })
 
 /**
@@ -4728,7 +4790,7 @@ export const zBoxNowLocker = z.object({
   addressLine2: z.string().readonly(),
   postalCode: z.string().readonly(),
   countryCode: z.string().register(z.globalRegistry, {
-    description: 'ISO 3166-1 alpha-2 κωδικός χώρας',
+    description: 'ISO 3166-1 alpha-2 country code',
   }).readonly(),
   note: z.string().readonly(),
   isActive: z.boolean().readonly(),
@@ -4761,7 +4823,7 @@ export const zBoxNowLockerDetail = z.object({
   addressLine2: z.string().readonly(),
   postalCode: z.string().readonly(),
   countryCode: z.string().register(z.globalRegistry, {
-    description: 'ISO 3166-1 alpha-2 κωδικός χώρας',
+    description: 'ISO 3166-1 alpha-2 country code',
   }).readonly(),
   note: z.string().readonly(),
   isActive: z.boolean().readonly(),
@@ -4793,11 +4855,11 @@ export const zBoxNowShipmentDetail = z.object({
   deliveryRequestId: z.string().readonly().nullable(),
   parcelId: z.string().readonly().nullable(),
   lockerExternalId: z.string().register(z.globalRegistry, {
-    description: 'Μη κανονικοποιημένο ID APM BoxNow — διατηρείται ακόμη κι αν διαγραφεί η εγγραφή BoxNowLocker',
+    description: 'Denormalised BoxNow APM ID — preserved even if the BoxNowLocker row is deleted',
   }).readonly(),
   parcelState: zBoxNowParcelState,
   parcelStateDisplay: z.string().register(z.globalRegistry, {
-    description: 'Ετικέτα σε αναγνώσιμη μορφή για την τιμή parcel_state',
+    description: 'Human-readable label for the parcel_state choice',
   }).readonly(),
   compartmentSize: zCompartmentSizeEnum,
   paymentMode: zPaymentModeEnum,
@@ -4806,12 +4868,12 @@ export const zBoxNowShipmentDetail = z.object({
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
   locker: zBoxNowLocker.nullable(),
   events: z.array(zBoxNowParcelEvent).register(z.globalRegistry, {
-    description: 'Τελευταία 20 συμβάντα δέματος ταξινομημένα κατά event_time φθίνουσα',
+    description: 'Last 20 parcel events ordered by event_time desc',
   }).readonly(),
   labelUrl: z.string().readonly().nullable(),
   weightGrams: z.int().readonly(),
   amountToBeCollected: z.number().gt(-1000000000).lt(1000000000).register(z.globalRegistry, {
-    description: 'Ποσό που εισπράττεται κατά την παράδοση (PoG / COD). Πάντα 0 στη Φάση 1.',
+    description: 'Amount collected at delivery (PoG / COD). Always 0 in Phase 1.',
   }).readonly(),
   allowReturn: z.boolean().readonly(),
   cancelRequestedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
@@ -5101,7 +5163,7 @@ export const zUserDetails = z.object({
   github: z.string().max(200).readonly().nullable(),
   bio: z.string().optional(),
   languageCode: z.string().max(10).register(z.globalRegistry, {
-    description: 'Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.',
+    description: 'Preferred language for emails and UI messages.',
   }).optional(),
   isActive: z.boolean().readonly(),
   isStaff: z.boolean().readonly(),
@@ -5165,20 +5227,20 @@ export const zBlogComment = z.object({
   user: zUserDetails,
   contentPreview: z.string().readonly().nullable(),
   isReply: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο',
+    description: 'Whether this comment is a reply to another comment',
   }).readonly(),
   parent: z.int().readonly().nullable(),
   hasReplies: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις',
+    description: 'Whether this comment has approved replies',
   }).readonly(),
   approved: z.boolean().readonly(),
   isEdited: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο έχει επεξεργαστεί',
+    description: 'Whether this comment has been edited',
   }).readonly(),
   likesCount: z.int().readonly(),
   repliesCount: z.int().readonly(),
   userHasLiked: z.boolean().register(z.globalRegistry, {
-    description: 'Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο',
+    description: 'Whether the current user has liked this comment',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -5206,20 +5268,20 @@ export const zBlogCommentDetail = z.object({
   user: zUserDetails,
   contentPreview: z.string().readonly().nullable(),
   isReply: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο είναι απάντηση σε άλλο σχόλιο',
+    description: 'Whether this comment is a reply to another comment',
   }).readonly(),
   parent: z.int().readonly().nullable(),
   hasReplies: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο έχει εγκεκριμένες απαντήσεις',
+    description: 'Whether this comment has approved replies',
   }).readonly(),
   approved: z.boolean().readonly(),
   isEdited: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το σχόλιο έχει επεξεργαστεί',
+    description: 'Whether this comment has been edited',
   }).readonly(),
   likesCount: z.int().readonly(),
   repliesCount: z.int().readonly(),
   userHasLiked: z.boolean().register(z.globalRegistry, {
-    description: 'Αν ο τρέχων χρήστης έχει επισημάνει αυτό το σχόλιο',
+    description: 'Whether the current user has liked this comment',
   }).readonly(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -5232,14 +5294,14 @@ export const zBlogCommentDetail = z.object({
     createdAt: z.iso.datetime({ offset: true }),
   }).readonly().nullable(),
   childrenComments: z.array(zBlogComment).register(z.globalRegistry, {
-    description: 'Άμεσα εγκεκριμένα θυγατρικά σχόλια (απαντήσεις)',
+    description: 'Direct approved child comments (replies)',
   }).readonly(),
   ancestorsPath: z.array(z.object({
     id: z.int(),
     contentPreview: z.string(),
     user: zUserDetails,
   })).register(z.globalRegistry, {
-    description: 'Διαδρομή από το ριζικό σχόλιο έως αυτό',
+    description: 'Path from root comment to this comment',
   }).readonly(),
   treePosition: z.object({
     level: z.int(),
@@ -5247,7 +5309,7 @@ export const zBlogCommentDetail = z.object({
     approvedDescendantsCount: z.int(),
     siblingsCount: z.int(),
   }).register(z.globalRegistry, {
-    description: 'Πληροφορίες θέσης στο δέντρο σχολίων',
+    description: 'Position information in the comment tree',
   }).readonly(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -5437,7 +5499,7 @@ export const zUserSubscription = z.object({
   subscribedAt: z.iso.datetime({ offset: true }).readonly(),
   unsubscribedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -5465,7 +5527,7 @@ export const zUserSubscriptionDetail = z.object({
   subscribedAt: z.iso.datetime({ offset: true }).readonly(),
   unsubscribedAt: z.iso.datetime({ offset: true }).readonly().nullable(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
   createdAt: z.iso.datetime({ offset: true }).readonly(),
   updatedAt: z.iso.datetime({ offset: true }).readonly(),
@@ -5474,7 +5536,7 @@ export const zUserSubscriptionDetail = z.object({
 export const zUserSubscriptionWriteRequest = z.object({
   topic: z.int(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
 })
 
@@ -5525,19 +5587,19 @@ export const zUserWriteRequest = z.object({
   ]).nullish(),
   bio: z.string().optional(),
   languageCode: z.string().min(1).max(10).register(z.globalRegistry, {
-    description: 'Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.',
+    description: 'Preferred language for emails and UI messages.',
   }).optional(),
 })
 
 export const zUsernameUpdateRequest = z.object({
   username: z.string().min(1).max(150).register(z.globalRegistry, {
-    description: 'Νέο όνομα χρήστη',
+    description: 'New username',
   }),
 })
 
 export const zUsernameUpdateResponse = z.object({
   detail: z.string().register(z.globalRegistry, {
-    description: 'Μήνυμα επιτυχίας για ενημέρωση ονόματος χρήστη',
+    description: 'Success message for username update',
   }),
 })
 
@@ -6048,59 +6110,59 @@ export const zNotificationUserDetailWritable = z.object({
  */
 export const zOrderCreateFromCartRequestWritable = z.object({
   payWayId: z.int().register(z.globalRegistry, {
-    description: 'ID μεθόδου πληρωμής',
+    description: 'Payment method ID',
   }),
   paymentIntentId: z.string().nullish(),
   firstName: z.string().min(1).max(150).register(z.globalRegistry, {
-    description: 'Όνομα πελάτη',
+    description: 'Customer first name',
   }),
   lastName: z.string().min(1).max(150).register(z.globalRegistry, {
-    description: 'Επώνυμο πελάτη',
+    description: 'Customer last name',
   }),
   email: z.email().min(1).register(z.globalRegistry, {
-    description: 'Email πελάτη',
+    description: 'Customer email address',
   }),
   street: z.string().min(1).max(255).register(z.globalRegistry, {
-    description: 'Όνομα οδού',
+    description: 'Street name',
   }),
   streetNumber: z.string().max(50).register(z.globalRegistry, {
-    description: 'Αριθμός οδού',
+    description: 'Street number',
   }).optional(),
   city: z.string().min(1).max(100).register(z.globalRegistry, {
-    description: 'Όνομα πόλης',
+    description: 'City name',
   }),
   zipcode: z.string().min(1).max(20).register(z.globalRegistry, {
-    description: 'Ταχυδρομικός κώδικας',
+    description: 'Postal/ZIP code',
   }),
   countryId: z.string().min(1).register(z.globalRegistry, {
-    description: 'Κωδικός χώρας alpha-2 (π.χ. \'GR\', \'US\')',
+    description: 'Country alpha-2 code (e.g., \'GR\', \'US\')',
   }),
   regionId: z.string().nullish(),
   phone: z.string().min(1).register(z.globalRegistry, {
-    description: 'Τηλέφωνο πελάτη',
+    description: 'Customer phone number',
   }),
   customerNotes: z.string().max(500).register(z.globalRegistry, {
-    description: 'Σημειώσεις πελάτη ή ειδικές οδηγίες',
+    description: 'Customer notes or special instructions',
   }).optional(),
   floor: z.string().max(50).register(z.globalRegistry, {
-    description: 'Αριθμός ή ένδειξη ορόφου (π.χ. FIRST_FLOOR)',
+    description: 'Floor number or label (e.g. FIRST_FLOOR)',
   }).optional(),
   locationType: z.string().max(100).register(z.globalRegistry, {
-    description: 'Τύπος τοποθεσίας, π.χ. HOME ή OFFICE (προαιρετικό)',
+    description: 'Location type, e.g. HOME or OFFICE (optional)',
   }).optional(),
   billingVatId: z.string().max(12).register(z.globalRegistry, {
-    description: 'ΑΦΜ αγοραστή. Υποχρεωτικό όταν το ``document_type`` είναι INVOICE· 9 ψηφία για ελληνικό ΑΦΜ, το αρχικό πρόθεμα EL/GR αφαιρείται αυτόματα.',
+    description: 'Buyer tax number (ΑΦΜ). Required when ``document_type`` is INVOICE; 9 digits for Greek ΑΦΜ, leading EL/GR prefix is stripped automatically.',
   }).optional(),
   billingCountry: z.string().max(2).register(z.globalRegistry, {
-    description: 'Κωδικός χώρας ISO 3166-1 alpha-2 για τη φορολογική ταυτότητα του αγοραστή. Προεπιλογή η χώρα της παραγγελίας όταν είναι κενό.',
+    description: 'ISO 3166-1 alpha-2 country code for the buyer\'s tax identity. Defaults to the order country when blank.',
   }).optional(),
   documentType: zOrderCreateDocumentType.optional(),
   loyaltyPointsToRedeem: z.int().gte(0).nullish(),
   boxnowLockerId: z.string().max(64).register(z.globalRegistry, {
-    description: 'ID locker APM BoxNow από το widget',
+    description: 'BoxNow APM locker ID from the widget',
   }).optional(),
   boxnowCompartmentSize: z.int().gte(1).lte(3).register(z.globalRegistry, {
-    description: 'Μέγεθος θυρίδας BoxNow: 1=Μικρό, 2=Μεσαίο, 3=Μεγάλο',
+    description: 'BoxNow compartment size: 1=Small, 2=Medium, 3=Large',
   }).optional().default(1),
   shippingProviderCode: z.union([
     z.string().max(32).regex(/^[-a-zA-Z0-9_]+$/),
@@ -6108,14 +6170,14 @@ export const zOrderCreateFromCartRequestWritable = z.object({
   ]).optional(),
   shippingKind: zShippingKind.optional(),
   acsStationExternalId: z.string().max(32).register(z.globalRegistry, {
-    description: 'Εξωτερικό ID καταστήματος/Smartpoint ACS (ροή σημείου παραλαβής Φάσης 2).',
+    description: 'ACS Smartpoint / shop external ID (Phase 2 pickup-point flow).',
   }).optional(),
   acsStationBranch: z.string().max(32).register(z.globalRegistry, {
-    description: 'Τιμή ACS_Station_Branch_Destination.',
+    description: 'ACS_Station_Branch_Destination value.',
   }).optional(),
   acsChargeType: zAcsChargeType.optional(),
   acsItemQuantity: z.int().gte(1).lte(20).register(z.globalRegistry, {
-    description: 'Προαιρετική παράκαμψη ανά παραγγελία για το ACS Item_Quantity (αριθμός φυσικών δεμάτων στην αποστολή). Προεπιλογή 1. ΔΕΝ πρέπει να οριστεί για παραλαβή Smartpoint — η ACS απορρίπτει vouchers πολλαπλών δεμάτων σε lockers.',
+    description: 'Optional per-order override for ACS Item_Quantity (number of physical parcels in the shipment). Defaults to 1. Must NOT be set for Smartpoint pickup — ACS rejects multipart vouchers on lockers.',
   }).optional(),
   meta: z.record(z.string(), z.unknown()).nullish(),
 }).register(z.globalRegistry, {
@@ -6458,7 +6520,7 @@ export const zPaginatedUserDataExportListWritable = z.object({
 
 export const zPatchedTaggedItemWriteRequestWritable = z.object({
   tagId: z.int().register(z.globalRegistry, {
-    description: 'ID ετικέτας προς ανάθεση',
+    description: 'ID of the tag to assign',
   }).optional(),
   contentType: z.int().optional(),
   objectId: z.int().gte(0).lte(2147483647).optional(),
@@ -6490,13 +6552,13 @@ export const zPayWayWritable = z.object({
   freeThreshold: z.number().gt(-1000000000).lt(1000000000),
   icon: z.url().nullish(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -6541,13 +6603,13 @@ export const zPayWayDetailWritable = z.object({
   freeThreshold: z.number().gt(-1000000000).lt(1000000000),
   icon: z.url().nullish(),
   providerCode: z.string().max(50).register(z.globalRegistry, {
-    description: 'Κωδικός που χρησιμοποιείται για την αναγνώριση του παρόχου πληρωμών στο σύστημα (π.χ. \'stripe\', \'paypal\')',
+    description: 'Code used to identify the payment provider in the system (e.g., \'stripe\', \'paypal\')',
   }).optional(),
   isOnlinePayment: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής διεκπεραιώνεται online',
+    description: 'Whether this payment method is processed online',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτή η μέθοδος πληρωμής απαιτεί χειροκίνητη επιβεβαίωση (π.χ. τραπεζική κατάθεση)',
+    description: 'Whether this payment method requires manual confirmation (e.g., bank transfer)',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -7085,17 +7147,17 @@ export const zSubscriptionTopicWritable = z.object({
     }).optional(),
   }),
   slug: z.string().max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -7133,17 +7195,17 @@ export const zSubscriptionTopicDetailWritable = z.object({
     }).optional(),
   }),
   slug: z.string().max(50).regex(/^[-a-zA-Z0-9_]+$/).register(z.globalRegistry, {
-    description: 'Μοναδικό αναγνωριστικό για το θέμα (π.χ. \'weekly-newsletter\')',
+    description: 'Unique identifier for the topic (e.g., \'weekly-newsletter\')',
   }),
   category: zTopicCategory.optional(),
   isActive: z.boolean().register(z.globalRegistry, {
-    description: 'Αν αυτό το θέμα είναι επί του παρόντος διαθέσιμο για εγγραφή',
+    description: 'Whether this topic is currently available for subscription',
   }).optional(),
   isDefault: z.boolean().register(z.globalRegistry, {
-    description: 'Αν οι νέοι χρήστες εγγράφονται αυτόματα σε αυτό το θέμα',
+    description: 'Whether new users are automatically subscribed to this topic',
   }).optional(),
   requiresConfirmation: z.boolean().register(z.globalRegistry, {
-    description: 'Αν η εγγραφή σε αυτό το θέμα απαιτεί επιβεβαίωση email',
+    description: 'Whether subscription to this topic requires email confirmation',
   }).optional(),
 }).register(z.globalRegistry, {
   description: 'Serializer that saves :class:`TranslatedFieldsField` automatically.',
@@ -7227,7 +7289,7 @@ export const zTaggedItemDetailWritable = z.object({
 
 export const zTaggedItemWriteRequestWritable = z.object({
   tagId: z.int().register(z.globalRegistry, {
-    description: 'ID ετικέτας προς ανάθεση',
+    description: 'ID of the tag to assign',
   }),
   contentType: z.int(),
   objectId: z.int().gte(0).lte(2147483647),
@@ -7310,7 +7372,7 @@ export const zUserDetailsWritable = z.object({
   birthDate: z.iso.date().nullish(),
   bio: z.string().optional(),
   languageCode: z.string().max(10).register(z.globalRegistry, {
-    description: 'Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.',
+    description: 'Preferred language for emails and UI messages.',
   }).optional(),
 })
 
@@ -7331,7 +7393,7 @@ export const zUserSubscriptionWritable = z.object({
   topic: z.int(),
   status: zSubscriptionStatus.optional(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
 })
 
@@ -7352,7 +7414,7 @@ export const zUserSubscriptionDetailWritable = z.object({
   topic: z.int(),
   status: zSubscriptionStatus.optional(),
   metadata: z.unknown().register(z.globalRegistry, {
-    description: 'Επιπλέον προτιμήσεις ή δεδομένα εγγραφής',
+    description: 'Additional subscription preferences or data',
   }).optional(),
 })
 
@@ -7366,14 +7428,14 @@ export const zListAgentOrdersResponse = z.array(zOrder)
 
 export const zListBlogAuthorQuery = z.object({
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|user_FirstName|\-user_FirstName|user_LastName|\-user_LastName|user_Email|\-user_Email|user_CreatedAt|\-user_CreatedAt|website|\-website)(?:,(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|user_FirstName|\-user_FirstName|user_LastName|\-user_LastName|user_Email|\-user_Email|user_CreatedAt|\-user_CreatedAt|website|\-website))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, user_FirstName, -user_FirstName, user_LastName, -user_LastName, user_Email, -user_Email, user_CreatedAt, -user_CreatedAt, website, -website',
@@ -7387,14 +7449,14 @@ export const zListBlogAuthorQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -7411,7 +7473,7 @@ export const zCreateBlogAuthorQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7444,7 +7506,7 @@ export const zRetrieveBlogAuthorQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7465,7 +7527,7 @@ export const zPartialUpdateBlogAuthorQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7486,7 +7548,7 @@ export const zUpdateBlogAuthorQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7524,7 +7586,7 @@ export const zListBlogCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|level|\-level|lft|\-lft|rght|\-rght|treeId|\-treeId|name|\-name)(?:,(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|level|\-level|lft|\-lft|rght|\-rght|treeId|\-treeId|name|\-name))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, sortOrder, -sortOrder, level, -level, lft, -lft, rght, -rght, treeId, -treeId, name, -name',
@@ -7538,14 +7600,14 @@ export const zListBlogCategoryQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -7562,7 +7624,7 @@ export const zCreateBlogCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7595,7 +7657,7 @@ export const zRetrieveBlogCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7616,7 +7678,7 @@ export const zPartialUpdateBlogCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7637,7 +7699,7 @@ export const zUpdateBlogCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -7816,7 +7878,7 @@ export const zListBlogCommentQuery = z.object({
     z.boolean(),
   ]).optional(),
   content: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by comment content (case-insensitive)',
   }).optional(),
   contentLength: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -7832,7 +7894,7 @@ export const zListBlogCommentQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   descendantOf: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -7865,7 +7927,7 @@ export const zListBlogCommentQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -7888,7 +7950,7 @@ export const zListBlogCommentQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   level: z.union([
     z.string().regex(/^-?\d+$/),
@@ -7968,14 +8030,14 @@ export const zListBlogCommentQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   parent: z.union([
     z.string().regex(/^-?\d+$/),
@@ -8001,7 +8063,7 @@ export const zListBlogCommentQuery = z.object({
     z.int(),
   ]).optional(),
   post_Category_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug κατηγορίας άρθρου',
+    description: 'Filter by blog post category slug',
   }).optional(),
   post_IsPublished: z.union([
     z.literal('true'),
@@ -8011,10 +8073,10 @@ export const zListBlogCommentQuery = z.object({
     z.boolean(),
   ]).optional(),
   post_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug άρθρου',
+    description: 'Filter by blog post slug',
   }).optional(),
   post_Title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο άρθρου',
+    description: 'Filter by blog post title',
   }).optional(),
   rght: z.union([
     z.string().regex(/^-?\d+$/),
@@ -8049,7 +8111,7 @@ export const zListBlogCommentQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη',
+    description: 'Filter by user email',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -8078,7 +8140,7 @@ export const zCreateBlogCommentQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -8111,7 +8173,7 @@ export const zRetrieveBlogCommentQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -8132,7 +8194,7 @@ export const zPartialUpdateBlogCommentQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -8153,7 +8215,7 @@ export const zUpdateBlogCommentQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -8188,7 +8250,7 @@ export const zListBlogCommentRepliesQuery = z.object({
     z.boolean(),
   ]).optional(),
   content: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by comment content (case-insensitive)',
   }).optional(),
   contentLength: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -8234,7 +8296,7 @@ export const zListBlogCommentRepliesQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -8353,7 +8415,7 @@ export const zListBlogCommentRepliesQuery = z.object({
     z.int(),
   ]).optional(),
   post_Category_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug κατηγορίας άρθρου',
+    description: 'Filter by blog post category slug',
   }).optional(),
   post_IsPublished: z.union([
     z.literal('true'),
@@ -8363,10 +8425,10 @@ export const zListBlogCommentRepliesQuery = z.object({
     z.boolean(),
   ]).optional(),
   post_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug άρθρου',
+    description: 'Filter by blog post slug',
   }).optional(),
   post_Title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο άρθρου',
+    description: 'Filter by blog post title',
   }).optional(),
   rght: z.union([
     z.string().regex(/^-?\d+$/),
@@ -8401,7 +8463,7 @@ export const zListBlogCommentRepliesQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη',
+    description: 'Filter by user email',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -8442,7 +8504,7 @@ export const zGetBlogCommentThreadQuery = z.object({
     z.boolean(),
   ]).optional(),
   content: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by comment content (case-insensitive)',
   }).optional(),
   contentLength: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -8488,7 +8550,7 @@ export const zGetBlogCommentThreadQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -8607,7 +8669,7 @@ export const zGetBlogCommentThreadQuery = z.object({
     z.int(),
   ]).optional(),
   post_Category_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug κατηγορίας άρθρου',
+    description: 'Filter by blog post category slug',
   }).optional(),
   post_IsPublished: z.union([
     z.literal('true'),
@@ -8617,10 +8679,10 @@ export const zGetBlogCommentThreadQuery = z.object({
     z.boolean(),
   ]).optional(),
   post_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug άρθρου',
+    description: 'Filter by blog post slug',
   }).optional(),
   post_Title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο άρθρου',
+    description: 'Filter by blog post title',
   }).optional(),
   rght: z.union([
     z.string().regex(/^-?\d+$/),
@@ -8655,7 +8717,7 @@ export const zGetBlogCommentThreadQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη',
+    description: 'Filter by user email',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -8702,7 +8764,7 @@ export const zListMyBlogCommentsQuery = z.object({
     z.boolean(),
   ]).optional(),
   content: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σχολίου (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by comment content (case-insensitive)',
   }).optional(),
   contentLength: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -8748,7 +8810,7 @@ export const zListMyBlogCommentsQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -8867,7 +8929,7 @@ export const zListMyBlogCommentsQuery = z.object({
     z.int(),
   ]).optional(),
   post_Category_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug κατηγορίας άρθρου',
+    description: 'Filter by blog post category slug',
   }).optional(),
   post_IsPublished: z.union([
     z.literal('true'),
@@ -8877,10 +8939,10 @@ export const zListMyBlogCommentsQuery = z.object({
     z.boolean(),
   ]).optional(),
   post_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug άρθρου',
+    description: 'Filter by blog post slug',
   }).optional(),
   post_Title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο άρθρου',
+    description: 'Filter by blog post title',
   }).optional(),
   rght: z.union([
     z.string().regex(/^-?\d+$/),
@@ -8915,7 +8977,7 @@ export const zListMyBlogCommentsQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη',
+    description: 'Filter by user email',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -8942,26 +9004,26 @@ export const zListBlogPostQuery = z.object({
     z.int(),
   ]).optional(),
   authorEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author email (case-insensitive)',
   }).optional(),
   authorName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author full name (case-insensitive)',
   }).optional(),
   category: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   categoryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by category name (case-insensitive)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -8971,7 +9033,7 @@ export const zListBlogPostQuery = z.object({
     z.boolean(),
   ]).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   featured: z.union([
     z.literal('true'),
@@ -8986,7 +9048,7 @@ export const zListBlogPostQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9002,7 +9064,7 @@ export const zListBlogPostQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   minComments: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -9032,23 +9094,23 @@ export const zListBlogPostQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -9056,25 +9118,25 @@ export const zListBlogPostQuery = z.object({
   slug: z.string().optional(),
   slug_Icontains: z.string().optional(),
   tagName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by tag label (case-insensitive)',
   }).optional(),
   tags: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by title (case-insensitive)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   uuid: z.uuid().optional(),
   viewCount: z.union([
@@ -9101,7 +9163,7 @@ export const zCreateBlogPostQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -9134,7 +9196,7 @@ export const zRetrieveBlogPostQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -9155,7 +9217,7 @@ export const zPartialUpdateBlogPostQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -9176,7 +9238,7 @@ export const zUpdateBlogPostQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -9231,26 +9293,26 @@ export const zListBlogPostRelatedQuery = z.object({
     z.int(),
   ]).optional(),
   authorEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author email (case-insensitive)',
   }).optional(),
   authorName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author full name (case-insensitive)',
   }).optional(),
   category: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   categoryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by category name (case-insensitive)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -9272,7 +9334,7 @@ export const zListBlogPostRelatedQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9303,13 +9365,13 @@ export const zListBlogPostRelatedQuery = z.object({
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, publishedAt, -publishedAt, viewCount, -viewCount, featured, -featured',
   }).optional(),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -9317,25 +9379,25 @@ export const zListBlogPostRelatedQuery = z.object({
   slug: z.string().optional(),
   slug_Icontains: z.string().optional(),
   tagName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by tag label (case-insensitive)',
   }).optional(),
   tags: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by title (case-insensitive)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   uuid: z.uuid().optional(),
   viewCount: z.union([
@@ -9378,26 +9440,26 @@ export const zListFeaturedBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   authorEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author email (case-insensitive)',
   }).optional(),
   authorName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author full name (case-insensitive)',
   }).optional(),
   category: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   categoryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by category name (case-insensitive)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -9419,7 +9481,7 @@ export const zListFeaturedBlogPostsQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9458,13 +9520,13 @@ export const zListFeaturedBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -9472,25 +9534,25 @@ export const zListFeaturedBlogPostsQuery = z.object({
   slug: z.string().optional(),
   slug_Icontains: z.string().optional(),
   tagName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by tag label (case-insensitive)',
   }).optional(),
   tags: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by title (case-insensitive)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   uuid: z.uuid().optional(),
   viewCount: z.union([
@@ -9519,26 +9581,26 @@ export const zListPopularBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   authorEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author email (case-insensitive)',
   }).optional(),
   authorName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author full name (case-insensitive)',
   }).optional(),
   category: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   categoryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by category name (case-insensitive)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -9560,7 +9622,7 @@ export const zListPopularBlogPostsQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9599,13 +9661,13 @@ export const zListPopularBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -9613,25 +9675,25 @@ export const zListPopularBlogPostsQuery = z.object({
   slug: z.string().optional(),
   slug_Icontains: z.string().optional(),
   tagName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by tag label (case-insensitive)',
   }).optional(),
   tags: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by title (case-insensitive)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   uuid: z.uuid().optional(),
   viewCount: z.union([
@@ -9656,26 +9718,26 @@ export const zListTrendingBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   authorEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author email (case-insensitive)',
   }).optional(),
   authorName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα συντάκτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by author full name (case-insensitive)',
   }).optional(),
   category: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   categoryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by category name (case-insensitive)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -9701,7 +9763,7 @@ export const zListTrendingBlogPostsQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9740,13 +9802,13 @@ export const zListTrendingBlogPostsQuery = z.object({
     z.int(),
   ]).optional(),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -9754,25 +9816,25 @@ export const zListTrendingBlogPostsQuery = z.object({
   slug: z.string().optional(),
   slug_Icontains: z.string().optional(),
   tagName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by tag label (case-insensitive)',
   }).optional(),
   tags: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by title (case-insensitive)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   uuid: z.uuid().optional(),
   viewCount: z.union([
@@ -9809,7 +9871,7 @@ export const zListBlogTagQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasLikedPosts: z.union([
     z.literal('true'),
@@ -9838,7 +9900,7 @@ export const zListBlogTagQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -9847,7 +9909,7 @@ export const zListBlogTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   maxPosts: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -9876,13 +9938,13 @@ export const zListBlogTagQuery = z.object({
     z.boolean(),
   ]).optional(),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα ετικέτας (μερική αντιστοίχιση)',
+    description: 'Filter by tag name (partial match)',
   }).optional(),
   name_Exact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβές όνομα ετικέτας',
+    description: 'Filter by exact tag name',
   }).optional(),
   name_Startswith: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ετικετών με όνομα που ξεκινά με',
+    description: 'Filter tags with names starting with',
   }).optional(),
   ordering: z.string().regex(/^(?:id|\-id|active|\-active|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|name|\-name)(?:,(?:id|\-id|active|\-active|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|name|\-name))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, active, -active, createdAt, -createdAt, updatedAt, -updatedAt, sortOrder, -sortOrder, name, -name',
@@ -9896,14 +9958,14 @@ export const zListBlogTagQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   post: z.union([
     z.string().regex(/^-?\d+$/),
@@ -9971,7 +10033,7 @@ export const zCreateBlogTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10004,7 +10066,7 @@ export const zRetrieveBlogTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10025,7 +10087,7 @@ export const zPartialUpdateBlogTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10046,7 +10108,7 @@ export const zUpdateBlogTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10115,19 +10177,19 @@ export const zListCartItemQuery = z.object({
     z.int(),
   ]).optional(),
   cart_User_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη καλαθιού (μερική αντιστοίχιση)',
+    description: 'Filter by cart user email (partial match)',
   }).optional(),
   cart_User_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χρήστη καλαθιού (όνομα ή επώνυμο)',
+    description: 'Filter by cart user name (first or last)',
   }).optional(),
   cart_Uuid: z.uuid().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά UUID καλαθιού',
+    description: 'Filter by cart UUID',
   }).optional(),
   cartLastActivityAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τελευταία δραστηριότητα καλαθιού μετά από ημερομηνία',
+    description: 'Filter by cart last activity after date',
   }).optional(),
   cartLastActivityBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τελευταία δραστηριότητα καλαθιού πριν από ημερομηνία',
+    description: 'Filter by cart last activity before date',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -10139,7 +10201,7 @@ export const zListCartItemQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -10147,7 +10209,7 @@ export const zListCartItemQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -10170,7 +10232,7 @@ export const zListCartItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   maxDiscountPercent: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -10216,14 +10278,14 @@ export const zListCartItemQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   product: z.union([
     z.string().regex(/^-?\d+$/),
@@ -10241,16 +10303,16 @@ export const zListCartItemQuery = z.object({
     z.int(),
   ]).optional(),
   product_Category_Slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug κατηγορίας προϊόντος',
+    description: 'Filter by product category slug',
   }).optional(),
   product_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)',
+    description: 'Filter by product name (partial match)',
   }).optional(),
   product_Sku: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά sku προϊόντος (ακριβής αντιστοίχιση)',
+    description: 'Filter by product sku (exact match)',
   }).optional(),
   product_Uuid: z.uuid().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά UUID προϊόντος',
+    description: 'Filter by product UUID',
   }).optional(),
   quantity: z.union([
     z.string().regex(/^-?\d+$/),
@@ -10330,7 +10392,7 @@ export const zRetrieveCartItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10357,7 +10419,7 @@ export const zPartialUpdateCartItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10392,7 +10454,7 @@ export const zListCartQuery = z.object({
     'guest',
     'user',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο καλαθιού\n\n* `user` - User Cart\n* `guest` - Guest Cart\n* `anonymous` - Anonymous Cart',
+    description: 'Filter by cart type\n\n* `user` - User Cart\n* `guest` - Guest Cart\n* `anonymous` - Anonymous Cart',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -10404,7 +10466,7 @@ export const zListCartQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   daysInactive: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -10430,7 +10492,7 @@ export const zListCartQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -10460,19 +10522,19 @@ export const zListCartQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   lastActivity: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή ημερομηνία τελευταίας δραστηριότητας',
+    description: 'Filter by exact last activity date',
   }).optional(),
   lastActivity_Date: z.iso.date().optional(),
   lastActivity_Gte: z.iso.datetime({ offset: true }).optional(),
   lastActivity_Lte: z.iso.datetime({ offset: true }).optional(),
   lastActivityAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο καλαθιών με τελευταία δραστηριότητα μετά από αυτή την ημερομηνία',
+    description: 'Filter carts with last activity after this date',
   }).optional(),
   lastActivityBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο καλαθιών με τελευταία δραστηριότητα πριν από αυτή την ημερομηνία',
+    description: 'Filter carts with last activity before this date',
   }).optional(),
   maxItems: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -10510,14 +10572,14 @@ export const zListCartQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -10550,10 +10612,10 @@ export const zListCartQuery = z.object({
     z.boolean(),
   ]).optional(),
   userEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)',
+    description: 'Filter by user email (partial match)',
   }).optional(),
   userName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα χρήστη (όνομα ή επώνυμο)',
+    description: 'Filter by user full name (first or last name)',
   }).optional(),
   uuid: z.uuid().optional(),
 })
@@ -10584,28 +10646,28 @@ export const zCreateContactResponse = zContactWrite
 
 export const zListCountryQuery = z.object({
   alpha2: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή διψήφιο κωδικό χώρας',
+    description: 'Filter by exact 2-letter country code',
   }).optional(),
   alpha2_Icontains: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά διψήφιο κωδικό χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by 2-letter country code (partial match)',
   }).optional(),
   alpha2_Iexact: z.string().optional(),
   alpha2_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
   alpha3: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή τριψήφιο κωδικό χώρας',
+    description: 'Filter by exact 3-letter country code',
   }).optional(),
   alpha3_Icontains: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τριψήφιο κωδικό χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by 3-letter country code (partial match)',
   }).optional(),
   alpha3_Iexact: z.string().optional(),
   alpha3_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
@@ -10618,7 +10680,7 @@ export const zListCountryQuery = z.object({
     'OC',
     'SA',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ήπειρο (βάσει κωδικών ISO)\n\n* `AF` - Africa\n* `AS` - Asia\n* `EU` - Europe\n* `NA` - North America\n* `OC` - Oceania\n* `SA` - South America\n* `AN` - Antarctica',
+    description: 'Filter by continent (based on ISO codes)\n\n* `AF` - Africa\n* `AS` - Asia\n* `EU` - Europe\n* `NA` - North America\n* `OC` - Oceania\n* `SA` - South America\n* `AN` - Antarctica',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -10630,7 +10692,7 @@ export const zListCountryQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasAllData: z.union([
     z.literal('true'),
@@ -10684,7 +10746,7 @@ export const zListCountryQuery = z.object({
   ]).optional(),
   isoCc_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -10705,19 +10767,19 @@ export const zListCountryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   multipleCodes: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλούς κωδικούς χωρών (διαχωρισμένους με κόμμα, alpha-2 ή alpha-3)',
+    description: 'Filter by multiple country codes (comma-separated, alpha-2 or alpha-3)',
   }).optional(),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by country name (partial match)',
   }).optional(),
   name_Exact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβές όνομα χώρας',
+    description: 'Filter by exact country name',
   }).optional(),
   name_Startswith: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο χωρών με όνομα που ξεκινά με',
+    description: 'Filter countries with names starting with',
   }).optional(),
   ordering: z.string().regex(/^(?:alpha2|\-alpha2|alpha3|\-alpha3|isoCc|\-isoCc|phoneCode|\-phoneCode|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|translations_Name|\-translations_Name)(?:,(?:alpha2|\-alpha2|alpha3|\-alpha3|isoCc|\-isoCc|phoneCode|\-phoneCode|createdAt|\-createdAt|updatedAt|\-updatedAt|sortOrder|\-sortOrder|translations_Name|\-translations_Name))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: alpha2, -alpha2, alpha3, -alpha3, isoCc, -isoCc, phoneCode, -phoneCode, createdAt, -createdAt, updatedAt, -updatedAt, sortOrder, -sortOrder, translations_Name, -translations_Name',
@@ -10731,14 +10793,14 @@ export const zListCountryQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   phoneCode: z.union([
     z.string().regex(/^-?\d+$/),
@@ -10750,7 +10812,7 @@ export const zListCountryQuery = z.object({
   ]).optional(),
   phoneCode_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -10803,7 +10865,7 @@ export const zCreateCountryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10811,7 +10873,7 @@ export const zCreateCountryResponse = zCountryDetail
 
 export const zDestroyCountryPath = z.object({
   alpha2: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Χώρα.',
+    description: 'A unique value identifying this Country.',
   }),
 })
 
@@ -10824,7 +10886,7 @@ export const zDestroyCountryResponse = z.void().register(z.globalRegistry, {
 
 export const zRetrieveCountryPath = z.object({
   alpha2: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Χώρα.',
+    description: 'A unique value identifying this Country.',
   }),
 })
 
@@ -10834,7 +10896,7 @@ export const zRetrieveCountryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10844,7 +10906,7 @@ export const zPartialUpdateCountryBody = zPatchedCountryWriteRequest
 
 export const zPartialUpdateCountryPath = z.object({
   alpha2: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Χώρα.',
+    description: 'A unique value identifying this Country.',
   }),
 })
 
@@ -10854,7 +10916,7 @@ export const zPartialUpdateCountryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10864,7 +10926,7 @@ export const zUpdateCountryBody = zCountryWriteRequest
 
 export const zUpdateCountryPath = z.object({
   alpha2: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Χώρα.',
+    description: 'A unique value identifying this Country.',
   }),
 })
 
@@ -10874,7 +10936,7 @@ export const zUpdateCountryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -10954,7 +11016,7 @@ export const zListNotificationUserQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasSeenAt: z.union([
     z.literal('true'),
@@ -10976,7 +11038,7 @@ export const zListNotificationUserQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -10985,20 +11047,20 @@ export const zListNotificationUserQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   notification: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   notification_Category: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατηγορία ειδοποίησης',
+    description: 'Filter by notification category',
   }).optional(),
   notification_ExpiresAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ειδοποιήσεων που λήγουν μετά από αυτή την ημερομηνία',
+    description: 'Filter notifications expiring after this date',
   }).optional(),
   notification_ExpiresBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ειδοποιήσεων που λήγουν πριν από αυτή την ημερομηνία',
+    description: 'Filter notifications expiring before this date',
   }).optional(),
   notification_IsExpired: z.union([
     z.literal('true'),
@@ -11008,28 +11070,28 @@ export const zListNotificationUserQuery = z.object({
     z.boolean(),
   ]).optional(),
   notification_Kind: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο ειδοποίησης',
+    description: 'Filter by notification kind',
   }).optional(),
   notification_Link: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά σύνδεσμο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by notification link (case-insensitive)',
   }).optional(),
   notification_Message: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά μήνυμα ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by notification message (case-insensitive)',
   }).optional(),
   notification_Priority: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά προτεραιότητα ειδοποίησης',
+    description: 'Filter by notification priority',
   }).optional(),
   notification_Title: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τίτλο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by notification title (case-insensitive)',
   }).optional(),
   notification_Type: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο ειδοποίησης (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by notification type (case-insensitive)',
   }).optional(),
   notificationIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID ειδοποιήσεων (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple notification IDs (comma-separated)',
   }).optional(),
   notificationKind: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο ειδοποίησης',
+    description: 'Filter by notification kind',
   }).optional(),
   ordering: z.string().regex(/^(?:id|\-id|user|\-user|user_Email|\-user_Email|user_FirstName|\-user_FirstName|user_LastName|\-user_LastName|notification|\-notification|notification_Kind|\-notification_Kind|notification_Category|\-notification_Category|notification_Priority|\-notification_Priority|notification_CreatedAt|\-notification_CreatedAt|seen|\-seen|seenAt|\-seenAt|createdAt|\-createdAt|updatedAt|\-updatedAt)(?:,(?:id|\-id|user|\-user|user_Email|\-user_Email|user_FirstName|\-user_FirstName|user_LastName|\-user_LastName|notification|\-notification|notification_Kind|\-notification_Kind|notification_Category|\-notification_Category|notification_Priority|\-notification_Priority|notification_CreatedAt|\-notification_CreatedAt|seen|\-seen|seenAt|\-seenAt|createdAt|\-createdAt|updatedAt|\-updatedAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, user, -user, user_Email, -user_Email, user_FirstName, -user_FirstName, user_LastName, -user_LastName, notification, -notification, notification_Kind, -notification_Kind, notification_Category, -notification_Category, notification_Priority, -notification_Priority, notification_CreatedAt, -notification_CreatedAt, seen, -seen, seenAt, -seenAt, createdAt, -createdAt, updatedAt, -updatedAt',
@@ -11043,14 +11105,14 @@ export const zListNotificationUserQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   recentNotifications: z.union([
     z.literal('true'),
@@ -11070,13 +11132,13 @@ export const zListNotificationUserQuery = z.object({
     z.boolean(),
   ]).optional(),
   seenAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ειδοποιήσεων που προβλήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter notifications seen after this date',
   }).optional(),
   seenAt_Date: z.iso.date().optional(),
   seenAt_Gte: z.iso.datetime({ offset: true }).optional(),
   seenAt_Lte: z.iso.datetime({ offset: true }).optional(),
   seenBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο ειδοποιήσεων που προβλήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter notifications seen before this date',
   }).optional(),
   seenOnly: z.union([
     z.literal('true'),
@@ -11106,10 +11168,10 @@ export const zListNotificationUserQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user email (case-insensitive)',
   }).optional(),
   user_FirstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user first name (case-insensitive)',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -11126,10 +11188,10 @@ export const zListNotificationUserQuery = z.object({
     z.boolean(),
   ]).optional(),
   user_LastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user last name (case-insensitive)',
   }).optional(),
   userIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple user IDs (comma-separated)',
   }).optional(),
   uuid: z.uuid().optional(),
 })
@@ -11157,7 +11219,7 @@ export const zRetrieveNotificationUserQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11175,7 +11237,7 @@ export const zPartialUpdateNotificationUserQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11193,7 +11255,7 @@ export const zUpdateNotificationUserQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11229,20 +11291,20 @@ export const zListOrderQuery = z.object({
     z.boolean(),
   ]).optional(),
   city: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)',
+    description: 'Filter by city (case-insensitive)',
   }).optional(),
   city_Icontains: z.string().optional(),
   country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό χώρας',
+    description: 'Filter by country code',
   }).optional(),
   country_Alpha2: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά alpha-2 κωδικό χώρας',
+    description: 'Filter by country alpha-2 code',
   }).optional(),
   country_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by country name (case-insensitive)',
   }).optional(),
   countryIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple country IDs (comma-separated)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -11254,15 +11316,15 @@ export const zListOrderQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   customerNotes: z.string().optional(),
   customerNotes_Icontains: z.string().optional(),
   documentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο εγγράφου',
+    description: 'Filter by document type',
   }).optional(),
   email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer email (case-insensitive)',
   }).optional(),
   email_Icontains: z.string().optional(),
   finalOrders: z.union([
@@ -11273,11 +11335,11 @@ export const zListOrderQuery = z.object({
     z.boolean(),
   ]).optional(),
   firstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer first name (case-insensitive)',
   }).optional(),
   firstName_Icontains: z.string().optional(),
   floor: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όροφο',
+    description: 'Filter by floor',
   }).optional(),
   hasCustomerNotes: z.union([
     z.literal('true'),
@@ -11320,7 +11382,7 @@ export const zListOrderQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -11350,14 +11412,14 @@ export const zListOrderQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   lastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer last name (case-insensitive)',
   }).optional(),
   lastName_Icontains: z.string().optional(),
   locationType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο τοποθεσίας',
+    description: 'Filter by location type',
   }).optional(),
   needsProcessing: z.union([
     z.literal('true'),
@@ -11378,14 +11440,14 @@ export const zListOrderQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   paidAmount_Gte: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -11415,14 +11477,14 @@ export const zListOrderQuery = z.object({
     z.boolean(),
   ]).optional(),
   payWay_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by payment method name (case-insensitive)',
   }).optional(),
   paymentId: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ID πληρωμής',
+    description: 'Filter by payment ID',
   }).optional(),
   paymentId_Icontains: z.string().optional(),
   paymentMethod: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά μέθοδο πληρωμής',
+    description: 'Filter by payment method',
   }).optional(),
   paymentMethod_Icontains: z.string().optional(),
   paymentStatus: z.enum([
@@ -11434,20 +11496,20 @@ export const zListOrderQuery = z.object({
     'PROCESSING',
     'REFUNDED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση πληρωμής\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε',
+    description: 'Filter by payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled',
   }).optional(),
   paymentStatus_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
   phone: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό τηλεφώνου',
+    description: 'Filter by phone number',
   }).optional(),
   phone_Icontains: z.string().optional(),
   place: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by place (case-insensitive)',
   }).optional(),
   place_Icontains: z.string().optional(),
   recentOrders: z.union([
@@ -11458,16 +11520,16 @@ export const zListOrderQuery = z.object({
     z.boolean(),
   ]).optional(),
   region: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό περιφέρειας',
+    description: 'Filter by region code',
   }).optional(),
   region_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by region name (case-insensitive)',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
   }).optional(),
   shippingCarrier: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά εταιρεία μεταφοράς',
+    description: 'Filter by shipping carrier',
   }).optional(),
   shippingCarrier_Icontains: z.string().optional(),
   shippingPrice_Gte: z.union([
@@ -11496,36 +11558,36 @@ export const zListOrderQuery = z.object({
     'RETURNED',
     'SHIPPED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων',
+    description: 'Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded',
   }).optional(),
   status_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
   statusList: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)',
+    description: 'Filter by multiple statuses (comma-separated)',
   }).optional(),
   statusUpdatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία',
+    description: 'Filter orders with status updated after this date',
   }).optional(),
   statusUpdatedAt_Date: z.iso.date().optional(),
   statusUpdatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   statusUpdatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   statusUpdatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία',
+    description: 'Filter orders with status updated before this date',
   }).optional(),
   street: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by street (case-insensitive)',
   }).optional(),
   street_Icontains: z.string().optional(),
   streetNumber: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό',
+    description: 'Filter by street number',
   }).optional(),
   streetNumber_Icontains: z.string().optional(),
   trackingNumber: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό παρακολούθησης',
+    description: 'Filter by tracking number',
   }).optional(),
   trackingNumber_Icontains: z.string().optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
@@ -11542,10 +11604,10 @@ export const zListOrderQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user email (case-insensitive)',
   }).optional(),
   user_FirstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user first name (case-insensitive)',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -11555,14 +11617,14 @@ export const zListOrderQuery = z.object({
     z.boolean(),
   ]).optional(),
   user_LastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user last name (case-insensitive)',
   }).optional(),
   userIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple user IDs (comma-separated)',
   }).optional(),
   uuid: z.uuid().optional(),
   zipcode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά Τ.Κ.',
+    description: 'Filter by zipcode',
   }).optional(),
 })
 
@@ -11576,7 +11638,7 @@ export const zCreateOrderQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11600,7 +11662,7 @@ export const zListOrderItemQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasNotes: z.union([
     z.literal('true'),
@@ -11629,7 +11691,7 @@ export const zListOrderItemQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -11659,10 +11721,10 @@ export const zListOrderItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   notes: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σημειώσεων (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by notes content (case-insensitive)',
   }).optional(),
   notes_Icontains: z.string().optional(),
   order: z.union([
@@ -11670,16 +11732,16 @@ export const zListOrderItemQuery = z.object({
     z.int(),
   ]).optional(),
   order_Country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό χώρας παραγγελίας',
+    description: 'Filter by order country code',
   }).optional(),
   order_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by order customer email (case-insensitive)',
   }).optional(),
   order_FirstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by order customer first name (case-insensitive)',
   }).optional(),
   order_LastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο πελάτη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by order customer last name (case-insensitive)',
   }).optional(),
   order_PaymentStatus: z.enum([
     'CANCELED',
@@ -11690,10 +11752,10 @@ export const zListOrderItemQuery = z.object({
     'PROCESSING',
     'REFUNDED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση πληρωμής παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε',
+    description: 'Filter by order payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled',
   }).optional(),
   order_Region: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό περιφέρειας παραγγελίας',
+    description: 'Filter by order region code',
   }).optional(),
   order_Status: z.enum([
     'CANCELED',
@@ -11705,20 +11767,20 @@ export const zListOrderItemQuery = z.object({
     'RETURNED',
     'SHIPPED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων',
+    description: 'Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded',
   }).optional(),
   order_User: z.union([
     z.string().regex(/^-?\d+$/),
     z.int(),
   ]).optional(),
   order_User_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη παραγγελίας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by order user email (case-insensitive)',
   }).optional(),
   orderIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID παραγγελιών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple order IDs (comma-separated)',
   }).optional(),
   orderStatuses: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλές καταστάσεις παραγγελιών (διαχωρισμένες με κόμμα)',
+    description: 'Filter by multiple order statuses (comma-separated)',
   }).optional(),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|quantity|\-quantity|price|\-price|sortOrder|\-sortOrder)(?:,(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|quantity|\-quantity|price|\-price|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, quantity, -quantity, price, -price, sortOrder, -sortOrder',
@@ -11752,14 +11814,14 @@ export const zListOrderItemQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   price: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -11801,16 +11863,16 @@ export const zListOrderItemQuery = z.object({
     z.int(),
   ]).optional(),
   product_Category_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα κατηγορίας προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by product category name (case-insensitive)',
   }).optional(),
   product_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα προϊόντος (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by product name (case-insensitive)',
   }).optional(),
   product_Sku: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά SKU προϊόντος',
+    description: 'Filter by product SKU',
   }).optional(),
   productIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID προϊόντων (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple product IDs (comma-separated)',
   }).optional(),
   quantity: z.union([
     z.string().regex(/^-?\d+$/),
@@ -11900,7 +11962,7 @@ export const zCreateOrderItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11933,7 +11995,7 @@ export const zRetrieveOrderItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11954,7 +12016,7 @@ export const zPartialUpdateOrderItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -11975,7 +12037,7 @@ export const zUpdateOrderItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12019,7 +12081,7 @@ export const zRetrieveOrderQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12040,7 +12102,7 @@ export const zPartialUpdateOrderQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12061,7 +12123,7 @@ export const zUpdateOrderQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12240,20 +12302,20 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   city: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πόλη (χωρίς πεζά/κεφαλαία)',
+    description: 'Filter by city (case-insensitive)',
   }).optional(),
   city_Icontains: z.string().optional(),
   country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό χώρας',
+    description: 'Filter by country code',
   }).optional(),
   country_Alpha2: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά alpha-2 κωδικό χώρας',
+    description: 'Filter by country alpha-2 code',
   }).optional(),
   country_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by country name (case-insensitive)',
   }).optional(),
   countryIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID χωρών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple country IDs (comma-separated)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -12267,10 +12329,10 @@ export const zListMyOrdersQuery = z.object({
   customerNotes: z.string().optional(),
   customerNotes_Icontains: z.string().optional(),
   documentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο εγγράφου',
+    description: 'Filter by document type',
   }).optional(),
   email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer email (case-insensitive)',
   }).optional(),
   email_Icontains: z.string().optional(),
   finalOrders: z.union([
@@ -12281,11 +12343,11 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   firstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer first name (case-insensitive)',
   }).optional(),
   firstName_Icontains: z.string().optional(),
   floor: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όροφο',
+    description: 'Filter by floor',
   }).optional(),
   hasCustomerNotes: z.union([
     z.literal('true'),
@@ -12328,7 +12390,7 @@ export const zListMyOrdersQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -12354,11 +12416,11 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   lastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο πελάτη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by customer last name (case-insensitive)',
   }).optional(),
   lastName_Icontains: z.string().optional(),
   locationType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο τοποθεσίας',
+    description: 'Filter by location type',
   }).optional(),
   needsProcessing: z.union([
     z.literal('true'),
@@ -12406,14 +12468,14 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   payWay_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα μεθόδου πληρωμής (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by payment method name (case-insensitive)',
   }).optional(),
   paymentId: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ID πληρωμής',
+    description: 'Filter by payment ID',
   }).optional(),
   paymentId_Icontains: z.string().optional(),
   paymentMethod: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά μέθοδο πληρωμής',
+    description: 'Filter by payment method',
   }).optional(),
   paymentMethod_Icontains: z.string().optional(),
   paymentStatus: z.enum([
@@ -12425,20 +12487,20 @@ export const zListMyOrdersQuery = z.object({
     'PROCESSING',
     'REFUNDED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση πληρωμής\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `COMPLETED` - Ολοκληρώθηκε\n* `FAILED` - Απέτυχε\n* `REFUNDED` - Επιστροφή Χρημάτων\n* `PARTIALLY_REFUNDED` - Μερική επιστροφή\n* `CANCELED` - Ακυρώθηκε',
+    description: 'Filter by payment status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `COMPLETED` - Completed\n* `FAILED` - Failed\n* `REFUNDED` - Refunded\n* `PARTIALLY_REFUNDED` - Partially Refunded\n* `CANCELED` - Canceled',
   }).optional(),
   paymentStatus_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
   phone: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό τηλεφώνου',
+    description: 'Filter by phone number',
   }).optional(),
   phone_Icontains: z.string().optional(),
   place: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τοποθεσία (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by place (case-insensitive)',
   }).optional(),
   place_Icontains: z.string().optional(),
   recentOrders: z.union([
@@ -12449,16 +12511,16 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   region: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό περιφέρειας',
+    description: 'Filter by region code',
   }).optional(),
   region_Name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα περιφέρειας (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by region name (case-insensitive)',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
   }).optional(),
   shippingCarrier: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά εταιρεία μεταφοράς',
+    description: 'Filter by shipping carrier',
   }).optional(),
   shippingCarrier_Icontains: z.string().optional(),
   shippingPrice_Gte: z.union([
@@ -12487,36 +12549,36 @@ export const zListMyOrdersQuery = z.object({
     'RETURNED',
     'SHIPPED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση παραγγελίας\n\n* `PENDING` - Εκκρεμεί\n* `PROCESSING` - Σε επεξεργασία\n* `SHIPPED` - Απεστάλη\n* `DELIVERED` - Παραδόθηκε\n* `COMPLETED` - Ολοκληρώθηκε\n* `CANCELED` - Ακυρώθηκε\n* `RETURNED` - Επιστράφηκε\n* `REFUNDED` - Επιστροφή Χρημάτων',
+    description: 'Filter by order status\n\n* `PENDING` - Pending\n* `PROCESSING` - Processing\n* `SHIPPED` - Shipped\n* `DELIVERED` - Delivered\n* `COMPLETED` - Completed\n* `CANCELED` - Canceled\n* `RETURNED` - Returned\n* `REFUNDED` - Refunded',
   }).optional(),
   status_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.string()),
   ]).optional(),
   statusList: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλές καταστάσεις (διαχωρισμένες με κόμμα)',
+    description: 'Filter by multiple statuses (comma-separated)',
   }).optional(),
   statusUpdatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε μετά από αυτή την ημερομηνία',
+    description: 'Filter orders with status updated after this date',
   }).optional(),
   statusUpdatedAt_Date: z.iso.date().optional(),
   statusUpdatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   statusUpdatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   statusUpdatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο παραγγελιών με κατάσταση που ενημερώθηκε πριν από αυτή την ημερομηνία',
+    description: 'Filter orders with status updated before this date',
   }).optional(),
   street: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά οδό (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by street (case-insensitive)',
   }).optional(),
   street_Icontains: z.string().optional(),
   streetNumber: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό',
+    description: 'Filter by street number',
   }).optional(),
   streetNumber_Icontains: z.string().optional(),
   trackingNumber: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό παρακολούθησης',
+    description: 'Filter by tracking number',
   }).optional(),
   trackingNumber_Icontains: z.string().optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
@@ -12533,10 +12595,10 @@ export const zListMyOrdersQuery = z.object({
     z.int(),
   ]).optional(),
   user_Email: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user email (case-insensitive)',
   }).optional(),
   user_FirstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user first name (case-insensitive)',
   }).optional(),
   user_IsActive: z.union([
     z.literal('true'),
@@ -12546,14 +12608,14 @@ export const zListMyOrdersQuery = z.object({
     z.boolean(),
   ]).optional(),
   user_LastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο χρήστη (χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by user last name (case-insensitive)',
   }).optional(),
   userIds: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πολλαπλά ID χρηστών (διαχωρισμένα με κόμμα)',
+    description: 'Filter by multiple user IDs (comma-separated)',
   }).optional(),
   uuid: z.uuid().optional(),
   zipcode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά Τ.Κ.',
+    description: 'Filter by zipcode',
   }).optional(),
 })
 
@@ -12601,10 +12663,10 @@ export const zListPayWayQuery = z.object({
     z.number(),
   ]).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   description: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)',
+    description: 'Filter by description (partial match)',
   }).optional(),
   freeThreshold_Gte: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -12652,10 +12714,10 @@ export const zListPayWayQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα (μερική αντιστοίχιση)',
+    description: 'Filter by name (partial match)',
   }).optional(),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|cost|\-cost|freeThreshold|\-freeThreshold|providerCode|\-providerCode|isOnlinePayment|\-isOnlinePayment|requiresConfirmation|\-requiresConfirmation|sortOrder|\-sortOrder)(?:,(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|cost|\-cost|freeThreshold|\-freeThreshold|providerCode|\-providerCode|isOnlinePayment|\-isOnlinePayment|requiresConfirmation|\-requiresConfirmation|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, cost, -cost, freeThreshold, -freeThreshold, providerCode, -providerCode, isOnlinePayment, -isOnlinePayment, requiresConfirmation, -requiresConfirmation, sortOrder, -sortOrder',
@@ -12669,17 +12731,17 @@ export const zListPayWayQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   providerCode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό παρόχου (μερική αντιστοίχιση)',
+    description: 'Filter by provider code (partial match)',
   }).optional(),
   providerCode_Icontains: z.string().optional(),
   requiresConfirmation: z.union([
@@ -12693,10 +12755,10 @@ export const zListPayWayQuery = z.object({
     description: 'A search term.',
   }).optional(),
   shippingKind: z.string().register(z.globalRegistry, {
-    description: 'Συνδυάστε με το ``shippingProviderCode`` για να φιλτράρετε τις μεθόδους πληρωμής βάσει των κανόνων συμβατότητας του μεταφορέα για αυτόν τον τύπο.',
+    description: 'Pair with ``shippingProviderCode`` to filter pay ways by the carrier\'s compatibility rules for that kind.',
   }).optional(),
   shippingProviderCode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο μεθόδων πληρωμής συμβατών με τον δεδομένο μεταφορέα αποστολής. Κάθε μεταφορέας διαθέτει τους δικούς του κανόνες συμβατότητας — το BoxNow (``boxnow``) υποστηρίζει αντικαταβολή σε lockers μέσω PAY ON THE GO και έτσι περνά κανονικά· η ACS περνά αμετάβλητη. Συνδυάστε με το ``shippingKind``.',
+    description: 'Filter pay ways compatible with the given shipping carrier. Each carrier owns its own compatibility rules — BoxNow (``boxnow``) supports COD on lockers via PAY ON THE GO and so passes through; ACS passes through unchanged. Pair with ``shippingKind``.',
   }).optional(),
   sortOrder: z.union([
     z.string().regex(/^-?\d+$/),
@@ -12723,7 +12785,7 @@ export const zCreatePayWayQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12750,7 +12812,7 @@ export const zRetrievePayWayQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12768,7 +12830,7 @@ export const zPartialUpdatePayWayQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12786,7 +12848,7 @@ export const zUpdatePayWayQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -12806,7 +12868,7 @@ export const zListProductQuery = z.object({
   ]).optional(),
   attribute_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -12816,7 +12878,7 @@ export const zListProductQuery = z.object({
   ]).optional(),
   attributeValue_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -12837,7 +12899,7 @@ export const zListProductQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   deletedAt_Date: z.iso.date().optional(),
   deletedAt_Gte: z.iso.datetime({ offset: true }).optional(),
@@ -12884,7 +12946,7 @@ export const zListProductQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   maxDiscount: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -12970,14 +13032,14 @@ export const zListProductQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   price: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -13054,7 +13116,7 @@ export const zCreateProductQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13087,7 +13149,7 @@ export const zRetrieveProductQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13108,7 +13170,7 @@ export const zPartialUpdateProductQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13129,7 +13191,7 @@ export const zUpdateProductQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13148,7 +13210,7 @@ export const zListProductImagesQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:price|\-price|createdAt|\-createdAt|active|\-active|availabilityPriority|\-availabilityPriority|viewCount|\-viewCount|stock|\-stock)(?:,(?:price|\-price|createdAt|\-createdAt|active|\-active|availabilityPriority|\-availabilityPriority|viewCount|\-viewCount|stock|\-stock))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: price, -price, createdAt, -createdAt, active, -active, availabilityPriority, -availabilityPriority, viewCount, -viewCount, stock, -stock',
@@ -13180,14 +13242,14 @@ export const zListProductReviewsQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -13236,7 +13298,7 @@ export const zListProductVariantsQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13244,7 +13306,7 @@ export const zListProductVariantsResponse = zProductVariantsResponse
 
 export const zListProductAlertQuery = z.object({
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   isActive: z.union([
     z.literal('true'),
@@ -13254,14 +13316,14 @@ export const zListProductAlertQuery = z.object({
     z.boolean(),
   ]).optional(),
   kind: z.enum(['price_drop', 'restock']).register(z.globalRegistry, {
-    description: '* `restock` - Αναπλήρωση\n* `price_drop` - Πτώση τιμής',
+    description: '* `restock` - Restock\n* `price_drop` - Price drop',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|notifiedAt|\-notifiedAt)(?:,(?:id|\-id|createdAt|\-createdAt|notifiedAt|\-notifiedAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, notifiedAt, -notifiedAt',
@@ -13275,14 +13337,14 @@ export const zListProductAlertQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   product: z.union([
     z.string().regex(/^-?\d+$/),
@@ -13303,7 +13365,7 @@ export const zCreateProductAlertQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13329,7 +13391,7 @@ export const zRetrieveProductAlertQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13353,7 +13415,7 @@ export const zListAttributeQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasValues: z.union([
     z.literal('true'),
@@ -13368,7 +13430,7 @@ export const zListAttributeQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -13377,7 +13439,7 @@ export const zListAttributeQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   name: z.string().optional(),
   ordering: z.string().regex(/^(?:id|\-id|sortOrder|\-sortOrder|createdAt|\-createdAt|updatedAt|\-updatedAt)(?:,(?:id|\-id|sortOrder|\-sortOrder|createdAt|\-createdAt|updatedAt|\-updatedAt))*$/).register(z.globalRegistry, {
@@ -13392,14 +13454,14 @@ export const zListAttributeQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -13436,7 +13498,7 @@ export const zCreateAttributeQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13469,7 +13531,7 @@ export const zRetrieveAttributeQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13488,7 +13550,7 @@ export const zPartialUpdateAttributeQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13507,7 +13569,7 @@ export const zUpdateAttributeQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13527,7 +13589,7 @@ export const zListAttributeValueQuery = z.object({
   ]).optional(),
   attribute_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -13541,7 +13603,7 @@ export const zListAttributeValueQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -13549,7 +13611,7 @@ export const zListAttributeValueQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -13558,7 +13620,7 @@ export const zListAttributeValueQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|attribute|\-attribute|sortOrder|\-sortOrder|createdAt|\-createdAt|updatedAt|\-updatedAt)(?:,(?:id|\-id|attribute|\-attribute|sortOrder|\-sortOrder|createdAt|\-createdAt|updatedAt|\-updatedAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, attribute, -attribute, sortOrder, -sortOrder, createdAt, -createdAt, updatedAt, -updatedAt',
@@ -13572,14 +13634,14 @@ export const zListAttributeValueQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -13617,7 +13679,7 @@ export const zCreateAttributeValueQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13650,7 +13712,7 @@ export const zRetrieveAttributeValueQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13669,7 +13731,7 @@ export const zPartialUpdateAttributeValueQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13688,7 +13750,7 @@ export const zUpdateAttributeValueQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13716,7 +13778,7 @@ export const zListProductCategoryQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   descendantOf: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -13742,7 +13804,7 @@ export const zListProductCategoryQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -13765,7 +13827,7 @@ export const zListProductCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   level: z.union([
     z.string().regex(/^-?\d+$/),
@@ -13807,14 +13869,14 @@ export const zListProductCategoryQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   parent: z.union([
     z.string().regex(/^-?\d+$/),
@@ -13866,7 +13928,7 @@ export const zCreateProductCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13899,7 +13961,7 @@ export const zRetrieveProductCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13920,7 +13982,7 @@ export const zPartialUpdateProductCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13941,7 +14003,7 @@ export const zUpdateProductCategoryQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -13992,7 +14054,7 @@ export const zListAllProductCategoryQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -14096,7 +14158,7 @@ export const zListProductCategoryImageQuery = z.object({
     z.int(),
   ]).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14114,14 +14176,14 @@ export const zListProductCategoryImageQuery = z.object({
     'SEASONAL',
     'THUMBNAIL',
   ]).register(z.globalRegistry, {
-    description: '* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα',
+    description: '* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder)(?:,(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: createdAt, -createdAt, imageType, -imageType, sortOrder, -sortOrder',
@@ -14135,14 +14197,14 @@ export const zListProductCategoryImageQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -14159,7 +14221,7 @@ export const zCreateProductCategoryImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14192,7 +14254,7 @@ export const zRetrieveProductCategoryImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14213,7 +14275,7 @@ export const zPartialUpdateProductCategoryImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14234,7 +14296,7 @@ export const zUpdateProductCategoryImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14272,7 +14334,7 @@ export const zGetProductCategoryImagesByCategoryQuery = z.object({
     'SEASONAL',
     'THUMBNAIL',
   ]).register(z.globalRegistry, {
-    description: '* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα',
+    description: '* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image',
   }).optional(),
   ordering: z.string().regex(/^(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder)(?:,(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: createdAt, -createdAt, imageType, -imageType, sortOrder, -sortOrder',
@@ -14312,7 +14374,7 @@ export const zGetProductCategoryImagesByTypeQuery = z.object({
     'SEASONAL',
     'THUMBNAIL',
   ]).register(z.globalRegistry, {
-    description: '* `MAIN` - Κύρια εικόνα\n* `BANNER` - Banner\n* `ICON` - Εικονίδιο\n* `THUMBNAIL` - Μικρογραφία\n* `GALLERY` - Εικόνα συλλογής\n* `BACKGROUND` - Εικόνα φόντου\n* `HERO` - Κεντρική εικόνα\n* `FEATURE` - Κεντρική Εικόνα\n* `PROMOTIONAL` - Προωθητική εικόνα\n* `SEASONAL` - Εποχιακή εικόνα',
+    description: '* `MAIN` - Main Image\n* `BANNER` - Banner Image\n* `ICON` - Icon Image\n* `THUMBNAIL` - Thumbnail Image\n* `GALLERY` - Gallery Image\n* `BACKGROUND` - Background Image\n* `HERO` - Hero Image\n* `FEATURE` - Feature Image\n* `PROMOTIONAL` - Promotional Image\n* `SEASONAL` - Seasonal Image',
   }).optional(),
   ordering: z.string().regex(/^(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder)(?:,(?:createdAt|\-createdAt|imageType|\-imageType|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: createdAt, -createdAt, imageType, -imageType, sortOrder, -sortOrder',
@@ -14332,7 +14394,7 @@ export const zListProductFavouriteQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14343,7 +14405,7 @@ export const zListProductFavouriteQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|userId|\-userId|productId|\-productId|createdAt|\-createdAt|updatedAt|\-updatedAt)(?:,(?:id|\-id|userId|\-userId|productId|\-productId|createdAt|\-createdAt|updatedAt|\-updatedAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, userId, -userId, productId, -productId, createdAt, -createdAt, updatedAt, -updatedAt',
@@ -14357,14 +14419,14 @@ export const zListProductFavouriteQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   product: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14404,7 +14466,7 @@ export const zCreateProductFavouriteQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14431,7 +14493,7 @@ export const zRetrieveProductFavouriteQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14449,7 +14511,7 @@ export const zPartialUpdateProductFavouriteQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14467,7 +14529,7 @@ export const zUpdateProductFavouriteQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14528,7 +14590,7 @@ export const zGetProductFavouritesByProductsResponse = z.array(zProductFavourite
 export const zListProductImageQuery = z.object({
   createdAt: z.iso.datetime({ offset: true }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14546,7 +14608,7 @@ export const zListProductImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|isMain|\-isMain|sortOrder|\-sortOrder)(?:,(?:id|\-id|createdAt|\-createdAt|updatedAt|\-updatedAt|isMain|\-isMain|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, createdAt, -createdAt, updatedAt, -updatedAt, isMain, -isMain, sortOrder, -sortOrder',
@@ -14560,14 +14622,14 @@ export const zListProductImageQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   product: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14593,7 +14655,7 @@ export const zCreateProductImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14626,7 +14688,7 @@ export const zRetrieveProductImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14647,7 +14709,7 @@ export const zPartialUpdateProductImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14668,7 +14730,7 @@ export const zUpdateProductImageQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14676,16 +14738,16 @@ export const zUpdateProductImageResponse = zProductImageDetail
 
 export const zListProductReviewQuery = z.object({
   comment: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιεχόμενο σχολίου (μερική αντιστοίχιση)',
+    description: 'Filter by comment content (partial match)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items created after this date',
   }).optional(),
   createdAt_Date: z.iso.date().optional(),
   createdAt_Gte: z.iso.datetime({ offset: true }).optional(),
   createdAt_Lte: z.iso.datetime({ offset: true }).optional(),
   createdBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items created before this date',
   }).optional(),
   currentlyPublished: z.union([
     z.literal('true'),
@@ -14695,7 +14757,7 @@ export const zListProductReviewQuery = z.object({
     z.boolean(),
   ]).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasComment: z.union([
     z.literal('true'),
@@ -14720,7 +14782,7 @@ export const zListProductReviewQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   maxRate: z.union([
     z.string().regex(/^-?\d+$/),
@@ -14742,14 +14804,14 @@ export const zListProductReviewQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   product: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -14779,16 +14841,16 @@ export const zListProductReviewQuery = z.object({
     z.number(),
   ]).optional(),
   productName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα προϊόντος (μερική αντιστοίχιση)',
+    description: 'Filter by product name (partial match)',
   }).optional(),
   publishedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items published after this date',
   }).optional(),
   publishedAt_Date: z.iso.date().optional(),
   publishedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   publishedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   publishedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που δημοσιεύθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items published before this date',
   }).optional(),
   publishedRecentDays: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -14826,33 +14888,33 @@ export const zListProductReviewQuery = z.object({
     'NEW',
     'TRUE',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση αξιολόγησης\n\n* `NEW` - Νέο\n* `TRUE` - Ναι\n* `FALSE` - Όχι',
+    description: 'Filter by review status\n\n* `NEW` - New\n* `TRUE` - True\n* `FALSE` - False',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter items updated after this date',
   }).optional(),
   updatedAt_Date: z.iso.date().optional(),
   updatedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   updatedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   updatedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο αντικειμένων που ενημερώθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter items updated before this date',
   }).optional(),
   user: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
     z.number(),
   ]).optional(),
   userEmail: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά email χρήστη (μερική αντιστοίχιση)',
+    description: 'Filter by user email (partial match)',
   }).optional(),
   userFirstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χρήστη (μερική αντιστοίχιση)',
+    description: 'Filter by user first name (partial match)',
   }).optional(),
   userId: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
     z.number(),
   ]).optional(),
   userLastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο χρήστη (μερική αντιστοίχιση)',
+    description: 'Filter by user last name (partial match)',
   }).optional(),
   userReviewCountMin: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -14878,7 +14940,7 @@ export const zCreateProductReviewQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14911,7 +14973,7 @@ export const zRetrieveProductReviewQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14932,7 +14994,7 @@ export const zPartialUpdateProductReviewQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14953,7 +15015,7 @@ export const zUpdateProductReviewQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -14973,17 +15035,17 @@ export const zGetUserProductReviewResponse = zProductReviewDetail
 
 export const zListRegionQuery = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)',
+    description: 'Filter by region alpha code (partial match)',
   }).optional(),
   alpha_Icontains: z.string().optional(),
   alphaExact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας',
+    description: 'Filter by exact region alpha code',
   }).optional(),
   country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά alpha-2 κωδικό χώρας',
+    description: 'Filter by country alpha-2 code',
   }).optional(),
   countryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by country name (partial match)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -14992,17 +15054,17 @@ export const zListRegionQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)',
+    description: 'Filter by region name (partial match)',
   }).optional(),
   ordering: z.string().regex(/^(?:createdAt|\-createdAt|alpha|\-alpha|sortOrder|\-sortOrder)(?:,(?:createdAt|\-createdAt|alpha|\-alpha|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: createdAt, -createdAt, alpha, -alpha, sortOrder, -sortOrder',
@@ -15016,14 +15078,14 @@ export const zListRegionQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -15059,7 +15121,7 @@ export const zCreateRegionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15067,7 +15129,7 @@ export const zCreateRegionResponse = zRegionDetail
 
 export const zDestroyRegionPath = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Περιοχή.',
+    description: 'A unique value identifying this Region.',
   }),
 })
 
@@ -15080,7 +15142,7 @@ export const zDestroyRegionResponse = z.void().register(z.globalRegistry, {
 
 export const zRetrieveRegionPath = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Περιοχή.',
+    description: 'A unique value identifying this Region.',
   }),
 })
 
@@ -15090,7 +15152,7 @@ export const zRetrieveRegionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15100,7 +15162,7 @@ export const zPartialUpdateRegionBody = zPatchedRegionWriteRequest
 
 export const zPartialUpdateRegionPath = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Περιοχή.',
+    description: 'A unique value identifying this Region.',
   }),
 })
 
@@ -15110,7 +15172,7 @@ export const zPartialUpdateRegionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15120,7 +15182,7 @@ export const zUpdateRegionBody = zRegionWriteRequest
 
 export const zUpdateRegionPath = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Περιοχή.',
+    description: 'A unique value identifying this Region.',
   }),
 })
 
@@ -15130,7 +15192,7 @@ export const zUpdateRegionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15138,23 +15200,23 @@ export const zUpdateRegionResponse = zRegionDetail
 
 export const zListRegionsByCountryPath = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'A unique value identifying this Περιοχή.',
+    description: 'A unique value identifying this Region.',
   }),
 })
 
 export const zListRegionsByCountryQuery = z.object({
   alpha: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αλφαβητικό κωδικό περιφέρειας (μερική αντιστοίχιση)',
+    description: 'Filter by region alpha code (partial match)',
   }).optional(),
   alpha_Icontains: z.string().optional(),
   alphaExact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή αλφαβητικό κωδικό περιφέρειας',
+    description: 'Filter by exact region alpha code',
   }).optional(),
   country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά alpha-2 κωδικό χώρας',
+    description: 'Filter by country alpha-2 code',
   }).optional(),
   countryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by country name (partial match)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -15163,7 +15225,7 @@ export const zListRegionsByCountryQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)',
+    description: 'Filter by region name (partial match)',
   }).optional(),
   ordering: z.string().regex(/^(?:createdAt|\-createdAt|alpha|\-alpha|sortOrder|\-sortOrder)(?:,(?:createdAt|\-createdAt|alpha|\-alpha|sortOrder|\-sortOrder))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: createdAt, -createdAt, alpha, -alpha, sortOrder, -sortOrder',
@@ -15204,13 +15266,13 @@ export const zListRegionsByCountryResponse = zPaginatedRegionList
 
 export const zApiV1SearchAnalyticsRetrieveQuery = z.object({
   contentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο περιεχομένου: \'product\', \'blog_post\', ή \'federated\'. Αν δεν δοθεί, συμπεριλαμβάνει όλους τους τύπους περιεχομένου.',
+    description: 'Filter by content type: \'product\', \'blog_post\', or \'federated\'. If not provided, includes all content types.',
   }).optional(),
   endDate: z.string().register(z.globalRegistry, {
-    description: 'Ημερομηνία λήξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει δεδομένα έως τη σημερινή ημερομηνία.',
+    description: 'End date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes data up to current date.',
   }).optional(),
   startDate: z.string().register(z.globalRegistry, {
-    description: 'Ημερομηνία έναρξης για το εύρος αναλυτικών (μορφή ISO: YYYY-MM-DD). Αν δεν δοθεί, συμπεριλαμβάνει όλα τα ιστορικά δεδομένα.',
+    description: 'Start date for analytics range (ISO format: YYYY-MM-DD). If not provided, includes all historical data.',
   }).optional(),
 })
 
@@ -15218,7 +15280,7 @@ export const zApiV1SearchAnalyticsRetrieveResponse = zSearchAnalyticsResponse
 
 export const zApiV1SearchBlogPostRetrieveQuery = z.object({
   languageCode: z.string().register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. \'en\', \'el\', \'de\'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.',
+    description: 'Language code to filter results (e.g., \'en\', \'el\', \'de\'). If not provided, searches all languages.',
   }).optional(),
   limit: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15229,15 +15291,19 @@ export const zApiV1SearchBlogPostRetrieveQuery = z.object({
     z.int(),
   ]).optional(),
   query: z.string().register(z.globalRegistry, {
-    description: 'String αναζήτησης',
+    description: 'Search query string',
   }),
 })
 
 export const zApiV1SearchBlogPostRetrieveResponse = zBlogPostMeiliSearchResponse
 
+export const zApiV1SearchClickCreateBody = zSearchClickRequestRequest
+
+export const zApiV1SearchClickCreateResponse = zSearchClickResponse
+
 export const zApiV1SearchFederatedRetrieveQuery = z.object({
   languageCode: z.string().register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. \'en\', \'el\', \'de\'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.',
+    description: 'Language code to filter results (e.g., \'en\', \'el\', \'de\'). If not provided, searches all languages.',
   }).optional(),
   limit: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15248,7 +15314,7 @@ export const zApiV1SearchFederatedRetrieveQuery = z.object({
     z.int(),
   ]).optional(),
   query: z.string().register(z.globalRegistry, {
-    description: 'String αναζήτησης',
+    description: 'Search query string',
   }),
 })
 
@@ -15256,16 +15322,16 @@ export const zApiV1SearchFederatedRetrieveResponse = zFederatedSearchResponse
 
 export const zApiV1SearchProductRetrieveQuery = z.object({
   attributeValues: z.string().register(z.globalRegistry, {
-    description: 'ID τιμών χαρακτηριστικών διαχωρισμένα με κόμμα (attribute_values IN [ids])',
+    description: 'Comma-separated attribute value IDs (attribute_values IN [ids])',
   }).optional(),
   categories: z.string().register(z.globalRegistry, {
-    description: 'ID κατηγοριών διαχωρισμένα με κόμμα (category IN [ids])',
+    description: 'Comma-separated category IDs (category IN [ids])',
   }).optional(),
   facets: z.string().register(z.globalRegistry, {
-    description: 'Πεδία facet διαχωρισμένα με κόμμα για πλήθη και στατιστικά',
+    description: 'Comma-separated facet fields for counts and stats',
   }).optional(),
   languageCode: z.string().register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για φιλτράρισμα αποτελεσμάτων (π.χ. \'en\', \'el\', \'de\'). Αν δεν δοθεί, αναζητά σε όλες τις γλώσσες.',
+    description: 'Language code to filter results (e.g., \'en\', \'el\', \'de\'). If not provided, searches all languages.',
   }).optional(),
   likesMin: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15288,10 +15354,10 @@ export const zApiV1SearchProductRetrieveQuery = z.object({
     z.number(),
   ]).optional(),
   query: z.string().register(z.globalRegistry, {
-    description: 'Ερώτημα αναζήτησης πλήρους κειμένου (κενό για χωρίς φίλτρο αναζήτησης)',
+    description: 'Full-text search query (empty for no search filter)',
   }).optional(),
   sort: z.string().register(z.globalRegistry, {
-    description: 'Πεδίο ταξινόμησης (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)',
+    description: 'Sort field (finalPrice, -finalPrice, -likesCount, -viewCount, -createdAt)',
   }).optional(),
   viewsMin: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15303,10 +15369,10 @@ export const zApiV1SearchProductRetrieveResponse = zProductMeiliSearchResponse
 
 export const zListTrendingSearchesQuery = z.object({
   contentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο περιεχομένου: product, blog_post, federated. Προεπιλογή product.',
+    description: 'Filter by content type: product, blog_post, federated. Defaults to product.',
   }).optional(),
   languageCode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ερωτημάτων ανά γλώσσα (π.χ. \'el\').',
+    description: 'Filter queries by language (e.g. \'el\').',
   }).optional(),
   limit: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15320,7 +15386,7 @@ export const zApiV1SettingsListResponse = z.array(zSetting)
 
 export const zApiV1SettingsGetRetrieveQuery = z.object({
   key: z.string().register(z.globalRegistry, {
-    description: 'Όνομα κλειδιού ρύθμισης (π.χ. CHECKOUT_SHIPPING_PRICE)',
+    description: 'Setting key name (e.g., CHECKOUT_SHIPPING_PRICE)',
   }),
 })
 
@@ -15409,14 +15475,14 @@ export const zFindNearestAcsStationsResponse = z.array(zAcsStation).register(z.g
 
 export const zListBoxNowLockerQuery = z.object({
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:externalId|\-externalId|postalCode|\-postalCode|lastSyncedAt|\-lastSyncedAt|createdAt|\-createdAt)(?:,(?:externalId|\-externalId|postalCode|\-postalCode|lastSyncedAt|\-lastSyncedAt|createdAt|\-createdAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: externalId, -externalId, postalCode, -postalCode, lastSyncedAt, -lastSyncedAt, createdAt, -createdAt',
@@ -15430,14 +15496,14 @@ export const zListBoxNowLockerQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -15456,7 +15522,7 @@ export const zRetrieveBoxNowLockerQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15523,10 +15589,10 @@ export const zListTagQuery = z.object({
     z.boolean(),
   ]).optional(),
   contentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ετικετών που χρησιμοποιούνται για συγκεκριμένο τύπο περιεχομένου',
+    description: 'Filter tags used for specific content type',
   }).optional(),
   contentType_AppLabel: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ετικετών που χρησιμοποιούνται για περιεχόμενο από συγκεκριμένη εφαρμογή',
+    description: 'Filter tags used for content from specific app',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -15538,7 +15604,7 @@ export const zListTagQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasLabel: z.union([
     z.literal('true'),
@@ -15560,25 +15626,25 @@ export const zListTagQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
   label: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)',
+    description: 'Filter by tag label (partial match)',
   }).optional(),
   label_Exact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή ετικέτα',
+    description: 'Filter by exact tag label',
   }).optional(),
   label_Startswith: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ετικετών με ετικέτα που ξεκινά με',
+    description: 'Filter tags with labels starting with',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   maxUsageCount: z.union([
     z.string().regex(/^-?\d+(\.\d+)?$/),
@@ -15611,14 +15677,14 @@ export const zListTagQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -15667,7 +15733,7 @@ export const zCreateTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15700,7 +15766,7 @@ export const zRetrieveTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15721,7 +15787,7 @@ export const zPartialUpdateTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15742,7 +15808,7 @@ export const zUpdateTagQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15750,10 +15816,10 @@ export const zUpdateTagResponse = zTagDetail
 
 export const zListTaggedItemQuery = z.object({
   contentType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα model τύπου περιεχομένου',
+    description: 'Filter by content type model name',
   }).optional(),
   contentType_AppLabel: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά app label τύπου περιεχομένου',
+    description: 'Filter by content type app label',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -15765,7 +15831,7 @@ export const zListTaggedItemQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   id: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15773,7 +15839,7 @@ export const zListTaggedItemQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -15782,7 +15848,7 @@ export const zListTaggedItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   objectId: z.union([
     z.string().regex(/^-?\d+$/),
@@ -15790,7 +15856,7 @@ export const zListTaggedItemQuery = z.object({
   ]).optional(),
   objectId_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int().gte(0).lte(2147483647)),
   ]).optional(),
@@ -15806,14 +15872,14 @@ export const zListTaggedItemQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -15830,7 +15896,7 @@ export const zListTaggedItemQuery = z.object({
     z.boolean(),
   ]).optional(),
   tag_Label: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ετικέτα (μερική αντιστοίχιση)',
+    description: 'Filter by tag label (partial match)',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items updated after this date',
@@ -15854,7 +15920,7 @@ export const zCreateTaggedItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15887,7 +15953,7 @@ export const zRetrieveTaggedItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15908,7 +15974,7 @@ export const zPartialUpdateTaggedItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15929,7 +15995,7 @@ export const zUpdateTaggedItemQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -15943,14 +16009,14 @@ export const zApiV1TenantResolveRetrieveResponse = zTenantConfig
 
 export const zListUserAccountQuery = z.object({
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   languageCode: z.enum([
     'de',
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:id|\-id|email|\-email|username|\-username|createdAt|\-createdAt|updatedAt|\-updatedAt)(?:,(?:id|\-id|email|\-email|username|\-username|createdAt|\-createdAt|updatedAt|\-updatedAt))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: id, -id, email, -email, username, -username, createdAt, -createdAt, updatedAt, -updatedAt',
@@ -15964,14 +16030,14 @@ export const zListUserAccountQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -15988,7 +16054,7 @@ export const zCreateUserAccountQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16007,7 +16073,7 @@ export const zRetrieveUserAccountQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16028,7 +16094,7 @@ export const zPartialUpdateUserAccountQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16049,7 +16115,7 @@ export const zUpdateUserAccountQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16303,17 +16369,17 @@ export const zRequestUserAccountDataExportResponse = zUserDataExport
 
 export const zListUserAddressQuery = z.object({
   city: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα πόλης (μερική αντιστοίχιση)',
+    description: 'Filter by city name (partial match)',
   }).optional(),
   city_Icontains: z.string().optional(),
   country: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά alpha_2 κωδικό χώρας',
+    description: 'Filter by country alpha_2 code',
   }).optional(),
   countryCode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό χώρας (π.χ. \'US\', \'CA\')',
+    description: 'Filter by country code (e.g., \'US\', \'CA\')',
   }).optional(),
   countryName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα χώρας (μερική αντιστοίχιση)',
+    description: 'Filter by country name (partial match)',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -16325,10 +16391,10 @@ export const zListUserAddressQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   firstName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα (μερική αντιστοίχιση)',
+    description: 'Filter by first name (partial match)',
   }).optional(),
   firstName_Icontains: z.string().optional(),
   floor: z.enum([
@@ -16342,10 +16408,10 @@ export const zListUserAddressQuery = z.object({
     'SIXTH_FLOOR_PLUS',
     'THIRD_FLOOR',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όροφο',
+    description: 'Filter by floor',
   }).optional(),
   fullName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά πλήρες όνομα (όνομα + επώνυμο)',
+    description: 'Filter by full name (first + last name)',
   }).optional(),
   hasNotes: z.union([
     z.literal('true'),
@@ -16360,7 +16426,7 @@ export const zListUserAddressQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -16376,14 +16442,14 @@ export const zListUserAddressQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   lastName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά επώνυμο (μερική αντιστοίχιση)',
+    description: 'Filter by last name (partial match)',
   }).optional(),
   lastName_Icontains: z.string().optional(),
   locationType: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά τύπο τοποθεσίας (ακριβής αντιστοίχιση, χωρίς διάκριση πεζών/κεφαλαίων)',
+    description: 'Filter by location type (exact match, case insensitive)',
   }).optional(),
   locationType_Icontains: z.string().optional(),
   locationTypeContains: z.string().register(z.globalRegistry, {
@@ -16401,37 +16467,37 @@ export const zListUserAddressQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   phone: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό τηλεφώνου (μερική αντιστοίχιση)',
+    description: 'Filter by phone number (partial match)',
   }).optional(),
   phone_Icontains: z.string().optional(),
   region: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αλφαριθμητικό κωδικό περιφέρειας',
+    description: 'Filter by region alpha code',
   }).optional(),
   regionCode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κωδικό περιφέρειας',
+    description: 'Filter by region code',
   }).optional(),
   regionName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα περιφέρειας (μερική αντιστοίχιση)',
+    description: 'Filter by region name (partial match)',
   }).optional(),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
   }).optional(),
   street: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα οδού (μερική αντιστοίχιση)',
+    description: 'Filter by street name (partial match)',
   }).optional(),
   street_Icontains: z.string().optional(),
   streetNumber: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά αριθμό',
+    description: 'Filter by street number',
   }).optional(),
   streetNumber_Icontains: z.string().optional(),
   title: z.string().optional(),
@@ -16447,11 +16513,11 @@ export const zListUserAddressQuery = z.object({
   }).optional(),
   uuid: z.uuid().optional(),
   zipcode: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ταχυδρομικό κώδικα (μερική αντιστοίχιση)',
+    description: 'Filter by zipcode (partial match)',
   }).optional(),
   zipcode_Icontains: z.string().optional(),
   zipcodeExact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβή ταχυδρομικό κώδικα',
+    description: 'Filter by exact zipcode',
   }).optional(),
 })
 
@@ -16465,7 +16531,7 @@ export const zCreateUserAddressQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16498,7 +16564,7 @@ export const zRetrieveUserAddressQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16519,7 +16585,7 @@ export const zPartialUpdateUserAddressQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16540,7 +16606,7 @@ export const zUpdateUserAddressQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16570,7 +16636,7 @@ export const zListUserSubscriptionQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   hasMetadata: z.union([
     z.literal('true'),
@@ -16585,7 +16651,7 @@ export const zListUserSubscriptionQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -16601,7 +16667,7 @@ export const zListUserSubscriptionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   ordering: z.string().regex(/^(?:subscribedAt|\-subscribedAt|unsubscribedAt|\-unsubscribedAt|createdAt|\-createdAt|updatedAt|\-updatedAt|status|\-status|topic_Category|\-topic_Category)(?:,(?:subscribedAt|\-subscribedAt|unsubscribedAt|\-unsubscribedAt|createdAt|\-createdAt|updatedAt|\-updatedAt|status|\-status|topic_Category|\-topic_Category))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: subscribedAt, -subscribedAt, unsubscribedAt, -unsubscribedAt, createdAt, -createdAt, updatedAt, -updatedAt, status, -status, topic_Category, -topic_Category',
@@ -16615,14 +16681,14 @@ export const zListUserSubscriptionQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   search: z.string().register(z.globalRegistry, {
     description: 'A search term.',
@@ -16633,16 +16699,16 @@ export const zListUserSubscriptionQuery = z.object({
     'PENDING',
     'UNSUBSCRIBED',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατάσταση συνδρομής\n\n* `ACTIVE` - Ενεργή\n* `PENDING` - Εκκρεμεί Επιβεβαίωση\n* `UNSUBSCRIBED` - Διαγραφή\n* `BOUNCED` - Επιστράφηκε',
+    description: 'Filter by subscription status\n\n* `ACTIVE` - Active\n* `PENDING` - Pending Confirmation\n* `UNSUBSCRIBED` - Unsubscribed\n* `BOUNCED` - Bounced',
   }).optional(),
   subscribedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο εγγραφών που δημιουργήθηκαν μετά από αυτή την ημερομηνία',
+    description: 'Filter subscriptions created after this date',
   }).optional(),
   subscribedAt_Date: z.iso.date().optional(),
   subscribedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   subscribedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   subscribedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο εγγραφών που δημιουργήθηκαν πριν από αυτή την ημερομηνία',
+    description: 'Filter subscriptions created before this date',
   }).optional(),
   topic: z.union([
     z.string().regex(/^-?\d+$/),
@@ -16657,28 +16723,28 @@ export const zListUserSubscriptionQuery = z.object({
     'PROMOTIONAL',
     'SYSTEM',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατηγορία θέματος\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο',
+    description: 'Filter by topic category\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other',
   }).optional(),
   topicDescription: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιγραφή θέματος (μερική αντιστοίχιση)',
+    description: 'Filter by topic description (partial match)',
   }).optional(),
   topicName: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα θέματος (μερική αντιστοίχιση)',
+    description: 'Filter by topic name (partial match)',
   }).optional(),
   topicSlug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug θέματος (μερική αντιστοίχιση)',
+    description: 'Filter by topic slug (partial match)',
   }).optional(),
   topicSlugExact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβές slug θέματος',
+    description: 'Filter by exact topic slug',
   }).optional(),
   unsubscribedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο εγγραφών με διαγραφή μετά από αυτή την ημερομηνία',
+    description: 'Filter subscriptions unsubscribed after this date',
   }).optional(),
   unsubscribedAt_Date: z.iso.date().optional(),
   unsubscribedAt_Gte: z.iso.datetime({ offset: true }).optional(),
   unsubscribedAt_Lte: z.iso.datetime({ offset: true }).optional(),
   unsubscribedBefore: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
-    description: 'Φίλτρο εγγραφών με διαγραφή πριν από αυτή την ημερομηνία',
+    description: 'Filter subscriptions unsubscribed before this date',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items updated after this date',
@@ -16702,7 +16768,7 @@ export const zCreateUserSubscriptionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16735,7 +16801,7 @@ export const zRetrieveUserSubscriptionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16756,7 +16822,7 @@ export const zPartialUpdateUserSubscriptionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16777,7 +16843,7 @@ export const zUpdateUserSubscriptionQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16820,7 +16886,7 @@ export const zListSubscriptionTopicQuery = z.object({
     'PROMOTIONAL',
     'SYSTEM',
   ]).register(z.globalRegistry, {
-    description: 'Φίλτρο ανά κατηγορία θέματος\n\n* `MARKETING` - Καμπάνιες marketing\n* `PRODUCT` - Ενημερώσεις προϊόντων\n* `ACCOUNT` - Λογαριασμός Ανενεργός\n* `SYSTEM` - Ειδοποιήσεις Συστήματος\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Προωθητικό\n* `OTHER` - Άλλο',
+    description: 'Filter by topic category\n\n* `MARKETING` - Marketing Campaigns\n* `PRODUCT` - Product Updates\n* `ACCOUNT` - Account Updates\n* `SYSTEM` - System Notifications\n* `NEWSLETTER` - Newsletter\n* `PROMOTIONAL` - Promotional\n* `OTHER` - Other',
   }).optional(),
   createdAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items created after this date',
@@ -16832,10 +16898,10 @@ export const zListSubscriptionTopicQuery = z.object({
     description: 'Filter items created before this date',
   }).optional(),
   cursor: z.string().register(z.globalRegistry, {
-    description: 'Δείκτης (cursor) για σελιδοποίηση',
+    description: 'Cursor for pagination',
   }).optional(),
   description: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά περιγραφή (μερική αντιστοίχιση)',
+    description: 'Filter by description (partial match)',
   }).optional(),
   hasSubscribers: z.union([
     z.literal('true'),
@@ -16850,7 +16916,7 @@ export const zListSubscriptionTopicQuery = z.object({
   ]).optional(),
   id_In: z.union([
     z.string().register(z.globalRegistry, {
-      description: 'Τιμές διαχωρισμένες με κόμμα',
+      description: 'Comma-separated values',
     }),
     z.array(z.int()),
   ]).optional(),
@@ -16873,10 +16939,10 @@ export const zListSubscriptionTopicQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
   name: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά όνομα (μερική αντιστοίχιση)',
+    description: 'Filter by name (partial match)',
   }).optional(),
   ordering: z.string().regex(/^(?:category|\-category|createdAt|\-createdAt|updatedAt|\-updatedAt|slug|\-slug)(?:,(?:category|\-category|createdAt|\-createdAt|updatedAt|\-updatedAt|slug|\-slug))*$/).register(z.globalRegistry, {
     description: 'Which field(s) to use when ordering the results. Multiple fields can be combined with commas (e.g. ``-isMain,-createdAt``). Available fields: category, -category, createdAt, -createdAt, updatedAt, -updatedAt, slug, -slug',
@@ -16890,14 +16956,14 @@ export const zListSubscriptionTopicQuery = z.object({
     z.int(),
   ]).optional(),
   pagination: z.enum(['false', 'true']).register(z.globalRegistry, {
-    description: 'Ενεργοποίηση/απενεργοποίηση σελιδοποίησης',
+    description: 'Enable or disable pagination',
   }).optional().default('true'),
   paginationType: z.enum([
     'cursor',
     'limitOffset',
     'pageNumber',
   ]).register(z.globalRegistry, {
-    description: 'Τύπος στρατηγικής σελιδοποίησης',
+    description: 'Pagination strategy type',
   }).optional().default('pageNumber'),
   requiresConfirmation: z.union([
     z.literal('true'),
@@ -16910,11 +16976,11 @@ export const zListSubscriptionTopicQuery = z.object({
     description: 'A search term.',
   }).optional(),
   slug: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά slug (μερική αντιστοίχιση)',
+    description: 'Filter by slug (partial match)',
   }).optional(),
   slug_Icontains: z.string().optional(),
   slugExact: z.string().register(z.globalRegistry, {
-    description: 'Φίλτρο ανά ακριβές slug',
+    description: 'Filter by exact slug',
   }).optional(),
   updatedAfter: z.iso.datetime({ offset: true }).register(z.globalRegistry, {
     description: 'Filter items updated after this date',
@@ -16938,7 +17004,7 @@ export const zCreateSubscriptionTopicQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16971,7 +17037,7 @@ export const zRetrieveSubscriptionTopicQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -16992,7 +17058,7 @@ export const zPartialUpdateSubscriptionTopicQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 
@@ -17013,7 +17079,7 @@ export const zUpdateSubscriptionTopicQuery = z.object({
     'el',
     'en',
   ]).register(z.globalRegistry, {
-    description: 'Κωδικός γλώσσας για μεταφράσεις (el, en, de)',
+    description: 'Language code for translations (el, en, de)',
   }).optional().default('el'),
 })
 


### PR DESCRIPTION
Wires the backend's Phase-1 click-tracking pipeline (grooveshop-django-api #16, live since v1.167.0) into the storefront:

## Changes

1. **`useSearchClickTracking` composable** — fire-and-forget POST to `/api/search/click` with the `queryId` every search response now carries. `keepalive: true` so the beacon survives the click's navigation; failures are swallowed (tracking must never affect UX).
2. **Search modal + `/search` page** attribute each result click: the result's `contentType` picks the matching sub-response `queryId` (`/api/search` merges two Django responses), `resultId` is the **master** id (what the backend's ranking signal keys on), `position` is the absolute index.
3. **`relaxedQuery` disclosure** on both surfaces — "εμφανίζονται αποτελέσματα για …" when the backend's zero-result fallback produced the results, instead of a silent query swap.
4. **New server route** `server/api/search/click.post.ts` (Zod-validated body via the generated `zApiV1SearchClickCreateBody`, 202).
5. **OpenAPI schema + generated types refreshed** from django-api v1.167.0 — mandatory, since `parseDataAs` strips unknown fields; without regeneration the new fields would silently vanish in the proxy.

## Verification

- vitest: 1706 passed / 1 skipped, `nuxt typecheck` clean, eslint clean
- Post-deploy: full click-loop verification on webside.gr (search → click → SearchClick row in the backend DB → admin Search Insights CTR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL3Fj7M3fbKEvS5nGu6i56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now indicate when relaxed matching is being used.
  * Clicking a search result records attribution details for improved search insights.
  * Added localized messaging for relaxed-query results, including Greek.

* **Bug Fixes**
  * Improved handling and validation of search-result click reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->